### PR TITLE
Reset seccomp filter count when escaping to root (https://github.com/tiann/KernelSU/pull/2708)

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -131,6 +131,7 @@ static void disable_seccomp(void)
 #ifdef CONFIG_SECCOMP
 	current->seccomp.mode = 0;
 	current->seccomp.filter = NULL;
+	atomic_set(&current->seccomp.filter_count, 0);
 #else
 #endif
 }


### PR DESCRIPTION
Reset seccomp filter count when escaping to root (https://github.com/tiann/KernelSU/pull/2708)

-Note: legacy kernels:
 https://github.com/selfmusing/kernel_xiaomi_violet/commit/9596554cfbdab57682a430c15ca64c691d404152