### PR TITLE
kernel: Fix potential memory leaks (https://github.com/tiann/KernelSU/pull/3170)

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -422,7 +422,10 @@ void persistent_allow_list()
 		goto put_task;
 	}
 	cb->func = do_persistent_allow_list;
-	task_work_add(tsk, cb, TWA_RESUME);
+	if (task_work_add(tsk, cb, TWA_RESUME)) {
+		kfree(cb);
+		pr_warn("save_allow_list add task_work failed\n");
+	}
 
 put_task:
 	put_task_struct(tsk);

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -291,12 +291,14 @@ void track_throne(bool prune_only)
 		char *package = strsep(&tmp, delim);
 		char *uid = strsep(&tmp, delim);
 		if (!uid || !package) {
+			kfree(data);
 			pr_err("update_uid: package or uid is NULL!\n");
 			break;
 		}
 
 		u32 res;
 		if (kstrtou32(uid, 10, &res)) {
+			kfree(data);
 			pr_err("update_uid: uid parse err\n");
 			break;
 		}


### PR DESCRIPTION
kernel: Fix potential memory leaks (https://github.com/tiann/KernelSU/pull/3170)

Author: fatalcoder524 <11532648+fatalcoder524@users.noreply.github.com>
Date:   Wed Jan 21 07:52:57 2026 +0530

- Callback cb not freed if task_work_add fails in Save allowlist Operation.
- uid_data not freed if uid/package or uid parse test fails.