### PR TITLE
fix 'for' loop problem (https://github.com/tiann/KernelSU/pull/2745)

### DIFF
--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -329,7 +329,8 @@ void ksu_sucompat_init()
 void ksu_sucompat_exit()
 {
 #ifdef CONFIG_KSU_KPROBES_HOOK
-	for (int i = 0; i < ARRAY_SIZE(su_kps); i++) {
+	int i;
+	for (i = 0; i < ARRAY_SIZE(su_kps); i++) {
 		destroy_kprobe(&su_kps[i]);
 	}
 #else


### PR DESCRIPTION
fix ‘for’ loop initial declarations are only allowed in c99 or c11 mode