### PR TITLE
kernel: abort manual hook compilation if not found ksu_handle_sys_reboot

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -93,21 +93,21 @@ HAVE_KSU_HOOK ?= 1
 
 # Checks hooks state
 ifeq ($(CONFIG_KSU_KPROBES_HOOK), y)
-$(info -- KernelSU: Hook mode: Kprobes)
+$(info -- KernelSU-Next: Hook mode: Kprobes)
 ccflags-y += -DKSU_KPROBES_HOOK
 # Let's make it 0, so it would pass.
 HAVE_KSU_HOOK := 0
 endif
 
 ifeq ($(CONFIG_KSU_MANUAL_HOOK), y)
-HAVE_KSU_HOOK := $(shell grep -q "ksu_handle_faccessat" $(srctree)/fs/open.c && echo 0 || echo 1)
+HAVE_KSU_HOOK := $(shell grep -q "ksu_handle_sys_reboot" $(srctree)/kernel/reboot.c && echo 0 || echo 1)
 ifeq ($(HAVE_KSU_HOOK),0)
-$(info -- KernelSU: Hook mode: Manual)
+$(info -- KernelSU-Next: Hook mode: Manual)
 endif
 endif
 
 ifneq ($(HAVE_KSU_HOOK),0)
-$(error -- KernelSU: No hooks were defined, please integrate manual hooks in your kernel!)
+$(error -- KernelSU-Next: No hooks were defined, please integrate manual hooks in your kernel!)
 endif
 
 # some backports


### PR DESCRIPTION
Many problems related to manual hooks stem from missing sys_reboot hook, so compilation will abort if that hook is not found.