### PR TITLE
docs: kernel_xiaomi_gourami expand support to match the kernel source

### DIFF
--- a/docs/pages/devices.html
+++ b/docs/pages/devices.html
@@ -361,7 +361,7 @@
                                 </a>
                             </td>
                             <td><a href="https://github.com/JuicerV3/kernel_xiaomi_gourami" target="_blank">kernel_xiaomi_gourami</a></td>
-                            <td>Xiaomi Poco F3 (alioth) (helluvaOS/hentaiOS)</td>
+                            <td>hentaiOS Gourami family: Mi 10(umi), Mi 10 Pro(cmi), Mi 10T Pro(apollo), Mi 10 Ultra(cas), POCO F2 Pro(lmi), POCO F3(alioth)</td>
                         </tr>
 
                         <tr>

--- a/docs/zh/pages/devices.html
+++ b/docs/zh/pages/devices.html
@@ -362,7 +362,7 @@
                                 </a>
                             </td>
                             <td><a href="https://github.com/JuicerV3/kernel_xiaomi_gourami" target="_blank">kernel_xiaomi_gourami</a></td>
-                            <td>Xiaomi Poco F3 (alioth) (helluvaOS/hentaiOS)</td>
+                            <td>hentaiOS Gourami family: Mi 10(umi), Mi 10 Pro(cmi), Mi 10T Pro(apollo), Mi 10 Ultra(cas), POCO F2 Pro(lmi), POCO F3(alioth)</td>
                         </tr>
 
                         <tr>


### PR DESCRIPTION
add support for Xiaomi(Gourami) family umi, cmi, apollo, cas, lmi, alioth to match the kernel source repository.