### PR TITLE
kernel: Remove duplicate include in core_hook

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -44,7 +44,6 @@
 #include "manager.h"
 #include "selinux/selinux.h"
 #include "throne_tracker.h"
-#include "throne_tracker.h"
 #include "kernel_compat.h"
 
 static bool ksu_module_mounted = false;


### PR DESCRIPTION
kernel: Remove duplicate include in core_hook

-throne_tracker.h