### PR TITLE
KernelSU: Kconfig: select CONFIG_OVERLAY_FS instead of depending on it

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -2,7 +2,7 @@ menu "KernelSU"
 
 config KSU
 	tristate "KernelSU function support"
-	depends on OVERLAY_FS
+	select OVERLAY_FS
 	default y
 	help
 	  Enable kernel-level root privileges on Android System.


### PR DESCRIPTION
Some old kernels have CONFIG_OVERLAY_FS disabled by default (like the Galaxy S10/N10 Kernel).

Since KernelSU depends on CONFIG_OVERLAY_FS, it fails to compile even if the user adds it manually.

This patch ensures that if CONFIG_OVERLAY_FS is disabled by default, it will be automatically enabled when KernelSU is selected.

Before applying this patch in an OverlayFS disabled kernel:

https://github.com/user-attachments/assets/3e4b21de-1eaa-419c-9724-2b45b5de5186

After applying this patch:

<img width="960" height="1050" alt="Screenshot From 2025-12-10 21-17-38" src="https://github.com/user-attachments/assets/c3730103-2f75-4d9a-a4ab-970286b4704c" />

OverlayFS is untouchable because of this new patch :) [ forced selected ]

<img width="960" height="1050" alt="Screenshot From 2025-12-10 21-17-48" src="https://github.com/user-attachments/assets/531fee66-94d8-4b17-b078-e9b59dc6e99f" />

Because, KernelSU selected the Overlayfs:

<img width="960" height="1050" alt="Screenshot From 2025-12-10 21-18-08" src="https://github.com/user-attachments/assets/34c9292c-b2be-4d50-8c01-d08ef4ef2798" />
