### PR TITLE
kernel: improve Git repository detection for KernelSU versioning (tiann/KernelSU#3108)

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -27,24 +27,22 @@ ccflags-y += -I$(objtree)/security/selinux -include $(srctree)/include/uapi/asm-
 
 obj-$(CONFIG_KSU) += kernelsu.o
 
-KDIR := $(KDIR)
-MDIR := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+LPATH := /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin
+MDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Check if this is a git repository
-# For in-tree build: check $(srctree)/$(src)/../.git
-# For out-of-tree build: check $(MDIR)/../.git
-ifeq ($(shell test -e $(srctree)/$(src)/../.git && echo "in-tree"),in-tree)
-# In-tree build (git submodule)
-$(shell cd $(srctree)/$(src); /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin [ -f ../.git/shallow ] && git fetch --unshallow)
-KSU_GIT_VERSION := $(shell cd $(srctree)/$(src); /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin git rev-list --count HEAD)
-KSU_GIT_TAG := $(shell cd $(srctree)/$(src); /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin git describe --tags --abbrev=0 2>/dev/null)
+# Try to detect Git repo intelligently
+GIT_ROOT := $(shell cd $(MDIR) && $(LPATH) git rev-parse --show-toplevel 2>/dev/null)
+ifneq ($(GIT_ROOT),)
+KERNEL_GIT_ROOT := $(shell cd $(srctree) && $(LPATH) git rev-parse --show-toplevel 2>/dev/null)
+ifneq ($(GIT_ROOT),$(KERNEL_GIT_ROOT))
+# Only set version if it's a different repo from kernel
+$(shell cd $(GIT_ROOT) && [ -f .git/shallow ] && $(LPATH) git fetch --unshallow 2>/dev/null || true)
+KSU_GIT_VERSION := $(shell cd $(GIT_ROOT) && $(LPATH) git rev-list --count HEAD 2>/dev/null)
+KSU_GIT_TAG := $(shell cd $(GIT_ROOT) && $(LPATH) git describe --tags --abbrev=0 2>/dev/null)
 KSU_GIT_VERSION_VALID := 1
-else ifeq ($(shell test -e $(MDIR)/../.git && echo "out-of-tree"),out-of-tree)
-# Out-of-tree build (standalone repository)
-$(shell cd $(MDIR); /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin [ -f ../.git/shallow ] && git fetch --unshallow)
-KSU_GIT_VERSION := $(shell cd $(MDIR); /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin git rev-list --count HEAD)
-KSU_GIT_TAG := $(shell cd $(MDIR); /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin git describe --tags --abbrev=0 2>/dev/null)
-KSU_GIT_VERSION_VALID := 1
+$(info -- KernelSU-Next Git repo detected at: $(GIT_ROOT))
+endif
 endif
 
 # Calculate version if git version is available


### PR DESCRIPTION
kernel: improve Git repository detection for KernelSU versioning (https://github.com/tiann/KernelSU/pull/3108)

Author: dabao1955 <dabao1955@163.com>
Date:   Wed Jan 14 14:49:20 2026 +0800

The previous logic for detecting the Git repository in KernelSU's Kbuild assumed two distinct build scenarios—in-tree (as a submodule) and out-of-tree (standalone)—and used hardcoded path checks (e.g., `$(srctree)/$(src)/../.git` or `$(MDIR)/../.git`) to differentiate them. This approach is fragile, sensitive to directory layout changes, and fails in more complex repository structures (e.g., subtrees, nested worktrees, or non-standard submodules).

This commit replaces the ad-hoc path inspection with `git rev-parse --show-toplevel`, which reliably determines the root of the containing Git repository from any subdirectory. This eliminates the need to distinguish between in-tree and out-of-tree builds and unifies the version detection logic into a single, robust code path.

Additionally:
- Removes the use of `realpath`, improving compatibility with older or minimal build environments where `realpath` may be unavailable.
- Retains shallow-clone handling by unshallowing the repository before counting commits, ensuring accurate version numbers.
- Adds an informative build message (`$(info ...)`) to indicate when a Git repository is successfully detected, aiding debuggability.

This change makes Kbuild more portable, maintainable, and resilient across diverse development and integration workflows.

Co-authored-by: pershoot <190600+pershoot@users.noreply.github.com>
Signed-off-by: dabao1955 <dabao1955@163.com>

-Adapt:
 -Bazel: explicit PATH (custom; LPATH) for 3rd party (git) invocations
 -KSUN tag
 -info