### PR TITLE
Revert "kernel: ksud: migrate init.rc handling to security_file_permission LSM"

### DIFF
--- a/kernel/lsm_hooks.c
+++ b/kernel/lsm_hooks.c
@@ -30,19 +30,6 @@ static int ksu_key_permission(key_ref_t key_ref, const struct cred *cred,
 }
 #endif
 
-extern bool ksu_vfs_read_hook __read_mostly;
-extern int ksu_handle_initrc(struct file **file_ptr);
-
-int ksu_file_permission(struct file *file, int mask)
-{
-	if (!ksu_vfs_read_hook)
-		return 0;
-
-	ksu_handle_initrc(&file);
-
-	return 0;
-}
-
 static int ksu_inode_rename(struct inode *old_inode, struct dentry *old_dentry,
 			    struct inode *new_inode, struct dentry *new_dentry)
 {
@@ -161,8 +148,7 @@ static struct security_hook_list ksu_hooks[] = {
 	LSM_HOOK_INIT(bprm_check_security, ksu_bprm_check),
 	LSM_HOOK_INIT(inode_permission, ksu_inode_permission),
 	LSM_HOOK_INIT(inode_rename, ksu_inode_rename),
-	LSM_HOOK_INIT(task_fix_setuid, ksu_task_fix_setuid),
-	LSM_HOOK_INIT(file_permission, ksu_file_permission)
+	LSM_HOOK_INIT(task_fix_setuid, ksu_task_fix_setuid)
 #endif
 };
 


### PR DESCRIPTION
Revert scope minimized hooks v1.7 and back to v1.6

It's cause no root acces when use standar ksu manual hooks and make kprobes hooks is broken