### PR TITLE
[BUGFIX] manager: Fix Module Flashing fails when orientation changes

### DIFF
--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
@@ -290,8 +290,11 @@ fun ModuleScreen(navigator: DestinationsNavigator) {
                 val confirmTitle = stringResource(R.string.module)
                 var zipUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
                 val confirmDialog = rememberConfirmDialog(onConfirm = {
-                    navigator.navigate(FlashScreenDestination(FlashIt.FlashModules(zipUris)))
-                    viewModel.markNeedRefresh()
+                    if (viewModel.zipUris.isNotEmpty()) {
+                        navigator.navigate(FlashScreenDestination(FlashIt.FlashModules(viewModel.zipUris)))
+                        viewModel.clearZipUris()
+                        viewModel.markNeedRefresh()
+                    }
                 })
                 val selectZipLauncher = rememberLauncherForActivityResult(
                     contract = ActivityResultContracts.StartActivityForResult()
@@ -310,6 +313,10 @@ fun ModuleScreen(navigator: DestinationsNavigator) {
                     } else {
                         data.data?.let { uris.add(it) }
                     }
+
+                    if (uris.isEmpty()) return@rememberLauncherForActivityResult
+
+                    viewModel.updateZipUris(uris)
 
                     // Show confirm dialog with selected zip file(s) name(s)
                     val moduleNames =

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/viewmodel/ModuleViewModel.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/viewmodel/ModuleViewModel.kt
@@ -1,5 +1,6 @@
 package com.rifsxd.ksunext.ui.viewmodel
 
+import android.net.Uri
 import android.os.SystemClock
 import android.util.Log
 import androidx.compose.runtime.derivedStateOf
@@ -91,6 +92,16 @@ class ModuleViewModel : ViewModel() {
 
     fun markNeedRefresh() {
         isNeedRefresh = true
+    }
+
+    var zipUris by mutableStateOf<List<Uri>>(emptyList())
+
+    fun updateZipUris(uris: List<Uri>) {
+        zipUris = uris
+    }
+
+    fun clearZipUris() {
+        zipUris = emptyList()
     }
 
     fun fetchModuleList() {


### PR DESCRIPTION
The issue is caused by re-rendering of Activity when orientation changes. All states are reset when it is re-rendered. Using ViewModel to manage zipUri fixes the issue.

Fixes issue: https://github.com/KernelSU-Next/KernelSU-Next/issues/488

Tested with Single and multiple Zips.