### PR TITLE
kernel: selinux: rules: Micro-optimize get_policydb() and fix illegal RCU lock usage in handle_sepolicy() (https://github.com/tiann/KernelSU/pull/2695)

### DIFF
--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -24,10 +24,10 @@ static struct policydb *get_policydb(void)
 // selinux_state does not exists before 4.19
 #ifdef KSU_COMPAT_USE_SELINUX_STATE
 #ifdef SELINUX_POLICY_INSTEAD_SELINUX_SS
-	struct selinux_policy *policy = rcu_dereference(selinux_state.policy);
+	struct selinux_policy *policy = selinux_state.policy;
 	db = &policy->policydb;
 #else
-	struct selinux_ss *ss = rcu_dereference(selinux_state.ss);
+	struct selinux_ss *ss = selinux_state.ss;
 	db = &ss->policydb;
 #endif
 #else
@@ -230,6 +230,8 @@ static void reset_avc_cache()
 
 int handle_sepolicy(unsigned long arg3, void __user *arg4)
 {
+	struct policydb *db;
+
 	if (!arg4) {
 		return -1;
 	}
@@ -291,9 +293,9 @@ int handle_sepolicy(unsigned long arg3, void __user *arg4)
 	subcmd = data.subcmd;
 #endif
 
-	rcu_read_lock();
+	mutex_lock(&ksu_rules);
 
-	struct policydb *db = get_policydb();
+	db = get_policydb();
 
 	int ret = -1;
 	if (cmd == CMD_NORMAL_PERM) {
@@ -543,7 +545,7 @@ int handle_sepolicy(unsigned long arg3, void __user *arg4)
 	}
 
 exit:
-	rcu_read_unlock();
+	mutex_unlock(&ksu_rules);
 
 	// only allow and xallow needs to reset avc cache, but we cannot do that because
 	// we are in atomic context. so we just reset it every time.


### PR DESCRIPTION
kernel: selinux: rules: Micro-optimize get_policydb() and fix illegal RCU lock usage in handle_sepolicy() (https://github.com/tiann/KernelSU/pull/2695)
Signed-off-by: Tashfin Shakeer Rhythm <tashfinshakeerrhythm@gmail.com>

-Update the other side of the conditional.
https://github.com/KernelSU-Next/KernelSU-Next/pull/721#issuecomment-3193787529
https://github.com/Atom-X-Devs/scarlet_xiaomi_sm7325/commit/06ac6d632f6ba8beb924f0bf5c4c02ecca2f3026#diff-8cea866f9b1ae8607ee66566fc7a63c950c64952a753e3691edc2b69622a7d86