### PR TITLE
ksud: Add second_stage init variant

### DIFF
--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -201,7 +201,8 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 					first_arg, p, sizeof(first_arg));
 				pr_info("/system/bin/init first arg: %s\n",
 					first_arg);
-				if (!strcmp(first_arg, "second_stage")) {
+				if (!strcmp(first_arg, "second_stage") || 
+				    (argc == 2 && !strcmp(first_arg, ""))) {
 					pr_info("/system/bin/init second_stage executed\n");
 					apply_kernelsu_rules();
 					init_second_stage_executed = true;


### PR DESCRIPTION
There are some ROMs based on AOSP that calls on second stage init with argc: 2 but with first_arg: "". This causes KSU to not work properly on those systems.

I have attached dmesgs from one of those said ROMs/systems, before and after the patch.
[dmesg-after.txt](https://github.com/user-attachments/files/21199372/dmesg-after.txt)
[dmesg-before.txt](https://github.com/user-attachments/files/21199373/dmesg-before.txt)
