### PR TITLE
POC: load icon app via ksu://icon/[packageName]

### DIFF
--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/AppIconUtil.java
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/AppIconUtil.java
@@ -1,0 +1,46 @@
+package com.rifsxd.ksunext.ui.webui;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AppIconUtil {
+    private static final Map<String, Bitmap> iconCache = new HashMap<>();
+
+    public static Bitmap loadAppIconSync(Context context, String packageName, int sizePx) {
+        Bitmap cached = iconCache.get(packageName);
+        if (cached != null) return cached;
+
+        try {
+            PackageManager pm = context.getPackageManager();
+            ApplicationInfo appInfo = pm.getApplicationInfo(packageName, 0);
+            Drawable drawable = pm.getApplicationIcon(appInfo);
+            Bitmap raw = drawableToBitmap(drawable, sizePx);
+            Bitmap icon = Bitmap.createScaledBitmap(raw, sizePx, sizePx, true);
+            iconCache.put(packageName, icon);
+            return icon;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static Bitmap drawableToBitmap(Drawable drawable, int size) {
+        if (drawable instanceof BitmapDrawable) return ((BitmapDrawable) drawable).getBitmap();
+
+        int width = drawable.getIntrinsicWidth() > 0 ? drawable.getIntrinsicWidth() : size;
+        int height = drawable.getIntrinsicHeight() > 0 ? drawable.getIntrinsicHeight() : size;
+
+        Bitmap bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bmp);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
+        return bmp;
+    }
+}

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/WebUIActivity.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/WebUIActivity.kt
@@ -97,6 +97,8 @@ class WebUIActivity : ComponentActivity() {
                     request: WebResourceRequest
                 ): WebResourceResponse? {
                     val url = request.url
+                    
+                    //POC: Handle ksu://icon/[packageName] to serve app icon via WebView
                     if (url.scheme.equals("ksu", ignoreCase = true) && url.host.equals("icon", ignoreCase = true)) {
                         val packageName = url.path?.substring(1) 
                         if (!packageName.isNullOrEmpty()) {

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/WebUIActivity.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/WebUIActivity.kt
@@ -96,7 +96,21 @@ class WebUIActivity : ComponentActivity() {
                     view: WebView,
                     request: WebResourceRequest
                 ): WebResourceResponse? {
-                    return webViewAssetLoader.shouldInterceptRequest(request.url)
+                    val url = request.url
+                    if (url.scheme.equals("ksu", ignoreCase = true) && url.host.equals("icon", ignoreCase = true)) {
+                        val packageName = url.path?.substring(1) 
+                        if (!packageName.isNullOrEmpty()) {
+                            val icon = AppIconUtil.loadAppIconSync(this@WebUIActivity, packageName, 512)
+                            if (icon != null) {
+                                val stream = java.io.ByteArrayOutputStream()
+                                icon.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, stream)
+                                val inputStream = java.io.ByteArrayInputStream(stream.toByteArray())
+                                return WebResourceResponse("image/png", null, inputStream)
+                            }
+                        }
+                    }
+            
+                    return webViewAssetLoader.shouldInterceptRequest(url)
                 }
                 override fun onPageFinished(view: WebView?, url: String?) {
                     super.onPageFinished(view, url)


### PR DESCRIPTION
Trying out a custom scheme `ksu://icon/{packageName}` to fetch app icons directly from the package.

- Added `AppIconUtil` (still in Java) to load bitmap from a package name
- In `WebUIActivity`, intercepts requests with that scheme and returns a `WebResourceResponse` with image/png

Only tested basic stuff, no caching yet, and not handling weird edge cases.

Main goal is for the WebUI frontend, so it can grab icons from installed apps without storing them manually.

Still a POC. Not final. But it works — good enough for testing the concept.