### PR TITLE
ci: update workflows

### DIFF
--- a/.github/workflows/build-debug-kernel.yml
+++ b/.github/workflows/build-debug-kernel.yml
@@ -17,11 +17,11 @@ jobs:
       matrix:
         include:
           - version: "5.10"
-            sub_level: 223
-            os_patch_level: 2024-11
+            sub_level: 228
+            os_patch_level: 2025-01
           - version: "5.15"
-            sub_level: 167
-            os_patch_level: 2024-11
+            sub_level: 170
+            os_patch_level: 2025-01
     uses: ./.github/workflows/gki-kernel.yml
     with:
       version: android13-${{ matrix.version }}
@@ -34,11 +34,11 @@ jobs:
       matrix:
         include:
           - version: "5.15"
-            sub_level: 167
-            os_patch_level: 2024-11
+            sub_level: 170
+            os_patch_level: 2025-01
           - version: "6.1"
-            sub_level: 115
-            os_patch_level: 2024-12
+            sub_level: 118
+            os_patch_level: 2025-01
     uses: ./.github/workflows/gki-kernel.yml
     with:
       version: android14-${{ matrix.version }}
@@ -51,8 +51,8 @@ jobs:
       matrix:
         include:
           - version: "6.6"
-            sub_level: 57
-            os_patch_level: 2024-12
+            sub_level: 58
+            os_patch_level: 2025-01
     uses: ./.github/workflows/gki-kernel.yml
     with:
       version: android15-${{ matrix.version }}

--- a/.github/workflows/build-kernel-a13.yml
+++ b/.github/workflows/build-kernel-a13.yml
@@ -36,6 +36,9 @@ jobs:
           - version: "5.10"
             sub_level: 223
             os_patch_level: 2024-11
+          - version: "5.10"
+            sub_level: 228
+            os_patch_level: 2025-01
           - version: "5.15"
             sub_level: 148
             os_patch_level: 2024-05
@@ -51,6 +54,9 @@ jobs:
           - version: "5.15"
             sub_level: 167
             os_patch_level: 2024-11
+          - version: "5.15"
+            sub_level: 170
+            os_patch_level: 2025-01
     uses: ./.github/workflows/gki-kernel.yml
     secrets: inherit
     with:
@@ -137,11 +143,11 @@ jobs:
       matrix:
         include:
           - version: "5.10"
-            sub_level: 223
-            os_patch_level: 2024-11
+            sub_level: 228
+            os_patch_level: 2025-01
           - version: "5.15"
-            sub_level: 167
-            os_patch_level: 2024-11
+            sub_level: 170
+            os_patch_level: 2025-01
     uses: ./.github/workflows/gki-kernel.yml
     with:
       version: android13-${{ matrix.version }}

--- a/.github/workflows/build-kernel-a14.yml
+++ b/.github/workflows/build-kernel-a14.yml
@@ -39,6 +39,9 @@ jobs:
           - version: "5.15"
             sub_level: 167
             os_patch_level: 2024-11
+          - version: "5.15"
+            sub_level: 170
+            os_patch_level: 2025-01
           - version: "6.1"
             sub_level: 75
             os_patch_level: 2024-05
@@ -63,6 +66,9 @@ jobs:
           - version: "6.1"
             sub_level: 115
             os_patch_level: 2024-12
+          - version: "6.1"
+            sub_level: 118
+            os_patch_level: 2025-01
     uses: ./.github/workflows/gki-kernel.yml
     secrets: inherit
     with:
@@ -149,11 +155,11 @@ jobs:
       matrix:
         include:
           - version: "5.15"
-            sub_level: 167
-            os_patch_level: 2024-11
+            sub_level: 170
+            os_patch_level: 2025-01
           - version: "6.1"
-            sub_level: 115
-            os_patch_level: 2024-12
+            sub_level: 118
+            os_patch_level: 2025-01
     uses: ./.github/workflows/gki-kernel.yml
     with:
       version: android14-${{ matrix.version }}

--- a/.github/workflows/build-kernel-a15.yml
+++ b/.github/workflows/build-kernel-a15.yml
@@ -36,6 +36,9 @@ jobs:
           - version: "6.6"
             sub_level: 57
             os_patch_level: 2024-12
+          - version: "6.6"
+            sub_level: 58
+            os_patch_level: 2025-01
     uses: ./.github/workflows/gki-kernel.yml
     secrets: inherit
     with:
@@ -122,8 +125,8 @@ jobs:
       matrix:
         include:
           - version: "6.6"
-            sub_level: 57
-            os_patch_level: 2024-12
+            sub_level: 58
+            os_patch_level: 2025-01
     uses: ./.github/workflows/gki-kernel.yml
     with:
       version: android15-${{ matrix.version }}

--- a/.github/workflows/build-lkm.yml
+++ b/.github/workflows/build-lkm.yml
@@ -18,20 +18,20 @@ jobs:
             sub_level: 226
             os_patch_level: 2024-11
           - version: "android13-5.10"
-            sub_level: 223
-            os_patch_level: 2024-11
+            sub_level: 228
+            os_patch_level: 2025-01
           - version: "android13-5.15"
-            sub_level: 167
-            os_patch_level: 2024-11
+            sub_level: 170
+            os_patch_level: 2025-01
           - version: "android14-5.15"
-            sub_level: 167
-            os_patch_level: 2024-11
+            sub_level: 170
+            os_patch_level: 2025-01
           - version: "android14-6.1"
-            sub_level: 115
-            os_patch_level: 2024-12
+            sub_level: 118
+            os_patch_level: 2025-01
           - version: "android15-6.6"
-            sub_level: 57
-            os_patch_level: 2024-12
+            sub_level: 58
+            os_patch_level: 2025-01
     uses: ./.github/workflows/gki-kernel.yml
     with:
       version: ${{ matrix.version }}

--- a/.github/workflows/build-manager-ci.yml
+++ b/.github/workflows/build-manager-ci.yml
@@ -23,7 +23,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-lkm:
+    uses: ./.github/workflows/build-lkm.yml
+    secrets: inherit
+
   build-susfsd:
+    needs: build-lkm
     strategy:
       matrix:
         include:
@@ -45,7 +50,6 @@ jobs:
     with:
       target: ${{ matrix.target }}
       os: ${{ matrix.os }}
-      pack_lkm: false
 
   build-ksud_magic:
     needs: build-susfsd
@@ -58,7 +62,6 @@ jobs:
     with:
       target: ${{ matrix.target }}
       os: ${{ matrix.os }}
-      pack_lkm: false
 
   build-manager:
     needs: [build-ksud_magic, build-ksud_overlayfs]

--- a/.github/workflows/build-manager-ci.yml
+++ b/.github/workflows/build-manager-ci.yml
@@ -13,17 +13,17 @@ on:
   pull_request:
     branches: [ "next" ]
     paths:
+      - '.github/workflows/build-manager-ci.yml'
       - 'manager/**'
+      - 'kernel/**'
+      - 'userspace/ksud_overlayfs**'
+      - 'userspace/ksud_magic/**'
+      - 'userspace/susfsd/**'
   workflow_call:
   workflow_dispatch:
 
 jobs:
-  build-lkm:
-    uses: ./.github/workflows/build-lkm.yml
-    secrets: inherit
-
   build-susfsd:
-    needs: build-lkm
     strategy:
       matrix:
         include:
@@ -45,9 +45,10 @@ jobs:
     with:
       target: ${{ matrix.target }}
       os: ${{ matrix.os }}
-  
+      pack_lkm: false
+
   build-ksud_magic:
-    needs: build-ksud_overlayfs
+    needs: build-susfsd
     strategy:
       matrix:
         include:
@@ -57,9 +58,10 @@ jobs:
     with:
       target: ${{ matrix.target }}
       os: ${{ matrix.os }}
+      pack_lkm: false
 
   build-manager:
-    needs: build-ksud_magic
+    needs: [build-ksud_magic, build-ksud_overlayfs]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -103,7 +105,7 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-        
+
       - name: Download arm64 susfsd
         uses: actions/download-artifact@v4
         with:
@@ -120,21 +122,20 @@ jobs:
         with:
           name: ksud_overlayfs-aarch64-linux-android
           path: ksud_overlayfs
-        
+
       - name: Copy ksud_overlayfs to app jniLibs
         run: |
           cp -f ../ksud_overlayfs/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_overlayfs.so
-      
+
       - name: Download arm64 ksud_magic
         uses: actions/download-artifact@v4
         with:
           name: ksud_magic-aarch64-linux-android
           path: ksud_magic
-        
+
       - name: Copy ksud_magic to app jniLibs
         run: |
           cp -f ../ksud_magic/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_magic.so
-          
 
       - name: Build with Gradle
         run: |
@@ -187,4 +188,3 @@ jobs:
             pip3 install telethon
             python3 $GITHUB_WORKSPACE/scripts/ksunextbot.py $APK
           fi
-  

--- a/.github/workflows/build-manager.yml
+++ b/.github/workflows/build-manager.yml
@@ -13,7 +13,12 @@ on:
   # pull_request:
   #   branches: [ "next" ]
   #   paths:
+  #     - '.github/workflows/build-manager-ci.yml'
   #     - 'manager/**'
+  #     - 'kernel/**'
+  #     - 'userspace/ksud_overlayfs**'
+  #     - 'userspace/ksud_magic/**'
+  #     - 'userspace/susfsd/**'
   workflow_call:
   workflow_dispatch:
 
@@ -45,9 +50,9 @@ jobs:
     with:
       target: ${{ matrix.target }}
       os: ${{ matrix.os }}
-  
+
   build-ksud_magic:
-    needs: build-ksud_overlayfs
+    needs: build-susfsd
     strategy:
       matrix:
         include:
@@ -59,7 +64,7 @@ jobs:
       os: ${{ matrix.os }}
 
   build-manager:
-    needs: build-ksud_magic
+    needs: [build-ksud_magic, build-ksud_overlayfs]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -103,7 +108,7 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-        
+
       - name: Download arm64 susfsd
         uses: actions/download-artifact@v4
         with:
@@ -120,21 +125,20 @@ jobs:
         with:
           name: ksud_overlayfs-aarch64-linux-android
           path: ksud_overlayfs
-        
+
       - name: Copy ksud_overlayfs to app jniLibs
         run: |
           cp -f ../ksud_overlayfs/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_overlayfs.so
-      
+
       - name: Download arm64 ksud_magic
         uses: actions/download-artifact@v4
         with:
           name: ksud_magic-aarch64-linux-android
           path: ksud_magic
-        
+
       - name: Copy ksud_magic to app jniLibs
         run: |
           cp -f ../ksud_magic/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_magic.so
-          
 
       - name: Build with Gradle
         run: |
@@ -187,4 +191,3 @@ jobs:
             pip3 install telethon
             python3 $GITHUB_WORKSPACE/scripts/ksunextbot.py $APK
           fi
-  

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,13 +6,15 @@ on:
       - next
     paths:
       - '.github/workflows/clippy.yml'
-      - 'userspace/ksud/**'
+      - 'userspace/ksud_magic/**'
+      - 'userspace/ksud_overlayfs/**'
   pull_request:
     branches:
-      - main
+      - next
     paths:
       - '.github/workflows/clippy.yml'
-      - 'userspace/ksud/**'
+      - 'userspace/ksud_magic/**'
+      - 'userspace/ksud_overlayfs/**'
 
 env:
   RUSTFLAGS: '-Dwarnings'
@@ -22,16 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup update --force-non-host stable-x86_64-unknown-linux-gnu
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: userspace/ksud
+      - run: rustup update stable
 
       - name: Install cross
-        run: |
-          cargo install cross --git https://github.com/cross-rs/cross --rev 66845c1
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev 66845c1
 
       - name: Run clippy
         run: |
-          cross clippy --manifest-path userspace/ksud/Cargo.toml --target aarch64-linux-android --release
-          cross clippy --manifest-path userspace/ksud/Cargo.toml --target x86_64-linux-android --release
+          cross clippy --manifest-path userspace/ksud_magic/Cargo.toml --target aarch64-linux-android --release
+          cross clippy --manifest-path userspace/ksud_magic/Cargo.toml --target x86_64-linux-android --release
+          cross clippy --manifest-path userspace/ksud_overlayfs/Cargo.toml --target aarch64-linux-android --release
+          cross clippy --manifest-path userspace/ksud_overlayfs/Cargo.toml --target x86_64-linux-android --release

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -6,13 +6,15 @@ on:
       - 'next'
     paths:
       - '.github/workflows/rustfmt.yml'
-      - 'userspace/ksud/**'
+      - 'userspace/ksud_magic/**'
+      - 'userspace/ksud_overlayfs/**'
   pull_request:
     branches:
       - 'next'
     paths:
       - '.github/workflows/rustfmt.yml'
-      - 'userspace/ksud/**'
+      - 'userspace/ksud_magic/**'
+      - 'userspace/ksud_overlayfs/**'
 
 permissions:
   checks: write
@@ -30,4 +32,9 @@ jobs:
       - uses: LoliGothick/rustfmt-check@master
         with:
           token: ${{ github.token }}
-          working-directory: userspace/ksud
+          working-directory: userspace/ksud_magic
+
+      - uses: LoliGothick/rustfmt-check@master
+        with:
+          token: ${{ github.token }}
+          working-directory: userspace/ksud_overlayfs

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -24,4 +24,4 @@ jobs:
         uses: ludeeus/action-shellcheck@2.0.0
         with:
           ignore_names: gradlew
-          ignore_paths: ./userspace/ksud/src/installer.sh
+          ignore_paths: ./userspace/ksud_magic/src/installer.sh ./userspace/ksud_overlayfs/src/installer.sh


### PR DESCRIPTION
- Update kernel patch levels
- Don't build LKM on build manager test CI (this makes test build too fast but LKM users can't test ci builds anymore) credit: @changhuapeng
- Build magic and overlayfs ksud at same time to build faster
- Update clippy, rustfmt and shell checks to match new ksud variants (clippy and rustfmt checks still needs fixes)