### PR TITLE
fix issues in legacy branch

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -190,8 +190,11 @@ ifeq ($(shell grep -q "atomic_t\s\+filter_count" $(srctree)/include/linux/seccom
 ccflags-y += -DKSU_OPTIONAL_SECCOMP_FILTER_CNT
 endif
 # some old kernel backport this, let's check if put_seccomp_filter still exist
+# some old kernel backport this, let's check if put_seccomp_filter still exist
 ifneq ($(shell grep -wq "put_seccomp_filter" $(srctree)/kernel/seccomp.c $(srctree)/include/linux/seccomp.h; echo $$?),0)
+ifeq ($(shell grep -wq "seccomp_filter_release" $(srctree)/kernel/seccomp.c $(srctree)/include/linux/seccomp.h; echo $$?),0)
 ccflags-y += -DKSU_OPTIONAL_SECCOMP_FILTER_RELEASE
+endif
 endif
 ifeq ($(shell grep -q "anon_inode_getfd_secure" $(srctree)/fs/anon_inodes.c; echo $$?),0)
 ccflags-y += -DKSU_HAS_GETFD_SECURE

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -16,6 +16,13 @@ config KSU_DEBUG
 	help
 	  Enable KernelSU debug mode.
 
+config KSU_ALLOWLIST_WORKAROUND
+	bool "KernelSU allowlist workaround"
+	depends on KSU
+	default n
+	help
+	  Enable workaround for broken allowlist save
+
 # For easier extern ifdef handling
 config KSU_MANUAL_HOOK
 	bool "KernelSU manual hook mode."

--- a/kernel/apk_sign.c
+++ b/kernel/apk_sign.c
@@ -16,6 +16,7 @@
 
 #include "apk_sign.h"
 #include "klog.h" // IWYU pragma: keep
+#include "kernel_compat.h"
 
 struct sdesc {
 	struct shash_desc shash;
@@ -72,19 +73,19 @@ static int ksu_sha256(const unsigned char *data, unsigned int datalen,
 static bool check_block(struct file *fp, u32 *size4, loff_t *pos, u32 *offset,
 			unsigned expected_size, const char *expected_sha256)
 {
-	kernel_read(fp, size4, 0x4, pos); // signer-sequence length
-	kernel_read(fp, size4, 0x4, pos); // signer length
-	kernel_read(fp, size4, 0x4, pos); // signed data length
+	ksu_kernel_read_compat(fp, size4, 0x4, pos); // signer-sequence length
+	ksu_kernel_read_compat(fp, size4, 0x4, pos); // signer length
+	ksu_kernel_read_compat(fp, size4, 0x4, pos); // signed data length
 
 	*offset += 0x4 * 3;
 
-	kernel_read(fp, size4, 0x4, pos); // digests-sequence length
+	ksu_kernel_read_compat(fp, size4, 0x4, pos); // digests-sequence length
 
 	*pos += *size4;
 	*offset += 0x4 + *size4;
 
-	kernel_read(fp, size4, 0x4, pos); // certificates length
-	kernel_read(fp, size4, 0x4, pos); // certificate length
+	ksu_kernel_read_compat(fp, size4, 0x4, pos); // certificates length
+	ksu_kernel_read_compat(fp, size4, 0x4, pos); // certificate length
 	*offset += 0x4 * 2;
 
 	if (*size4 == expected_size) {
@@ -96,7 +97,7 @@ static bool check_block(struct file *fp, u32 *size4, loff_t *pos, u32 *offset,
 			pr_info("cert length overlimit\n");
 			return false;
 		}
-		kernel_read(fp, cert, *size4, pos);
+		ksu_kernel_read_compat(fp, cert, *size4, pos);
 		unsigned char digest[SHA256_DIGEST_SIZE];
 		if (IS_ERR(ksu_sha256(cert, *size4, digest))) {
 			pr_info("sha256 error\n");
@@ -138,7 +139,7 @@ static bool has_v1_signature_file(struct file *fp)
 
 	loff_t pos = 0;
 
-	while (kernel_read(fp, &header,
+	while (ksu_kernel_read_compat(fp, &header,
 					sizeof(struct zip_entry_header), &pos) ==
 		sizeof(struct zip_entry_header)) {
 		if (header.signature != 0x04034b50) {
@@ -148,7 +149,7 @@ static bool has_v1_signature_file(struct file *fp)
 		// Read the entry file name
 		if (header.file_name_length == sizeof(MANIFEST) - 1) {
 			char fileName[sizeof(MANIFEST)];
-			kernel_read(fp, fileName,
+			ksu_kernel_read_compat(fp, fileName,
 						header.file_name_length, &pos);
 			fileName[header.file_name_length] = '\0';
 
@@ -185,7 +186,7 @@ static __always_inline bool check_v2_signature(char *path,
 	bool v3_1_signing_exist = false;
 
 	int i;
-	struct file *fp = filp_open(path, O_RDONLY, 0);
+	struct file *fp = ksu_filp_open_compat(path, O_RDONLY, 0);
 	if (IS_ERR(fp)) {
 		pr_err("open %s error.\n", path);
 		return false;
@@ -198,10 +199,10 @@ static __always_inline bool check_v2_signature(char *path,
 	for (i = 0;; ++i) {
 		unsigned short n;
 		pos = generic_file_llseek(fp, -i - 2, SEEK_END);
-		kernel_read(fp, &n, 2, &pos);
+		ksu_kernel_read_compat(fp, &n, 2, &pos);
 		if (n == i) {
 			pos -= 22;
-			kernel_read(fp, &size4, 4, &pos);
+			ksu_kernel_read_compat(fp, &size4, 4, &pos);
 			if ((size4 ^ 0xcafebabeu) == 0xccfbf1eeu) {
 				break;
 			}
@@ -214,17 +215,17 @@ static __always_inline bool check_v2_signature(char *path,
 
 	pos += 12;
 	// offset
-	kernel_read(fp, &size4, 0x4, &pos);
+	ksu_kernel_read_compat(fp, &size4, 0x4, &pos);
 	pos = size4 - 0x18;
 
-	kernel_read(fp, &size8, 0x8, &pos);
-	kernel_read(fp, buffer, 0x10, &pos);
+	ksu_kernel_read_compat(fp, &size8, 0x8, &pos);
+	ksu_kernel_read_compat(fp, buffer, 0x10, &pos);
 	if (strcmp((char *)buffer, "APK Sig Block 42")) {
 		goto clean;
 	}
 
 	pos = size4 - (size8 + 0x8);
-	kernel_read(fp, &size_of_block, 0x8, &pos);
+	ksu_kernel_read_compat(fp, &size_of_block, 0x8, &pos);
 	if (size_of_block != size8) {
 		goto clean;
 	}
@@ -233,12 +234,12 @@ static __always_inline bool check_v2_signature(char *path,
 	while (loop_count++ < 10) {
 		uint32_t id;
 		uint32_t offset;
-		kernel_read(fp, &size8, 0x8,
+		ksu_kernel_read_compat(fp, &size8, 0x8,
 					&pos); // sequence length
 		if (size8 == size_of_block) {
 			break;
 		}
-		kernel_read(fp, &id, 0x4, &pos); // id
+		ksu_kernel_read_compat(fp, &id, 0x4, &pos); // id
 		offset = 4;
 		if (id == 0x7109871au) {
 			v2_signing_blocks++;

--- a/kernel/app_profile.c
+++ b/kernel/app_profile.c
@@ -216,12 +216,20 @@ void seccomp_filter_release(struct task_struct *tsk);
 
 void disable_seccomp(void)
 {
+	// https://github.com/backslashxx/KernelSU/tree/e28930645e764b9f0e5d0d1b0d5e236464939075/kernel/app_profile.c
+	if (!!!current->seccomp.mode) {
+		return;
+	}
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) ||                          \
+     defined(KSU_OPTIONAL_SECCOMP_FILTER_RELEASE))
 	struct task_struct *fake;
 	fake = kmalloc(sizeof(*fake), GFP_ATOMIC);
 	if (!fake) {
 		pr_err("%s: cannot allocate fake struct!\n", __func__);
 		return;
 	}
+#endif
 
     // Refer to kernel/seccomp.c: seccomp_set_mode_strict
     // When disabling Seccomp, ensure that current->sighand->siglock is held during the operation.
@@ -234,8 +242,16 @@ void disable_seccomp(void)
 	clear_thread_flag(TIF_SECCOMP);
 #endif
 
-    memcpy(fake, current, sizeof(*fake));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) ||                          \
+     defined(KSU_OPTIONAL_SECCOMP_FILTER_RELEASE))
+	memcpy(fake, current, sizeof(*fake));
+#endif
 	current->seccomp.mode = 0;
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) &&                           \
+     !defined(KSU_OPTIONAL_SECCOMP_FILTER_RELEASE))
+	// put_seccomp_filter is allowed while we holding sighand
+	put_seccomp_filter(current);
+#endif
 	current->seccomp.filter = NULL;
 // 5.9+ have filter_count, but optional.
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0) ||                          \
@@ -244,6 +260,8 @@ void disable_seccomp(void)
 #endif
     spin_unlock_irq(&current->sighand->siglock);
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) ||                          \
+     defined(KSU_OPTIONAL_SECCOMP_FILTER_RELEASE))
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
     // https://github.com/torvalds/linux/commit/bfafe5efa9754ebc991750da0bcca2a6694f3ed3#diff-45eb79a57536d8eccfc1436932f093eb5c0b60d9361c39edb46581ad313e8987R576-R577
     fake->flags |= PF_EXITING;
@@ -251,18 +269,7 @@ void disable_seccomp(void)
     // https://github.com/torvalds/linux/commit/0d8315dddd2899f519fe1ca3d4d5cdaf44ea421e#diff-45eb79a57536d8eccfc1436932f093eb5c0b60d9361c39edb46581ad313e8987R556-R558
     fake->sighand = NULL;
 #endif
-// some old kernel backport seccomp_filter_release..
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) &&                           \
-     defined(KSU_OPTIONAL_SECCOMP_FILTER_RELEASE))
 	seccomp_filter_release(fake);
-	kfree(fake);
-// never, ever call seccomp_filter_release on 6.10+ (no effect)
-#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) &&                          \
-     LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0))
-	seccomp_filter_release(fake);
-	kfree(fake);
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
-	put_seccomp_filter(fake);
 	kfree(fake);
 #endif
 }

--- a/kernel/file_wrapper.c
+++ b/kernel/file_wrapper.c
@@ -13,6 +13,7 @@
 #include <linux/uaccess.h>
 #include <linux/version.h>
 #include <linux/mount.h>
+#include <linux/module.h>
 
 #include "objsec.h"
 

--- a/kernel/kernel_compat.c
+++ b/kernel/kernel_compat.c
@@ -11,7 +11,7 @@
 #include "kernel_compat.h"
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) ||                           \
-	defined(CONFIG_IS_HW_HISI)
+	defined(CONFIG_IS_HW_HISI) || defined(CONFIG_KSU_ALLOWLIST_WORKAROUND)
 #include <linux/key.h>
 #include <linux/errno.h>
 #include <linux/cred.h>
@@ -38,6 +38,51 @@ static int install_session_keyring(struct key *keyring)
 	return commit_creds(new);
 }
 #endif
+
+struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) ||                           \
+	defined(CONFIG_IS_HW_HISI) || defined(CONFIG_KSU_ALLOWLIST_WORKAROUND)
+	if (init_session_keyring != NULL && !current_cred()->session_keyring &&
+	    (current->flags & PF_WQ_WORKER)) {
+		pr_info("installing init session keyring for older kernel\n");
+		install_session_keyring(init_session_keyring);
+	}
+#endif
+	return filp_open(filename, flags, mode);
+}
+
+ssize_t ksu_kernel_read_compat(struct file *p, void *buf, size_t count,
+			       loff_t *pos)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) ||                          \
+	defined(KSU_OPTIONAL_KERNEL_READ)
+	return kernel_read(p, buf, count, pos);
+#else
+	loff_t offset = pos ? *pos : 0;
+	ssize_t result = kernel_read(p, offset, (char *)buf, count);
+	if (pos && result > 0) {
+		*pos = offset + result;
+	}
+	return result;
+#endif
+}
+
+ssize_t ksu_kernel_write_compat(struct file *p, const void *buf, size_t count,
+				loff_t *pos)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) ||                          \
+	defined(KSU_OPTIONAL_KERNEL_WRITE)
+	return kernel_write(p, buf, count, pos);
+#else
+	loff_t offset = pos ? *pos : 0;
+	ssize_t result = kernel_write(p, buf, count, offset);
+	if (pos && result > 0) {
+		*pos = offset + result;
+	}
+	return result;
+#endif
+}
 
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && !defined(KSU_HAS_PATH_MOUNT))
@@ -128,3 +173,45 @@ strncpy_from_user_nofault(char *dst, const void __user *unsafe_addr,
 #endif
 }
 #endif // #ifndef KSU_OPTIONAL_STRNCPY
+
+static void *__kvmalloc(size_t size, gfp_t flags)
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 12, 0)
+// https://elixir.bootlin.com/linux/v4.4.302/source/security/apparmor/lib.c#L79
+	void *buffer = NULL;
+
+	if (size == 0)
+		return NULL;
+
+	/* do not attempt kmalloc if we need more than 16 pages at once */
+	if (size <= (16 * PAGE_SIZE))
+		buffer = kmalloc(size, flags | GFP_NOIO | __GFP_NOWARN);
+	if (!buffer) {
+		if (flags & __GFP_ZERO)
+			buffer = vzalloc(size);
+		else
+			buffer = vmalloc(size);
+	}
+	return buffer;
+#else
+	return kvmalloc(size, flags);
+#endif
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+// https://elixir.bootlin.com/linux/v5.10.247/source/mm/util.c#L664
+void *ksu_compat_kvrealloc(const void *p, size_t oldsize, size_t newsize,
+			   gfp_t flags)
+{
+	void *newp;
+
+	if (oldsize >= newsize)
+		return (void *)p;
+	newp = __kvmalloc(newsize, flags);
+	if (!newp)
+		return NULL;
+	memcpy(newp, p, oldsize);
+	kvfree(p);
+	return newp;
+}
+#endif

--- a/kernel/kernel_compat.c
+++ b/kernel/kernel_compat.c
@@ -39,6 +39,27 @@ static int install_session_keyring(struct key *keyring)
 }
 #endif
 
+// mnt_ns context switch for environment that android_init->nsproxy->mnt_ns != init_task.nsproxy->mnt_ns, such as WSA
+struct ksu_ns_fs_saved {
+        struct nsproxy *ns;
+        struct fs_struct *fs;
+};
+
+static void ksu_save_ns_fs(struct ksu_ns_fs_saved *ns_fs_saved)
+{
+        ns_fs_saved->ns = current->nsproxy;
+        ns_fs_saved->fs = current->fs;
+}
+
+static void ksu_load_ns_fs(struct ksu_ns_fs_saved *ns_fs_saved)
+{
+        current->nsproxy = ns_fs_saved->ns;
+        current->fs = ns_fs_saved->fs;
+}
+
+static bool android_context_saved_enabled = false;
+static struct ksu_ns_fs_saved android_context_saved;
+
 struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) ||                           \
@@ -49,7 +70,23 @@ struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
 		install_session_keyring(init_session_keyring);
 	}
 #endif
-	return filp_open(filename, flags, mode);
+    // switch mnt_ns even if current is not wq_worker, to ensure what we open is the correct file in android mnt_ns, rather than user created mnt_ns
+    struct ksu_ns_fs_saved saved;
+    if (android_context_saved_enabled) {
+            pr_info("start switch current nsproxy and fs to android context\n");
+            task_lock(current);
+            ksu_save_ns_fs(&saved);
+            ksu_load_ns_fs(&android_context_saved);
+            task_unlock(current);
+    }
+    struct file *fp = filp_open(filename, flags, mode);
+	    if (android_context_saved_enabled) {
+            task_lock(current);
+            ksu_load_ns_fs(&saved);
+            task_unlock(current);
+            pr_info("switch current nsproxy and fs back to saved successfully\n");
+    }
+    return fp;
 }
 
 ssize_t ksu_kernel_read_compat(struct file *p, void *buf, size_t count,

--- a/kernel/kernel_compat.h
+++ b/kernel/kernel_compat.h
@@ -28,6 +28,18 @@
 #endif
 #endif
 
+extern struct file *ksu_filp_open_compat(const char *filename, int flags,
+					 umode_t mode);
+extern ssize_t ksu_kernel_read_compat(struct file *p, void *buf, size_t count,
+				      loff_t *pos);
+extern ssize_t ksu_kernel_write_compat(struct file *p, const void *buf,
+				       size_t count, loff_t *pos);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) ||                           \
+	defined(CONFIG_IS_HW_HISI) || defined(CONFIG_KSU_ALLOWLIST_WORKAROUND)
+extern struct key *init_session_keyring;
+#endif
+
 extern long ksu_copy_from_user_nofault(void *dst, const void __user *src, size_t size);
 /*
  * ksu_copy_from_user_retry
@@ -45,6 +57,11 @@ static long ksu_copy_from_user_retry(void *to,
 	// we faulted! fallback to slow path
 	return copy_from_user(to, from, count);
 }
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+extern void *ksu_compat_kvrealloc(const void *p, size_t oldsize, size_t newsize,
+				  gfp_t flags);
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
 #define ksu_access_ok(addr, size) access_ok(addr, size)

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -17,7 +17,9 @@
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
 #include <linux/aio.h>
 #endif
+#ifdef KSU_KPROBES_HOOK
 #include <linux/kprobes.h>
+#endif
 #include <linux/printk.h>
 #include <linux/types.h>
 #include <linux/uaccess.h>
@@ -39,6 +41,7 @@
 #include "throne_tracker.h"
 #include "kernel_compat.h"
 
+extern int ksu_observer_init(void);
 bool ksu_module_mounted __read_mostly = false;
 bool ksu_boot_completed __read_mostly = false;
 
@@ -199,6 +202,9 @@ static int __maybe_unused count(struct user_arg_ptr argv, int max)
 
 			if (fatal_signal_pending(current))
 				return -ERESTARTNOHAND;
+#ifndef KSU_KPROBES_HOOK
+			cond_resched();
+#endif
 		}
 	}
 	return i;
@@ -374,6 +380,11 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 				struct user_arg_ptr *argv,
 				struct user_arg_ptr *envp, int *flags)
 {
+#ifndef KSU_KPROBES_HOOK
+	if (!ksu_execveat_hook) {
+		return 0;
+	}
+#endif
 	struct filename *filename;
 
 	static const char app_process[] = "/system/bin/app_process";
@@ -408,6 +419,7 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 				if (!strcmp(first_arg, "second_stage")) {
 					pr_info("/system/bin/init second_stage executed\n");
 					apply_kernelsu_rules();
+					setup_ksu_cred();
 					init_second_stage_executed = true;
 				}
 			} else {
@@ -430,6 +442,7 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 				if (!strcmp(first_arg, "--second-stage")) {
 					pr_info("/init second_stage executed\n");
 					apply_kernelsu_rules();
+					setup_ksu_cred();
 					init_second_stage_executed = true;
 				}
 			} else {
@@ -463,6 +476,7 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 					     !strcmp(env_value, "true"))) {
 						pr_info("/init second_stage executed\n");
 						apply_kernelsu_rules();
+						setup_ksu_cred();
 						init_second_stage_executed = true;
 					}
 				}

--- a/kernel/lsm_hooks.c
+++ b/kernel/lsm_hooks.c
@@ -30,6 +30,60 @@ static int ksu_key_permission(key_ref_t key_ref, const struct cred *cred,
 }
 #endif
 
+static int ksu_inode_rename(struct inode *old_inode, struct dentry *old_dentry,
+			    struct inode *new_inode, struct dentry *new_dentry)
+{
+	// skip kernel threads
+	if (!current->mm) {
+		return 0;
+	}
+
+	// skip non system uid
+	if (current_uid().val != 1000) {
+		return 0;
+	}
+
+	if (!old_dentry || !new_dentry) {
+		return 0;
+	}
+
+	// /data/system/packages.list.tmp -> /data/system/packages.list
+	if (strcmp(new_dentry->d_iname, "packages.list")) {
+		return 0;
+	}
+
+	char path[128];
+	char *buf = dentry_path_raw(new_dentry, path, sizeof(path));
+	if (IS_ERR(buf)) {
+		pr_err("dentry_path_raw failed.\n");
+		return 0;
+	}
+
+	if (!strstr(buf, "/system/packages.list")) {
+		return 0;
+	}
+
+	pr_info("renameat: %s -> %s, new path: %s\n", old_dentry->d_iname,
+		new_dentry->d_iname, buf);
+
+	/*
+	 * RKSU note:
+	 * track_throne(true) only occurs on on_boot_completed event.
+	 * When using this LSM, we must handle it here, else it returns
+	 * ENOENT (-2).
+	 */
+	static bool did = false;
+	if (ksu_boot_completed && !did) {
+		did = true;
+		track_throne(true);
+		return 0;
+	}
+
+	track_throne(false);
+
+	return 0;
+}
+
 static int ksu_task_fix_setuid(struct cred *new, const struct cred *old,
 			       int flags)
 {
@@ -87,14 +141,15 @@ int ksu_bprm_check(struct linux_binprm *bprm)
 
 static struct security_hook_list ksu_hooks[] = {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) ||                           \
-	defined(CONFIG_IS_HW_HISI)
+	defined(CONFIG_IS_HW_HISI) || defined(CONFIG_KSU_ALLOWLIST_WORKAROUND)
 	LSM_HOOK_INIT(key_permission, ksu_key_permission),
 #endif
-	LSM_HOOK_INIT(inode_permission, ksu_inode_permission),
 #ifndef KSU_KPROBES_HOOK
 	LSM_HOOK_INIT(bprm_check_security, ksu_bprm_check),
-#endif
+	LSM_HOOK_INIT(inode_permission, ksu_inode_permission),
+	LSM_HOOK_INIT(inode_rename, ksu_inode_rename),
 	LSM_HOOK_INIT(task_fix_setuid, ksu_task_fix_setuid)
+#endif
 };
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)

--- a/kernel/seccomp_cache.h
+++ b/kernel/seccomp_cache.h
@@ -1,5 +1,5 @@
-#ifndef __KSU_H_KERNEL_COMPAT
-#define __KSU_H_KERNEL_COMPAT
+#ifndef __KSU_H_SECCOMP_CACHE
+#define __KSU_H_SECCOMP_CACHE
 
 #include <linux/fs.h>
 #include <linux/version.h>

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -1,6 +1,7 @@
 #include "selinux.h"
 #include "linux/cred.h"
 #include "linux/sched.h"
+#include "linux/security.h"
 #include "objsec.h"
 #include "linux/version.h"
 #include "../klog.h" // IWYU pragma: keep

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -53,6 +53,11 @@ static inline taskcred_sec_t *selinux_cred(const struct cred *cred)
 #define KERNEL_SU_CONTEXT "u:r:" KERNEL_SU_DOMAIN ":s0"
 #define KSU_FILE_CONTEXT "u:object_r:" KERNEL_SU_FILE ":s0"
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) ||                        \
+	defined(KSU_COMPAT_HAS_SELINUX_STATE)
+#define KSU_COMPAT_USE_SELINUX_STATE
+#endif
+
 void setup_selinux(const char *);
 
 void setenforce(bool);

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -586,21 +586,13 @@ static bool add_genfscon(struct policydb *db, const char *fs_name,
     return false;
 }
 
-static void *ksu_realloc(void *old, size_t new_size, size_t old_size)
-{
-    // we can't use krealloc, because it may be read-only
-    void *new = kzalloc(new_size, GFP_ATOMIC);
-    if (!new) {
-        return NULL;
-    }
-    if (old_size) {
-        memcpy(new, old, old_size);
-    }
-    // we can't use kfree, because it may be read-only
-    // there maybe some leaks, maybe we can check ptr_write, but it's not a big deal
-    // kfree(old);
-    return new;
-}
+// https://github.com/torvalds/linux/commit/590b9d576caec6b4c46bba49ed36223a399c3fc5#diff-cc9aa90e094e6e0f47bd7300db4f33cf4366b98b55d8753744f31eb69c691016R844-R845
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+#define ksu_kvrealloc(p, new_size, _old_size) kvrealloc(p, new_size, GFP_ATOMIC)
+#else
+#define ksu_kvrealloc(p, new_size, old_size)                                   \
+	ksu_compat_kvrealloc(p, old_size, new_size, GFP_ATOMIC)
+#endif
 
 static bool add_type(struct policydb *db, const char *type_name, bool attr)
 {
@@ -634,7 +626,7 @@ static bool add_type(struct policydb *db, const char *type_name, bool attr)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
     struct ebitmap *new_type_attr_map_array =
-        ksu_realloc(db->type_attr_map_array, value * sizeof(struct ebitmap),
+        ksu_kvrealloc(db->type_attr_map_array, value * sizeof(struct ebitmap),
                     (value - 1) * sizeof(struct ebitmap));
 
     if (!new_type_attr_map_array) {
@@ -643,7 +635,7 @@ static bool add_type(struct policydb *db, const char *type_name, bool attr)
     }
 
     struct type_datum **new_type_val_to_struct =
-        ksu_realloc(db->type_val_to_struct,
+        ksu_kvrealloc(db->type_val_to_struct,
                     sizeof(*db->type_val_to_struct) * value,
                     sizeof(*db->type_val_to_struct) * (value - 1));
 
@@ -653,7 +645,7 @@ static bool add_type(struct policydb *db, const char *type_name, bool attr)
     }
 
     char **new_val_to_name_types =
-        ksu_realloc(db->sym_val_to_name[SYM_TYPES], sizeof(char *) * value,
+        ksu_kvrealloc(db->sym_val_to_name[SYM_TYPES], sizeof(char *) * value,
                     sizeof(char *) * (value - 1));
     if (!new_val_to_name_types) {
         pr_err("add_type: alloc val_to_name failed\n");

--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -432,7 +432,7 @@ static int do_get_hook_mode(void __user *arg)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
 	strscpy(cmd.mode, type, sizeof(cmd.mode));
 #else
-	strscpy(cmd.mode, type, sizeof(cmd.mode));
+	strlcpy(cmd.mode, type, sizeof(cmd.mode));
 #endif
 
 	if (copy_to_user(arg, &cmd, sizeof(cmd))) {

--- a/kernel/util.c
+++ b/kernel/util.c
@@ -4,6 +4,13 @@
 #include <linux/pgtable.h>
 #endif
 #include <linux/printk.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 7, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#include <linux/sched/task.h>
+#else
+#include <linux/sched.h>
+#endif
+#endif
 #include <asm/current.h>
 
 #include "util.h"


### PR DESCRIPTION
This commit fix some compilation errors in legacy kernels (< 4.14) and GKI2 kernels with manual hooks, fix some errors related to manual hooks, and add more compatibility for legacy / non-gki kernels.
Tested in 4.14, 5.4 and 5.15 kernels with manual hooks.