### PR TITLE
kernel: handle optional backports

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -37,6 +37,18 @@ ifeq ($(shell grep -q "struct selinux_state " $(srctree)/security/selinux/includ
 ccflags-y += -DKSU_COMPAT_HAS_SELINUX_STATE
 endif
 
+ifeq ($(shell grep -q "strncpy_from_user_nofault" $(srctree)/include/linux/uaccess.h; echo $$?),0)
+ccflags-y += -DKSU_STRNCPY_FROM_USER_NOFAULT
+endif
+
+ifeq ($(shell grep -q "ssize_t kernel_read" $(srctree)/fs/read_write.c; echo $$?),0)
+ccflags-y += -DKSU_KERNEL_READ
+endif
+
+ifeq ($(shell grep "ssize_t kernel_write" $(srctree)/fs/read_write.c | grep -q "const void" ; echo $$?),0)
+ccflags-y += -DKSU_KERNEL_WRITE
+endif
+
 ifndef KSU_NEXT_EXPECTED_SIZE
 KSU_NEXT_EXPECTED_SIZE := 0x3e6
 endif

--- a/kernel/kernel_compat.c
+++ b/kernel/kernel_compat.c
@@ -107,7 +107,7 @@ struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
 ssize_t ksu_kernel_read_compat(struct file *p, void *buf, size_t count,
 			       loff_t *pos)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) || defined(KSU_KERNEL_READ)
 	return kernel_read(p, buf, count, pos);
 #else
 	loff_t offset = pos ? *pos : 0;
@@ -122,7 +122,7 @@ ssize_t ksu_kernel_read_compat(struct file *p, void *buf, size_t count,
 ssize_t ksu_kernel_write_compat(struct file *p, const void *buf, size_t count,
 				loff_t *pos)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) || defined(KSU_KERNEL_WRITE)
 	return kernel_write(p, buf, count, pos);
 #else
 	loff_t offset = pos ? *pos : 0;
@@ -134,7 +134,7 @@ ssize_t ksu_kernel_write_compat(struct file *p, const void *buf, size_t count,
 #endif
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0) || defined(KSU_STRNCPY_FROM_USER_NOFAULT)
 long ksu_strncpy_from_user_nofault(char *dst, const void __user *unsafe_addr,
 				   long count)
 {


### PR DESCRIPTION
Cherry pick from https://github.com/backslashxx/KernelSU/commit/8bb9518060b06152b99f11465e20febc45359d3c https://github.com/backslashxx/KernelSU/commit/a4a7db7f40556287bfe53b65e998283c06363dd9

Backporting is cool, but not everyone has the skills for it.
This commit does NOT make it required, but it will allow compiler
to use whats in-kernel if it exists.

The following are backportable:
 - kernel_read / kernel_write
 	< 4.14, backport chain, tested on 4.9
 	https://github.com/torvalds/linux/commit/e13ec939e96b13e664bb6cee361cc976a0ee621a
	https://github.com/torvalds/linux/commit/bdd1d2d3d251c65b74ac4493e08db18971c09240
	https://github.com/torvalds/linux/commit/c41fbad015dabb0a40ecca50c3ff5658eb6471ff
	https://github.com/torvalds/linux/commit/ac452acae1caa1a451142a30b4e1ea09cfac4410

 - strncpy_from_user_nofault
 	for 5.4, apply: https://github.com/torvalds/linux/commit/bd88bb5d4007949be7154deae7cef7173c751a95
 	for 4.x, apply: https://github.com/xiaomi-sdm678/android_kernel_xiaomi_mojito/commit/424e21f3b01ddaeb86cef7efd3f519a7e342fb67
 	for any failures, just SKIP THIS or check dependency chain of, https://github.com/gregkh/linux/commit/3d7081822f7f9eab867d9bcc8fd635208ec438e0
 		this got backported to v4.4.236, v4.9.236, v4.14.197, v4.19.144

- hint, `curl $url.patch | git am`

Signed-off-by: backslashxx <118538522+backslashxx@users.noreply.github.com>
