### PR TITLE
Add Samsung Galaxy A23 5G (a23xq) and Samsung Galaxy Note 9 (Exynos) to Unofficially Supported devices

### DIFF
--- a/docs/pages/devices.html
+++ b/docs/pages/devices.html
@@ -285,7 +285,7 @@
                         <tr>
                             <td>
                                 <a href="https://github.com/blueskychan-dev" target="_blank">
-                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="riarumoda" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
+                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="blueskychan-dev" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
                                     blueskychan-dev
                                 </a>
                             </td>
@@ -296,7 +296,7 @@
                         <tr>
                             <td>
                                 <a href="https://github.com/blueskychan-dev" target="_blank">
-                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="riarumoda" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
+                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="blueskychan-dev" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
                                     blueskychan-dev
                                 </a>
                             </td>

--- a/docs/pages/devices.html
+++ b/docs/pages/devices.html
@@ -281,6 +281,28 @@
                             <td><a href="https://github.com/hxsyzl/kernel_lge_sm8150" target="_blank">kernel_lge_sm8150</a></td>
                             <td>LG V50, V50s, G8, G8s, G8x</td>
                         </tr>
+
+                        <tr>
+                            <td>
+                                <a href="https://github.com/blueskychan-dev" target="_blank">
+                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="riarumoda" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
+                                    blueskychan-dev
+                                </a>
+                            </td>
+                            <td><a href="https://github.com/galaxybuild-project/android_kernel_samsung_a23xq" target="_blank">android_kernel_samsung_a23xq</a></td>
+                            <td>Wonderful Kernel for Samsung Galaxy A23 5G (Snapdragon 695)</td>
+                        </tr>
+
+                        <tr>
+                            <td>
+                                <a href="https://github.com/blueskychan-dev" target="_blank">
+                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="riarumoda" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
+                                    blueskychan-dev
+                                </a>
+                            </td>
+                            <td><a href="https://github.com/galaxybuild-project/exynos-linux-stable" target="_blank">exynos-linux-stable</a></td>
+                            <td>xxTR-Kernel but MindPatched for Samsung Galaxy Note 9 (Exynos 9810)</td>
+                        </tr>
                         
                         <!-- <tr>
                             <td>Example Maintainer</td>


### PR DESCRIPTION
I'm confirmed that the web page is working fine on my side.
![image](https://github.com/user-attachments/assets/d34d675d-e7c0-459a-aab8-4679c686e094)

- Added [android_kernel_samsung_a23xq](https://github.com/galaxybuild-project/android_kernel_samsung_a23xq)
- Added [exynos-linux-stable](https://github.com/galaxybuild-project/exynos-linux-stable)
