### PR TITLE
kernel, ksud, manager: Remove enhanced security feature (tiann/KernelSU#3123)

### DIFF
--- a/kernel/feature.h
+++ b/kernel/feature.h
@@ -6,7 +6,6 @@
 enum ksu_feature_id {
 	KSU_FEATURE_SU_COMPAT = 0,
 	KSU_FEATURE_KERNEL_UMOUNT = 1,
-	KSU_FEATURE_ENHANCED_SECURITY = 2,
 
     // custom extensions
     KSU_FEATURE_AVC_SPOOF = 10003,

--- a/kernel/setuid_hook.c
+++ b/kernel/setuid_hook.c
@@ -14,7 +14,6 @@
 
 #include "allowlist.h"
 #include "setuid_hook.h"
-#include "feature.h"
 #include "klog.h" // IWYU pragma: keep
 #include "manager.h"
 #include "selinux/selinux.h"
@@ -22,29 +21,6 @@
 #include "supercalls.h"
 #include "syscall_hook_manager.h"
 #include "kernel_umount.h"
-
-static bool ksu_enhanced_security_enabled = false;
-
-static int enhanced_security_feature_get(u64 *value)
-{
-    *value = ksu_enhanced_security_enabled ? 1 : 0;
-    return 0;
-}
-
-static int enhanced_security_feature_set(u64 value)
-{
-    bool enable = value != 0;
-    ksu_enhanced_security_enabled = enable;
-    pr_info("enhanced_security: set to %d\n", enable);
-    return 0;
-}
-
-static const struct ksu_feature_handler enhanced_security_handler = {
-    .feature_id = KSU_FEATURE_ENHANCED_SECURITY,
-    .name = "enhanced_security",
-    .get_handler = enhanced_security_feature_get,
-    .set_handler = enhanced_security_feature_set,
-};
 
 static void ksu_install_manager_fd_tw_func(struct callback_head *cb)
 {
@@ -59,31 +35,6 @@ int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid)
     uid_t old_uid = current_uid().val;
 
     pr_info("handle_setresuid from %d to %d\n", old_uid, new_uid);
-
-    // if old process is root, ignore it.
-    if (old_uid != 0 && ksu_enhanced_security_enabled) {
-        // disallow any non-ksu domain escalation from non-root to root!
-        // euid is what we care about here as it controls permission
-        if (unlikely(euid == 0)) {
-            if (!is_ksu_domain()) {
-                pr_warn("find suspicious EoP: %d %s, from %d to %d\n",
-                        current->pid, current->comm, old_uid, new_uid);
-                force_sig(SIGKILL);
-                return 0;
-            }
-        }
-        // disallow appuid decrease to any other uid if it is not allowed to su
-        if (is_appuid(old_uid)) {
-            if (euid < current_euid().val &&
-                !ksu_is_allow_uid_for_current(old_uid)) {
-                pr_warn("find suspicious EoP: %d %s, from %d to %d\n",
-                        current->pid, current->comm, old_uid, new_uid);
-                force_sig(SIGKILL);
-                return 0;
-            }
-        }
-        return 0;
-    }
 
     if (likely(ksu_is_manager_appid_valid()) &&
         unlikely(ksu_get_manager_appid() == new_uid % PER_USER_RANGE)) {
@@ -125,14 +76,10 @@ int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid)
 void ksu_setuid_hook_init(void)
 {
     ksu_kernel_umount_init();
-    if (ksu_register_feature_handler(&enhanced_security_handler)) {
-        pr_err("Failed to register enhanced security feature handler\n");
-    }
 }
 
 void ksu_setuid_hook_exit(void)
 {
     pr_info("ksu_core_exit\n");
     ksu_kernel_umount_exit();
-    ksu_unregister_feature_handler(KSU_FEATURE_ENHANCED_SECURITY);
 }

--- a/manager/app/src/main/cpp/jni.cc
+++ b/manager/app/src/main/cpp/jni.cc
@@ -354,18 +354,6 @@ Java_com_rifsxd_ksunext_Natives_setKernelUmountEnabled(JNIEnv *env, jobject thiz
 
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_rifsxd_ksunext_Natives_isEnhancedSecurityEnabled(JNIEnv *env, jobject thiz) {
-    return is_enhanced_security_enabled();
-}
-
-extern "C"
-JNIEXPORT jboolean JNICALL
-Java_com_rifsxd_ksunext_Natives_setEnhancedSecurityEnabled(JNIEnv *env, jobject thiz, jboolean enabled) {
-    return set_enhanced_security_enabled(enabled);
-}
-
-extern "C"
-JNIEXPORT jboolean JNICALL
 Java_com_rifsxd_ksunext_Natives_isAvcSpoofEnabled(JNIEnv *env, jobject thiz) {
     return is_avc_spoof_enabled();
 }

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -239,20 +239,3 @@ const char* get_version_tag(void)
 bool is_zygisk_enabled() {
     return !!getenv("ZYGISK_ENABLED");
 }
-
-
-bool set_enhanced_security_enabled(bool enabled) {
-    return set_feature(KSU_FEATURE_ENHANCED_SECURITY, enabled ? 1 : 0);
-}
-
-bool is_enhanced_security_enabled() {
-    uint64_t value = 0;
-    bool supported = false;
-    if (!get_feature(KSU_FEATURE_ENHANCED_SECURITY, &value, &supported)) {
-        return false;
-    }
-    if (!supported) {
-        return false;
-    }
-    return value != 0;
-}

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -83,7 +83,6 @@ int get_app_profile(app_profile *profile);
 enum ksu_feature_id {
     KSU_FEATURE_SU_COMPAT = 0,
     KSU_FEATURE_KERNEL_UMOUNT = 1,
-    KSU_FEATURE_ENHANCED_SECURITY = 2,
     KSU_FEATURE_AVC_SPOOF = 10003,
 };
 
@@ -175,11 +174,6 @@ struct ksu_get_hook_mode_cmd {
 struct ksu_get_version_tag_cmd {
     char tag[32];
 };
-
-// Enhanced security
-bool set_enhanced_security_enabled(bool enabled);
-
-bool is_enhanced_security_enabled();
 
 // Avc spoof
 bool set_avc_spoof_enabled(bool enabled);

--- a/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
@@ -100,15 +100,6 @@ object Natives {
     external fun setKernelUmountEnabled(enabled: Boolean): Boolean
 
     /**
-     * Enhanced security can be enabled/disabled.
-     *  0: disabled
-     *  1: enabled
-     *  negative : error
-     */
-    external fun isEnhancedSecurityEnabled(): Boolean
-    external fun setEnhancedSecurityEnabled(enabled: Boolean): Boolean
-
-    /**
      * Get the user name for the uid.
      */
     external fun getUserName(uid: Int): String?

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
@@ -121,10 +121,6 @@ fun SettingScreen(navigator: DestinationsNavigator) {
                 value = getFeatureStatus("avc_spoof")
             }
 
-            val enhancedSecurityStatus by produceState(initialValue = "") {
-                value = getFeatureStatus("enhanced_security")
-            }
-
             val suCompatStatus by produceState(initialValue = "") {
                 value = getFeatureStatus("su_compat")
             }
@@ -227,28 +223,6 @@ fun SettingScreen(navigator: DestinationsNavigator) {
                                 val shouldEnable = !checked
                                 if (Natives.setAvcSpoofEnabled(shouldEnable)) {
                                     isAvcSpoofDisabled = !shouldEnable
-                                }
-                            }
-                        }
-
-                        if (enhancedSecurityStatus == "supported") {
-                            var isEnhancedSecurityDisabled by rememberSaveable {
-                                mutableStateOf(!Natives.isEnhancedSecurityEnabled())
-                            }
-
-                            SwitchItem(
-                                icon = Icons.Filled.EnhancedEncryption,
-                                title = stringResource(R.string.settings_disable_enhanced_security),
-                                summary = stringResource(R.string.settings_disable_enhanced_security_summary),
-                                checked = isEnhancedSecurityDisabled,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .clip(RoundedCornerShape(8.dp)),
-                                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                            ) { checked ->
-                                val shouldEnable = !checked
-                                if (Natives.setEnhancedSecurityEnabled(shouldEnable)) {
-                                    isEnhancedSecurityDisabled = !shouldEnable
                                 }
                             }
                         }

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -228,8 +228,6 @@
     <string name="settings_disable_kernel_umount_summary">Temporarily disable kernel-level umount behavior controlled by KernelSU.</string>
     <string name="settings_disable_avc_spoof">Disable avc spoofing</string>
     <string name="settings_disable_avc_spoof_summary">Disable fixing selinux context leak caused by avc denial in audit log.</string>
-    <string name="settings_disable_enhanced_security">Disable enhanced security</string>
-    <string name="settings_disable_enhanced_security_summary">Disable stricter security policies.</string>
     <string name="meta_module">Meta</string>
     <string name="donate">Donate</string>
 </resources>


### PR DESCRIPTION
kernel, ksud, manager: Remove enhanced security feature (https://github.com/tiann/KernelSU/pull/3123)

Author: Wang Han <416810799@qq.com> (aviraxp)
Date:   Wed Dec 31 21:56:49 2025 +0800

This feature does not work with tracepoint hook because setresuid is not even hooked for apps not in allowlist. It was invented when we still use task_fix_setuid LSM hook, but since it is inlined in oplus kernel and we switched to tracepoint hook, we don't have a reliable way to implement this feature without introducing side channels. Remove it and avoid confuse users.