### PR TITLE
selinux: Cache SID lookups for domain checks (https://github.com/tiann/KernelSU/pull/3128)

### DIFF
--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -62,7 +62,6 @@ static struct work_struct stop_vfs_read_work;
 static struct work_struct stop_execve_hook_work;
 static struct work_struct stop_input_hook_work;
 
-u32 ksu_file_sid;
 void on_post_fs_data(void)
 {
 	static bool done = false;
@@ -72,13 +71,11 @@ void on_post_fs_data(void)
 	}
 	done = true;
 	pr_info("on_post_fs_data!\n");
+
 	ksu_load_allow_list();
 	ksu_observer_init();
 	// sanity check, this may influence the performance
 	stop_input_hook();
-
-	ksu_file_sid = ksu_get_ksu_file_sid();
-	pr_info("ksu_file sid: %d\n", ksu_file_sid);
 }
 
 extern void ext4_unregister_sysfs(struct super_block *sb);
@@ -251,6 +248,7 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 			check_argv(*argv, 1, "second_stage", buf, sizeof(buf))) {
 			pr_info("/system/bin/init second_stage executed\n");
 			apply_kernelsu_rules();
+			cache_sid();
 			setup_ksu_cred();
 			init_second_stage_executed = true;
 		}

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -11,12 +11,16 @@
 
 #define KERNEL_SU_CONTEXT "u:r:" KERNEL_SU_DOMAIN ":s0"
 #define KSU_FILE_CONTEXT "u:object_r:" KERNEL_SU_FILE ":s0"
+#define ZYGOTE_CONTEXT "u:r:zygote:s0"
+#define INIT_CONTEXT "u:r:init:s0"
 
 void setup_selinux(const char *);
 
 void setenforce(bool);
 
 bool getenforce();
+
+void cache_sid(void);
 
 bool is_task_ksu_domain(const struct cred *cred);
 
@@ -27,8 +31,6 @@ bool is_zygote(const struct cred *cred);
 bool is_init(const struct cred *cred);
 
 void apply_kernelsu_rules();
-
-u32 ksu_get_ksu_file_sid();
 
 int handle_sepolicy(unsigned long arg3, void __user *arg4);
 


### PR DESCRIPTION
selinux: Cache SID lookups for domain checks (https://github.com/tiann/KernelSU/pull/3128)

Author: 0xSecureByte <chirantan.code@gmail.com>
Date:   Mon Jan 5 14:17:14 2026 +0530

'Cache SELinux SIDs for su/zygote/init contexts at init time instead of
resolving them on every domain check. Reduces overhead from string-based
lookups to simple integer comparisons'.

---------

Signed-off-by: 0xSecureByte <chirantan.code@gmail.com>
Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>