### PR TITLE
manager: Improvements

### DIFF
--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
@@ -111,6 +111,7 @@ import com.rifsxd.ksunext.ui.viewmodel.ModuleViewModel
 import com.rifsxd.ksunext.ui.webui.WebUIActivity
 import com.rifsxd.ksunext.ui.webui.WebUIXActivity
 import androidx.core.net.toUri
+import com.dergoogler.mmrl.platform.model.ModuleConfig.Companion.asModuleConfig
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Destination<RootGraph>
@@ -299,17 +300,37 @@ fun ModuleScreen(navigator: DestinationsNavigator) {
                     },
                     onClickModule = { id, name, hasWebUi ->
                         if (hasWebUi) {
+                            val wxEngine = Intent(context, WebUIXActivity::class.java)
+                                .setData("kernelsu://webuix/$id".toUri())
+                                .putExtra("id", id)
+                                .putExtra("name", name)
+
+                            val ksuEngine = Intent(context, WebUIActivity::class.java)
+                                .setData("kernelsu://webui/$id".toUri())
+                                .putExtra("id", id)
+                                .putExtra("name", name)
+
+                            val config = id.asModuleConfig
+
+                            val engine = config.getWebuiEngine(context)
+
+                            if (engine != null) {
+                                webUILauncher.launch(
+                                    when (config.getWebuiEngine(context)) {
+                                        "wx" -> wxEngine
+                                        "ksu" -> ksuEngine
+                                        else -> wxEngine
+                                    }
+                                )
+
+                                return@ModuleList
+                            }
+
                             webUILauncher.launch(
                                 if (prefs.getBoolean("use_webuix", true) && Platform.isAlive) {
-                                    Intent(context, WebUIXActivity::class.java)
-                                        .setData("kernelsu://webuix/$id".toUri())
-                                        .putExtra("id", id)
-                                        .putExtra("name", name)
+                                    wxEngine
                                 } else {
-                                    Intent(context, WebUIActivity::class.java)
-                                        .setData("kernelsu://webui/$id".toUri())
-                                        .putExtra("id", id)
-                                        .putExtra("name", name)
+                                    ksuEngine
                                 }
                             )
                         }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
@@ -111,6 +111,7 @@ import com.rifsxd.ksunext.ui.viewmodel.ModuleViewModel
 import com.rifsxd.ksunext.ui.webui.WebUIActivity
 import com.rifsxd.ksunext.ui.webui.WebUIXActivity
 import androidx.core.net.toUri
+import com.dergoogler.mmrl.platform.model.ModuleConfig
 import com.dergoogler.mmrl.platform.model.ModuleConfig.Companion.asModuleConfig
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -909,7 +910,8 @@ fun ModuleItemPreview() {
         updateJson = "",
         hasWebUi = false,
         hasActionScript = false,
-        dirId = "dirId"
+        dirId = "dirId",
+        config = ModuleConfig()
     )
     ModuleItem(EmptyDestinationsNavigator, module, "", {}, {}, {}, {}, {})
 }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
@@ -110,6 +110,7 @@ import com.rifsxd.ksunext.ui.util.restoreModule
 import com.rifsxd.ksunext.ui.viewmodel.ModuleViewModel
 import com.rifsxd.ksunext.ui.webui.WebUIActivity
 import com.rifsxd.ksunext.ui.webui.WebUIXActivity
+import androidx.core.net.toUri
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Destination<RootGraph>
@@ -301,12 +302,12 @@ fun ModuleScreen(navigator: DestinationsNavigator) {
                             webUILauncher.launch(
                                 if (prefs.getBoolean("use_webuix", true) && Platform.isAlive) {
                                     Intent(context, WebUIXActivity::class.java)
-                                        .setData(Uri.parse("kernelsu://webuix/$id"))
+                                        .setData("kernelsu://webuix/$id".toUri())
                                         .putExtra("id", id)
                                         .putExtra("name", name)
                                 } else {
                                     Intent(context, WebUIActivity::class.java)
-                                        .setData(Uri.parse("kernelsu://webui/$id"))
+                                        .setData("kernelsu://webui/$id".toUri())
                                         .putExtra("id", id)
                                         .putExtra("name", name)
                                 }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/viewmodel/ModuleViewModel.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/viewmodel/ModuleViewModel.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.dergoogler.mmrl.platform.model.ModuleConfig
+import com.dergoogler.mmrl.platform.model.ModuleConfig.Companion.asModuleConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.text.Collator
@@ -39,7 +41,8 @@ class ModuleViewModel : ViewModel() {
         val updateJson: String,
         val hasWebUi: Boolean,
         val hasActionScript: Boolean,
-        val dirId: String
+        val dirId: String,
+        val config: ModuleConfig,
     )
 
     data class ModuleUpdateInfo(
@@ -104,20 +107,24 @@ class ModuleViewModel : ViewModel() {
                     .asSequence()
                     .map { array.getJSONObject(it) }
                     .map { obj ->
+                        val id = obj.getString("id")
+                        val config = id.asModuleConfig
+
                         ModuleInfo(
-                            obj.getString("id"),
-                            obj.optString("name"),
+                            id,
+                            config.name ?: obj.optString("name"),
                             obj.optString("author", "Unknown"),
                             obj.optString("version", "Unknown"),
                             obj.optInt("versionCode", 0),
-                            obj.optString("description"),
+                            config.description ?: obj.optString("description"),
                             obj.getBoolean("enabled"),
                             obj.getBoolean("update"),
                             obj.getBoolean("remove"),
                             obj.optString("updateJson"),
                             obj.optBoolean("web"),
                             obj.optBoolean("action"),
-                            obj.getString("dir_id")
+                            obj.getString("dir_id"),
+                            config
                         )
                     }.toList()
                 isNeedRefresh = false

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -199,7 +199,7 @@
     <string name="settings_disable_su_summary">Temporarily disable the ability of any app to gain root privileges via the ⁠su command (existing root processes won\'t be affected).</string>
     <string name="settings_language">Language</string>
     <string name="use_webuix">Use WebUI X</string>
-    <string name="use_webuix_summary">Use WebUI X instead of WebUI, which supports more APIs.</string>
+    <string name="use_webuix_summary">Use WebUI X instead of WebUI, which supports more APIs. Be aware that developers can override this feature in their module config.</string>
     <string name="use_webuix_eruda">Inject Eruda into WebUI X</string>
     <string name="use_webuix_eruda_summary">Inject a debug console into WebUI X to make debugging easier. Requires web debugging to be on.</string>
 </resources>

--- a/manager/gradle/libs.versions.toml
+++ b/manager/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ parcelablelist = "2.0.1"
 libsu = "6.0.0"
 apksign = "1.4"
 cmaker = "1.2"
-mmrl = "1998c70b77"
+mmrl = "2bb00b3c2b"
 
 [plugins]
 agp-app = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This allows the developer to override the user preference of the selected WebUI engine.

Supported engines are:

- `wx` for WebUI X
- `ksu` for the KernelSU WebUI

All not named strings will default to `wx`

`R.string.use_webuix_summary` needs new proper translations

Also added support for multilingual module metadata 

`/data/adb/modules/<ID>/config.json`

Valid file names: 

- `config.json`
- `config.mmrl.json`

> Why not `config.wx.json`? Because it doesn't targets WebUI/X.

```jsonc
{
    // Module name as Map<String, String> or just as String
    "name": {
        "en": "Systemless module",
        "de": "Systemloses Modul"
    },
    "name": "Systemless module",
    
    // Module description as Map<String, String> or just as String
    "description": {
        "en": "This is a systemless module",
        "de": "Dies ist ein systemloses Modul"
    },
    "description": "This is a systemless module",

    // Override the WebUI engine no matter what the user selected. defaults to `wx`
    // This does take NO effect on MMRL
    "webui-engine": "ksu"
}
``` 