### PR TITLE
Change to Exynos 9810 Family.

### DIFF
--- a/docs/pages/devices.html
+++ b/docs/pages/devices.html
@@ -301,7 +301,7 @@
                                 </a>
                             </td>
                             <td><a href="https://github.com/galaxybuild-project/exynos-linux-stable" target="_blank">exynos-linux-stable</a></td>
-                            <td>xxTR-Kernel but MindPatched for Samsung Galaxy Note 9 (Exynos 9810)</td>
+                            <td>xxTR-Kernel but MindPatched for Exynos 9810 Family (Galaxy S9, S9+, Note 9)</td>
                         </tr>
                         
                         <!-- <tr>

--- a/docs/pages/devices.html
+++ b/docs/pages/devices.html
@@ -285,7 +285,7 @@
                         <tr>
                             <td>
                                 <a href="https://github.com/blueskychan-dev" target="_blank">
-                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="riarumoda" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
+                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="blueskychan-dev" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
                                     blueskychan-dev
                                 </a>
                             </td>
@@ -296,7 +296,7 @@
                         <tr>
                             <td>
                                 <a href="https://github.com/blueskychan-dev" target="_blank">
-                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="riarumoda" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
+                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="blueskychan-dev" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
                                     blueskychan-dev
                                 </a>
                             </td>

--- a/docs/pages/devices.html
+++ b/docs/pages/devices.html
@@ -281,6 +281,28 @@
                             <td><a href="https://github.com/hxsyzl/kernel_lge_sm8150" target="_blank">kernel_lge_sm8150</a></td>
                             <td>LG V50, V50s, G8, G8s, G8x</td>
                         </tr>
+
+                        <tr>
+                            <td>
+                                <a href="https://github.com/blueskychan-dev" target="_blank">
+                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="riarumoda" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
+                                    blueskychan-dev
+                                </a>
+                            </td>
+                            <td><a href="https://github.com/galaxybuild-project/android_kernel_samsung_a23xq" target="_blank">android_kernel_samsung_a23xq</a></td>
+                            <td>Wonderful Kernel for Samsung Galaxy A23 5G (Snapdragon 695)</td>
+                        </tr>
+
+                        <tr>
+                            <td>
+                                <a href="https://github.com/blueskychan-dev" target="_blank">
+                                    <img src="https://avatars.githubusercontent.com/blueskychan-dev?v=4" alt="riarumoda" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
+                                    blueskychan-dev
+                                </a>
+                            </td>
+                            <td><a href="https://github.com/galaxybuild-project/exynos-linux-stable" target="_blank">exynos-linux-stable</a></td>
+                            <td>xxTR-Kernel but MindPatched for Samsung Galaxy Note 9 (Exynos 9810)</td>
+                        </tr>
                         
                         <!-- <tr>
                             <td>Example Maintainer</td>


### PR DESCRIPTION
I realized that xxtr kernel but mindpatched is also build for S9/S9+/Note 9, so i rechecked everything before pull request again, i hope this will won't happening again!

I'm very sorry for this!