### PR TITLE
manager: fix integer underflow in `get_manager_uid`

### DIFF
--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -65,7 +65,7 @@ int get_version(void) {
 }
 
 uid_t get_manager_uid() {
-    uid_t manager_uid = (uid_t)-1;
+    uid_t manager_uid = 0;
     ksuctl(CMD_GET_MANAGER_UID, &manager_uid, nullptr);
     return manager_uid;
 }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
@@ -59,7 +59,7 @@ object Natives {
 
     /**
      * Get the UID of the current root manager.
-     * @return manager UID, or -1 if unavailable.
+     * @return manager UID, or 0 if unavailable.
      */
     external fun getManagerUid(): Int
 


### PR DESCRIPTION
Fixes an underflow in the new `get_manager_uid` function.