### PR TITLE
Update Zygisk Injection string

### DIFF
--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Home.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Home.kt
@@ -653,7 +653,7 @@ private fun InfoCard(autoExpand: Boolean = false) {
                         Spacer(Modifier.height(16.dp))
                         InfoCardItem(
                             label = stringResource(R.string.zygisk_status),
-                            content = stringResource(R.string.enabled),
+                            content = stringResource(R.string.zygisk_enabled),
                             icon = Icons.Filled.Vaccines
                         )
                     }

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -224,6 +224,7 @@
     <string name="sucompat_disabled">SUCOMPAT DISABLED</string>
     <string name="zygisk_required">Zygisk required</string>
     <string name="zygisk_status">Zygisk injection</string>
+    <string name="zygisk_enabled">Enabled</string> 
     <plurals name="home_superuser_count">
         <item quantity="one">Superuser</item>
         <item quantity="other">Superusers</item>


### PR DESCRIPTION
Separate the Enabled string in Zygisk Injection because you know, some languages ​​in the Home section are not translated to create synchronization with Selinux which is also not translated (Japanese)