### PR TITLE
docs: Add Xiaomi Poco F3 (alioth) (helluvaOS/hentaiOS) to Unofficiall…

### DIFF
--- a/docs/pages/devices.html
+++ b/docs/pages/devices.html
@@ -358,6 +358,17 @@
                             <td><a href="https://github.com/ravindu644/beyondx_stock" target="_blank">beyondx_stock</a></td>
                             <td>Samsung Galaxy S10 5G (Stock ROM)</td>
                         </tr>
+
+                        <tr>
+                            <td>
+                                <a href="https://github.com/JuicerV3" target="_blank">
+                                    <img src="https://avatars.githubusercontent.com/JuicerV3?v=4" alt="JuicerV3" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
+                                    JuicerV3
+                                </a>
+                            </td>
+                            <td><a href="https://github.com/JuicerV3/kernel_xiaomi_gourami" target="_blank">kernel_xiaomi_gourami</a></td>
+                            <td>Xiaomi Poco F3 (alioth) (helluvaOS/hentaiOS)</td>
+                        </tr>
                         
                         <!-- <tr>
                             <td>Example maintainer</td>

--- a/docs/zh/pages/devices.html
+++ b/docs/zh/pages/devices.html
@@ -359,6 +359,17 @@
                             <td><a href="https://github.com/ravindu644/beyondx_stock" target="_blank">beyondx_stocky</a></td>
                             <td>Samsung Galaxy S10 5G (Stock ROM)</td>
                         </tr>
+
+                        <tr>
+                            <td>
+                                <a href="https://github.com/JuicerV3" target="_blank">
+                                    <img src="https://avatars.githubusercontent.com/JuicerV3?v=4" alt="JuicerV3" class="rounded-circle" width="30" height="30" style="margin-right: 10px;">
+                                    JuicerV3
+                                </a>
+                            </td>
+                            <td><a href="https://github.com/JuicerV3/kernel_xiaomi_gourami" target="_blank">kernel_xiaomi_gourami</a></td>
+                            <td>Xiaomi Poco F3 (alioth) (helluvaOS/hentaiOS)</td>
+                        </tr>
                         
                         <!-- <tr>
                             <td>Example maintainer</td>


### PR DESCRIPTION
Added Xiaomi Poco F3 (alioth) KernelSU-Next patched helluvaOS/hentaiOS kernel to Unofficially supported devices.