### PR TITLE
kernel: Fixing symbol names causing x64 kernel compilation failure (https://github.com/tiann/KernelSU/pull/3147)

### DIFF
--- a/kernel/arch.h
+++ b/kernel/arch.h
@@ -24,7 +24,7 @@
 #define SYS_EXECVE_SYMBOL "__arm64_sys_execve"
 // https://cs.android.com/android/kernel/superproject/+/common-android-mainline:common/scripts/syscalltbl.sh;l=57;drc=9142be9e6443fd641ca37f820efe00d9cd890eb1
 // https://cs.android.com/android/kernel/superproject/+/common-android-mainline:common/scripts/syscall.tbl;l=104;drc=b36d4b6aa88ef039647228b98c59a875e92f8c8e
-#define SYS_NEWFSTATAT_SYMBOL "__arm64_sys_newfstat"
+#define SYS_FSTAT_SYMBOL "__arm64_sys_newfstat"
 #else
 #define PRCTL_SYMBOL "sys_prctl"
 #define SYS_READ_SYMBOL "sys_read"
@@ -52,7 +52,7 @@
 #define REBOOT_SYMBOL "__x64_sys_reboot"
 #define SYS_READ_SYMBOL "__x64_sys_read"
 #define SYS_EXECVE_SYMBOL "__x64_sys_execve"
-#define SYS_NEWFSTATAT_SYMBOL "__x64_sys_newfstat"
+#define SYS_FSTAT_SYMBOL "__x64_sys_newfstat"
 #else
 #define PRCTL_SYMBOL "sys_prctl"
 #define SYS_READ_SYMBOL "sys_read"

--- a/kernel/arch.h
+++ b/kernel/arch.h
@@ -24,7 +24,7 @@
 #define SYS_EXECVE_SYMBOL "__arm64_sys_execve"
 // https://cs.android.com/android/kernel/superproject/+/common-android-mainline:common/scripts/syscalltbl.sh;l=57;drc=9142be9e6443fd641ca37f820efe00d9cd890eb1
 // https://cs.android.com/android/kernel/superproject/+/common-android-mainline:common/scripts/syscall.tbl;l=104;drc=b36d4b6aa88ef039647228b98c59a875e92f8c8e
-#define SYS_FSTAT_SYMBOL "__arm64_sys_newfstat"
+#define SYS_NEWFSTATAT_SYMBOL "__arm64_sys_newfstat"
 #else
 #define PRCTL_SYMBOL "sys_prctl"
 #define SYS_READ_SYMBOL "sys_read"

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -583,7 +583,7 @@ static struct kprobe sys_read_kp = {
 };
 
 static struct kretprobe sys_fstat_kp = {
-	.kp.symbol_name = SYS_NEWFSTATAT_SYMBOL,
+	.kp.symbol_name = SYS_FSTAT_SYMBOL,
 	.entry_handler = sys_fstat_handler_pre,
 	.handler = sys_fstat_handler_post,
 	.data_size = sizeof(void *),

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -583,7 +583,7 @@ static struct kprobe sys_read_kp = {
 };
 
 static struct kretprobe sys_fstat_kp = {
-	.kp.symbol_name = SYS_FSTAT_SYMBOL,
+	.kp.symbol_name = SYS_NEWFSTATAT_SYMBOL,
 	.entry_handler = sys_fstat_handler_pre,
 	.handler = sys_fstat_handler_post,
 	.data_size = sizeof(void *),


### PR DESCRIPTION
kernel: Fixing symbol names causing x64 kernel compilation failure (https://github.com/tiann/KernelSU/pull/3147)

Author: u9521 <63995396+u9521@users.noreply.github.com>
Date:   Mon Jan 12 10:50:33 2026 +0800