### PR TITLE
ci(workflows): add artifact caching to build-manager-ci and build-manager-spoofed workflows

### DIFF
--- a/.github/workflows/build-manager-ci.yml
+++ b/.github/workflows/build-manager-ci.yml
@@ -19,12 +19,48 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-cache:
+    runs-on: ubuntu-latest
+    outputs:
+      cache-hit: ${{ steps.cache-artifacts.outputs.cache-hit }}
+      cache-key: ${{ steps.generate-cache-key.outputs.cache-key }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate cache key from source files
+        id: generate-cache-key
+        run: |
+          # Calculate hash of all files except manager directory
+          HASH=$(find . -type f \
+            -not -path "./manager/*" \
+            -not -path "./.git/*" \
+            -not -path "./.github/workflows/build-manager-ci.yml" \
+            -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1)
+          echo "cache-key=artifacts-$HASH" >> $GITHUB_OUTPUT
+          echo "Generated cache key: artifacts-$HASH"
+
+      - name: Check for cached artifacts
+        id: cache-artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            cached-artifacts/susfsd
+            cached-artifacts/ksud_overlayfs
+            cached-artifacts/ksud_magic
+          key: ${{ steps.generate-cache-key.outputs.cache-key }}
+
   build-lkm:
+    needs: check-cache
+    if: needs.check-cache.outputs.cache-hit != 'true'
     uses: ./.github/workflows/build-lkm.yml
     secrets: inherit
 
   build-susfsd:
-    needs: build-lkm
+    needs: [check-cache, build-lkm]
+    if: needs.check-cache.outputs.cache-hit != 'true'
     strategy:
       matrix:
         include:
@@ -34,7 +70,8 @@ jobs:
       os: ${{ matrix.os }}
 
   build-ksud:
-    needs: build-susfsd
+    needs: [check-cache, build-susfsd]
+    if: needs.check-cache.outputs.cache-hit != 'true'
     strategy:
       matrix:
         include:
@@ -49,8 +86,43 @@ jobs:
       target: ${{ matrix.target }}
       os: ${{ matrix.os }}
 
+  cache-artifacts:
+    needs: [check-cache, build-ksud]
+    if: needs.check-cache.outputs.cache-hit != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download susfsd artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: susfsd-linux-android
+          path: cached-artifacts/susfsd
+
+      - name: Download ksud_overlayfs artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ksud_overlayfs-*
+          path: cached-artifacts/ksud_overlayfs
+          merge-multiple: true
+
+      - name: Download ksud_magic artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ksud_magic-*
+          path: cached-artifacts/ksud_magic
+          merge-multiple: true
+
+      - name: Cache artifacts
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            cached-artifacts/susfsd
+            cached-artifacts/ksud_overlayfs
+            cached-artifacts/ksud_magic
+          key: ${{ needs.check-cache.outputs.cache-key }}
+
   build-manager:
-    needs: build-ksud
+    needs: [check-cache, build-ksud]
+    if: always() && needs.check-cache.result == 'success' && (needs.check-cache.outputs.cache-hit == 'true' || needs.build-ksud.result == 'success')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -92,87 +164,122 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # Restore cached artifacts if cache hit
+      - name: Restore cached artifacts
+        if: needs.check-cache.outputs.cache-hit == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            cached-artifacts/susfsd
+            cached-artifacts/ksud_overlayfs
+            cached-artifacts/ksud_magic
+          key: ${{ needs.check-cache.outputs.cache-key }}
+
+      # Download fresh artifacts if cache miss
       - name: Download susfsd
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: susfsd-linux-android
           path: .
 
-      - name: Copy susfsd to app jniLibs
-        run: |
-          mkdir -p app/src/main/jniLibs/arm64-v8a
-          cp -f ../arm64-v8a/susfsd ../manager/app/src/main/jniLibs/arm64-v8a/libsusfsd.so
-          
-          mkdir -p app/src/main/jniLibs/armeabi-v7a
-          cp -f ../armeabi-v7a/susfsd ../manager/app/src/main/jniLibs/armeabi-v7a/libsusfsd.so
-
-          mkdir -p app/src/main/jniLibs/x86_64
-          cp -f ../x86_64/susfsd ../manager/app/src/main/jniLibs/x86_64/libsusfsd.so
-
-
+      # Download fresh ksud artifacts if cache miss
       - name: Download arm64 ksud_overlayfs
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_overlayfs-aarch64-linux-android
           path: ksud_overlayfs
           
       - name: Download arm ksud_overlayfs
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_overlayfs-armv7-linux-androideabi
           path: ksud_overlayfs
 
       - name: Download x86_64 ksud_overlayfs
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_overlayfs-x86_64-linux-android
           path: ksud_overlayfs
 
-      - name: Copy ksud_overlayfs to app jniLibs
-        run: |
-          mkdir -p app/src/main/jniLibs/arm64-v8a
-
-          mkdir -p app/src/main/jniLibs/armeabi-v7a
-
-          mkdir -p app/src/main/jniLibs/x86_64
-
-          cp -f ../ksud_overlayfs/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_overlayfs.so
-          
-          cp -f ../ksud_overlayfs/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_overlayfs.so
-
-          cp -f ../ksud_overlayfs/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_overlayfs.so
-
       - name: Download arm64 ksud_magic
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_magic-aarch64-linux-android
           path: ksud_magic
           
       - name: Download arm ksud_magic
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_magic-armv7-linux-androideabi
           path: ksud_magic
         
       - name: Download x86_64 ksud_magic
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_magic-x86_64-linux-android
           path: ksud_magic
 
+      # Copy artifacts to jniLibs (works for both cached and fresh)
+      - name: Copy susfsd to app jniLibs
+        run: |
+          mkdir -p app/src/main/jniLibs/arm64-v8a
+          mkdir -p app/src/main/jniLibs/armeabi-v7a
+          mkdir -p app/src/main/jniLibs/x86_64
+          
+          if [ "${{ needs.check-cache.outputs.cache-hit }}" == "true" ]; then
+            # Copy from cached artifacts
+            cp -f ../cached-artifacts/susfsd/arm64-v8a/susfsd ../manager/app/src/main/jniLibs/arm64-v8a/libsusfsd.so
+            cp -f ../cached-artifacts/susfsd/armeabi-v7a/susfsd ../manager/app/src/main/jniLibs/armeabi-v7a/libsusfsd.so
+            cp -f ../cached-artifacts/susfsd/x86_64/susfsd ../manager/app/src/main/jniLibs/x86_64/libsusfsd.so
+          else
+            # Copy from fresh artifacts
+            cp -f ../arm64-v8a/susfsd ../manager/app/src/main/jniLibs/arm64-v8a/libsusfsd.so
+            cp -f ../armeabi-v7a/susfsd ../manager/app/src/main/jniLibs/armeabi-v7a/libsusfsd.so
+            cp -f ../x86_64/susfsd ../manager/app/src/main/jniLibs/x86_64/libsusfsd.so
+          fi
+
+      - name: Copy ksud_overlayfs to app jniLibs
+        run: |
+          mkdir -p app/src/main/jniLibs/arm64-v8a
+          mkdir -p app/src/main/jniLibs/armeabi-v7a
+          mkdir -p app/src/main/jniLibs/x86_64
+
+          if [ "${{ needs.check-cache.outputs.cache-hit }}" == "true" ]; then
+            # Copy from cached artifacts
+            cp -f ../cached-artifacts/ksud_overlayfs/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_overlayfs.so
+            cp -f ../cached-artifacts/ksud_overlayfs/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_overlayfs.so
+            cp -f ../cached-artifacts/ksud_overlayfs/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_overlayfs.so
+          else
+            # Copy from fresh artifacts
+            cp -f ../ksud_overlayfs/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_overlayfs.so
+            cp -f ../ksud_overlayfs/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_overlayfs.so
+            cp -f ../ksud_overlayfs/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_overlayfs.so
+          fi
+
       - name: Copy ksud_magic to app jniLibs
         run: |
           mkdir -p app/src/main/jniLibs/arm64-v8a
-
           mkdir -p app/src/main/jniLibs/armeabi-v7a
-
           mkdir -p app/src/main/jniLibs/x86_64
 
-          cp -f ../ksud_magic/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_magic.so
-          
-          cp -f ../ksud_magic/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_magic.so
-
-          cp -f ../ksud_magic/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_magic.so
+          if [ "${{ needs.check-cache.outputs.cache-hit }}" == "true" ]; then
+            # Copy from cached artifacts
+            cp -f ../cached-artifacts/ksud_magic/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_magic.so
+            cp -f ../cached-artifacts/ksud_magic/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_magic.so
+            cp -f ../cached-artifacts/ksud_magic/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_magic.so
+          else
+            # Copy from fresh artifacts
+            cp -f ../ksud_magic/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_magic.so
+            cp -f ../ksud_magic/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_magic.so
+            cp -f ../ksud_magic/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_magic.so
+          fi
 
       - name: Build with Gradle
         run: |

--- a/.github/workflows/build-manager-spoofed.yml
+++ b/.github/workflows/build-manager-spoofed.yml
@@ -21,12 +21,48 @@ on:
     - cron: "0 12 * * *" # 6 PM UTC+6 | 12 PM UTC
 
 jobs:
+  check-cache:
+    runs-on: ubuntu-latest
+    outputs:
+      cache-hit: ${{ steps.cache-artifacts.outputs.cache-hit }}
+      cache-key: ${{ steps.generate-cache-key.outputs.cache-key }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate cache key from source files
+        id: generate-cache-key
+        run: |
+          # Calculate hash of all files except manager directory
+          HASH=$(find . -type f \
+            -not -path "./manager/*" \
+            -not -path "./.git/*" \
+            -not -path "./.github/workflows/build-manager-spoofed.yml" \
+            -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1)
+          echo "cache-key=artifacts-spoofed-$HASH" >> $GITHUB_OUTPUT
+          echo "Generated cache key: artifacts-spoofed-$HASH"
+
+      - name: Check for cached artifacts
+        id: cache-artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            cached-artifacts/susfsd
+            cached-artifacts/ksud_overlayfs
+            cached-artifacts/ksud_magic
+          key: ${{ steps.generate-cache-key.outputs.cache-key }}
+
   build-lkm:
+    needs: check-cache
+    if: needs.check-cache.outputs.cache-hit != 'true'
     uses: ./.github/workflows/build-lkm.yml
     secrets: inherit
 
   build-susfsd:
-    needs: build-lkm
+    needs: [check-cache, build-lkm]
+    if: needs.check-cache.outputs.cache-hit != 'true'
     strategy:
       matrix:
         include:
@@ -36,7 +72,8 @@ jobs:
       os: ${{ matrix.os }}
 
   build-ksud:
-    needs: build-susfsd
+    needs: [check-cache, build-susfsd]
+    if: needs.check-cache.outputs.cache-hit != 'true'
     strategy:
       matrix:
         include:
@@ -51,8 +88,43 @@ jobs:
       target: ${{ matrix.target }}
       os: ${{ matrix.os }}
 
+  cache-artifacts:
+    needs: [check-cache, build-ksud]
+    if: needs.check-cache.outputs.cache-hit != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download susfsd artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: susfsd-linux-android
+          path: cached-artifacts/susfsd
+
+      - name: Download ksud_overlayfs artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ksud_overlayfs-*
+          path: cached-artifacts/ksud_overlayfs
+          merge-multiple: true
+
+      - name: Download ksud_magic artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ksud_magic-*
+          path: cached-artifacts/ksud_magic
+          merge-multiple: true
+
+      - name: Cache artifacts
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            cached-artifacts/susfsd
+            cached-artifacts/ksud_overlayfs
+            cached-artifacts/ksud_magic
+          key: ${{ needs.check-cache.outputs.cache-key }}
+
   build-manager:
-    needs: build-ksud
+    needs: [check-cache, build-ksud]
+    if: always() && needs.check-cache.result == 'success' && (needs.check-cache.outputs.cache-hit == 'true' || needs.build-ksud.result == 'success')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -99,75 +171,122 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # Restore cached artifacts if cache hit
+      - name: Restore cached artifacts
+        if: needs.check-cache.outputs.cache-hit == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            cached-artifacts/susfsd
+            cached-artifacts/ksud_overlayfs
+            cached-artifacts/ksud_magic
+          key: ${{ needs.check-cache.outputs.cache-key }}
+
+      # Download fresh artifacts if cache miss
       - name: Download susfsd
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: susfsd-linux-android
           path: .
 
-      - name: Copy susfsd to app jniLibs
-        run: |
-          mkdir -p app/src/main/jniLibs/arm64-v8a
-          cp -f ../arm64-v8a/susfsd ../manager/app/src/main/jniLibs/arm64-v8a/libsusfsd.so
-          
-          mkdir -p app/src/main/jniLibs/armeabi-v7a
-          cp -f ../armeabi-v7a/susfsd ../manager/app/src/main/jniLibs/armeabi-v7a/libsusfsd.so
-
-          mkdir -p app/src/main/jniLibs/x86_64
-          cp -f ../x86_64/susfsd ../manager/app/src/main/jniLibs/x86_64/libsusfsd.so
-
-
+      # Download fresh ksud artifacts if cache miss
       - name: Download arm64 ksud_overlayfs
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_overlayfs-aarch64-linux-android
           path: ksud_overlayfs
           
       - name: Download arm ksud_overlayfs
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_overlayfs-armv7-linux-androideabi
           path: ksud_overlayfs
 
       - name: Download x86_64 ksud_overlayfs
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_overlayfs-x86_64-linux-android
           path: ksud_overlayfs
 
-      - name: Copy ksud_overlayfs to app jniLibs
-        run: |
-          cp -f ../ksud_overlayfs/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_overlayfs.so
-          
-          cp -f ../ksud_overlayfs/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_overlayfs.so
-
-          cp -f ../ksud_overlayfs/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_overlayfs.so
-
       - name: Download arm64 ksud_magic
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_magic-aarch64-linux-android
           path: ksud_magic
           
       - name: Download arm ksud_magic
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_magic-armv7-linux-androideabi
           path: ksud_magic
         
       - name: Download x86_64 ksud_magic
+        if: needs.check-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: ksud_magic-x86_64-linux-android
           path: ksud_magic
 
+      # Copy artifacts to jniLibs (works for both cached and fresh)
+      - name: Copy susfsd to app jniLibs
+        run: |
+          mkdir -p app/src/main/jniLibs/arm64-v8a
+          mkdir -p app/src/main/jniLibs/armeabi-v7a
+          mkdir -p app/src/main/jniLibs/x86_64
+          
+          if [ "${{ needs.check-cache.outputs.cache-hit }}" == "true" ]; then
+            # Copy from cached artifacts
+            cp -f ../cached-artifacts/susfsd/arm64-v8a/susfsd ../manager/app/src/main/jniLibs/arm64-v8a/libsusfsd.so
+            cp -f ../cached-artifacts/susfsd/armeabi-v7a/susfsd ../manager/app/src/main/jniLibs/armeabi-v7a/libsusfsd.so
+            cp -f ../cached-artifacts/susfsd/x86_64/susfsd ../manager/app/src/main/jniLibs/x86_64/libsusfsd.so
+          else
+            # Copy from fresh artifacts
+            cp -f ../arm64-v8a/susfsd ../manager/app/src/main/jniLibs/arm64-v8a/libsusfsd.so
+            cp -f ../armeabi-v7a/susfsd ../manager/app/src/main/jniLibs/armeabi-v7a/libsusfsd.so
+            cp -f ../x86_64/susfsd ../manager/app/src/main/jniLibs/x86_64/libsusfsd.so
+          fi
+
+      - name: Copy ksud_overlayfs to app jniLibs
+        run: |
+          mkdir -p app/src/main/jniLibs/arm64-v8a
+          mkdir -p app/src/main/jniLibs/armeabi-v7a
+          mkdir -p app/src/main/jniLibs/x86_64
+
+          if [ "${{ needs.check-cache.outputs.cache-hit }}" == "true" ]; then
+            # Copy from cached artifacts
+            cp -f ../cached-artifacts/ksud_overlayfs/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_overlayfs.so
+            cp -f ../cached-artifacts/ksud_overlayfs/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_overlayfs.so
+            cp -f ../cached-artifacts/ksud_overlayfs/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_overlayfs.so
+          else
+            # Copy from fresh artifacts
+            cp -f ../ksud_overlayfs/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_overlayfs.so
+            cp -f ../ksud_overlayfs/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_overlayfs.so
+            cp -f ../ksud_overlayfs/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_overlayfs.so
+          fi
+
       - name: Copy ksud_magic to app jniLibs
         run: |
-          cp -f ../ksud_magic/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_magic.so
-          
-          cp -f ../ksud_magic/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_magic.so
+          mkdir -p app/src/main/jniLibs/arm64-v8a
+          mkdir -p app/src/main/jniLibs/armeabi-v7a
+          mkdir -p app/src/main/jniLibs/x86_64
 
-          cp -f ../ksud_magic/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_magic.so
+          if [ "${{ needs.check-cache.outputs.cache-hit }}" == "true" ]; then
+            # Copy from cached artifacts
+            cp -f ../cached-artifacts/ksud_magic/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_magic.so
+            cp -f ../cached-artifacts/ksud_magic/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_magic.so
+            cp -f ../cached-artifacts/ksud_magic/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_magic.so
+          else
+            # Copy from fresh artifacts
+            cp -f ../ksud_magic/aarch64-linux-android/release/ksud ../manager/app/src/main/jniLibs/arm64-v8a/libksud_magic.so
+            cp -f ../ksud_magic/armv7-linux-androideabi/release/ksud ../manager/app/src/main/jniLibs/armeabi-v7a/libksud_magic.so
+            cp -f ../ksud_magic/x86_64-linux-android/release/ksud ../manager/app/src/main/jniLibs/x86_64/libksud_magic.so
+          fi
 
       - name: Build with Gradle
         run: |


### PR DESCRIPTION
Add cache check, save and restore steps to avoid rebuilding artifacts when source files haven't changed. The workflows now check for cached artifacts first and only rebuilds if cache is invalid or missing.