### PR TITLE
Treewide: Add 'optics' and 'prism' partition mount support

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -641,6 +641,8 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 	try_umount("/system_ext", true, 0);
 	try_umount("/vendor", true, 0);
 	try_umount("/product", true, 0);
+	try_umount("/optics", true, 0);
+	try_umount("/prism", true, 0);
 	try_umount("/data/adb/modules", false, MNT_DETACH);
 
 	// try umount ksu temp path

--- a/userspace/ksud_magic/src/installer.sh
+++ b/userspace/ksud_magic/src/installer.sh
@@ -199,6 +199,16 @@ mount_partitions() {
   if [ -f /system/init -o -L /system/init ]; then
     SYSTEM_ROOT=true
     setup_mntpoint /system_root
+    for part in optics prism; do
+      if [ -d "/system_root/$part" ]; then
+        setup_mntpoint "/$part"
+
+        # Check if already mounted before mounting
+        if ! grep -q " /$part " /proc/mounts; then
+          mount_ro_ensure "$part$SLOT" "/$part"
+        fi
+      fi
+    done
     if ! mount --move /system /system_root; then
       umount /system
       umount -l /system 2>/dev/null

--- a/userspace/ksud_magic/src/installer.sh
+++ b/userspace/ksud_magic/src/installer.sh
@@ -200,8 +200,10 @@ mount_partitions() {
     SYSTEM_ROOT=true
     setup_mntpoint /system_root
     for part in optics prism; do
-      setup_mntpoint "/$part"
-      mount_ro_ensure "$part$SLOT" "/$part"
+      if [ -d "/system_root/$part" ]; then
+        setup_mntpoint "/$part"
+        mount_ro_ensure "$part$SLOT" "/$part"
+      fi
     done
     if ! mount --move /system /system_root; then
       umount /system

--- a/userspace/ksud_magic/src/installer.sh
+++ b/userspace/ksud_magic/src/installer.sh
@@ -200,14 +200,8 @@ mount_partitions() {
     SYSTEM_ROOT=true
     setup_mntpoint /system_root
     for part in optics prism; do
-      if [ -d "/system_root/$part" ]; then
-        setup_mntpoint "/$part"
-
-        # Check if already mounted before mounting
-        if ! grep -q " /$part " /proc/mounts; then
-          mount_ro_ensure "$part$SLOT" "/$part"
-        fi
-      fi
+      setup_mntpoint "/$part"
+      mount_ro_ensure "$part$SLOT" "/$part"
     done
     if ! mount --move /system /system_root; then
       umount /system

--- a/userspace/ksud_magic/src/installer.sh
+++ b/userspace/ksud_magic/src/installer.sh
@@ -393,6 +393,8 @@ install_module() {
   handle_partition system_ext true
   handle_partition product true
   handle_partition odm true
+  handle_partition optics true
+  handle_partition prism true
 
   # Handle replace folders
   for TARGET in $REPLACE; do

--- a/userspace/ksud_magic/src/magic_mount.rs
+++ b/userspace/ksud_magic/src/magic_mount.rs
@@ -154,6 +154,8 @@ fn collect_module_files() -> Result<Option<Node>> {
             ("system_ext", true),
             ("product", true),
             ("odm", false),
+	    ("optics", true),
+	    ("prism", true),
         ] {
             let path_of_root = Path::new("/").join(partition);
             let path_of_system = Path::new("/system").join(partition);

--- a/userspace/ksud_overlayfs/src/init_event.rs
+++ b/userspace/ksud_overlayfs/src/init_event.rs
@@ -42,7 +42,7 @@ pub fn mount_modules_systemlessly(module_dir: &str) -> Result<()> {
 
     let mut system_lowerdir: Vec<String> = Vec::new();
 
-    let partition = vec!["vendor", "product", "system_ext", "odm", "oem"];
+    let partition = vec!["vendor", "product", "optics", "prism", "system_ext", "odm", "oem"];
     let mut partition_lowerdir: HashMap<String, Vec<String>> = HashMap::new();
     for ele in &partition {
         partition_lowerdir.insert((*ele).to_string(), Vec::new());

--- a/userspace/ksud_overlayfs/src/installer.sh
+++ b/userspace/ksud_overlayfs/src/installer.sh
@@ -408,6 +408,8 @@ install_module() {
   handle_partition system_ext
   handle_partition product
   handle_partition odm
+  handle_partition optics
+  handle_partition prism
 
   if $BOOTMODE; then
     mktouch $NVBASE/modules/$MODID/update


### PR DESCRIPTION
* Necessary partition for CSC feature mods on Samsung Galaxy devices.

Reopened to add new partition prism.

@rifsxd, firstly I hope you're doing well.

I plan to add the check marks to select reboot options later and do a PR for it too once I know it works ofc