### PR TITLE
Fix Japanese translation of SELinux status

### DIFF
--- a/manager/app/src/main/res/values-ja/strings.xml
+++ b/manager/app/src/main/res/values-ja/strings.xml
@@ -25,9 +25,9 @@
     <string name="home_android">Android バージョン</string>
     <string name="home_manager_version">アプリのバージョン</string>
     <string name="home_selinux_status">SELinuxの状態</string>
-    <string name="selinux_status_disabled">無効</string>
-    <string name="selinux_status_enforcing">強制</string>
-    <string name="selinux_status_permissive">許可モード</string>
+    <string name="selinux_status_disabled">Disabled</string>
+    <string name="selinux_status_enforcing">Enforcing</string>
+    <string name="selinux_status_permissive">Permissive</string>
     <string name="selinux_status_unknown">不明</string>
     <string name="superuser">スーパーユーザー</string>
     <string name="module_failed_to_enable">モジュールを有効にできませんでした：%s</string>


### PR DESCRIPTION
I'm a native Japanese speaker and I think it is inappropriate to translate SELinux status into Japanese.
I propose to change the translation.

I tested Pixel 8 AVD.

## Before Fix

The character displayed is “強制”(kyōsei ) in Japanese characters, which means "forcing".

<img width="500" alt="before-fix" src="https://github.com/user-attachments/assets/b05a0fe9-57eb-4094-9c5d-2bf0a97a7466">

## After Fix

The SELinux status is not translated and is displayed ”Enforcing".

<img width="500" alt="After-fix" src="https://github.com/user-attachments/assets/be909871-fd91-4a17-90e6-3de872bd7299">

I'm not familiar with AVD, and I have not verified other status.
