### PR TITLE
feat: safe LKM temporary unload support 添加临时卸载支持

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -1,5 +1,6 @@
 #include <linux/rcupdate.h>
 #include <linux/limits.h>
+#include <linux/module.h>
 #include <linux/rculist.h>
 #include <linux/mutex.h>
 #include <linux/task_work.h>
@@ -422,6 +423,7 @@ close_file:
     filp_close(fp, 0);
 out:
     kfree(_cb);
+    module_put(THIS_MODULE); /* Release module ref taken before task_work_add */
 }
 
 void ksu_persistent_allow_list()
@@ -440,8 +442,14 @@ void ksu_persistent_allow_list()
 		pr_err("save_allow_list alloc cb err\b");
 		goto put_task;
 	}
+	/* Pin module so callback code isn't freed before it runs */
+	if (!try_module_get(THIS_MODULE)) {
+		kfree(cb);
+		goto put_task;
+	}
 	cb->func = do_persistent_allow_list;
 	if (task_work_add(tsk, cb, TWA_RESUME)) {
+		module_put(THIS_MODULE);
 		kfree(cb);
 		pr_warn("save_allow_list add task_work failed\n");
 	}

--- a/kernel/app_profile.h
+++ b/kernel/app_profile.h
@@ -65,4 +65,6 @@ void escape_with_root_profile(void);
 
 void escape_to_root_for_init(void);
 
+void ksu_app_profile_init(void);
+
 #endif

--- a/kernel/kernel_umount.c
+++ b/kernel/kernel_umount.c
@@ -1,4 +1,5 @@
 #include <linux/sched.h>
+#include <linux/module.h>
 #include <linux/slab.h>
 #include <linux/task_work.h>
 #include <linux/cred.h>
@@ -9,6 +10,7 @@
 #include <linux/path.h>
 #include <linux/printk.h>
 #include <linux/types.h>
+
 
 #include "kernel_umount.h"
 #include "klog.h" // IWYU pragma: keep
@@ -89,6 +91,7 @@ static void umount_tw_func(struct callback_head *cb)
 	revert_creds(saved);
 
 	kfree(tw);
+	module_put(THIS_MODULE); /* Release module ref taken before task_work_add */
 }
 
 int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
@@ -138,15 +141,59 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
 	if (!tw)
 		return 0;
 
+	/* Pin module so umount callback code isn't freed before it runs */
+	if (!try_module_get(THIS_MODULE)) {
+		kfree(tw);
+		return 0;
+	}
+
 	tw->cb.func = umount_tw_func;
 
 	int err = task_work_add(current, &tw->cb, TWA_RESUME);
 	if (err) {
+		module_put(THIS_MODULE);
 		kfree(tw);
 		pr_warn("unmount add task_work failed\n");
 	}
 
 	return 0;
+}
+
+
+
+void ksu_umount_all(void)
+{
+	struct mount_entry *entry;
+	const struct cred *saved;
+
+	if (!ksu_module_mounted) {
+		pr_info("ksu_umount_all: no modules mounted, skip\n");
+		return;
+	}
+
+	if (!ksu_cred) {
+		pr_warn("ksu_umount_all: no ksu_cred, cannot umount\n");
+		return;
+	}
+
+	saved = override_creds(ksu_cred);
+
+	/* Step 1: unmount paths from the registered mount list */
+	down_read(&mount_list_lock);
+	list_for_each_entry(entry, &mount_list, list) {
+		pr_info("ksu_umount_all: list: %s flags 0x%x\n",
+			entry->umountable, entry->flags);
+		try_umount(entry->umountable, entry->flags);
+	}
+	up_read(&mount_list_lock);
+
+	/* Third-party module mounts (Zygisk, LSPosed, MoveCertificate, etc.)
+	 * are handled by the Manager App's user-space cleanup script. */
+
+	revert_creds(saved);
+
+	ksu_module_mounted = false;
+	pr_info("ksu_umount_all: done\n");
 }
 
 void ksu_kernel_umount_init(void)

--- a/kernel/kernel_umount.h
+++ b/kernel/kernel_umount.h
@@ -11,6 +11,9 @@ void ksu_kernel_umount_exit(void);
 // Handler function to be called from setresuid hook
 int ksu_handle_umount(uid_t old_uid, uid_t new_uid);
 
+// Unmount all module mounts globally (called during module exit)
+void ksu_umount_all(void);
+
 // for the umount list
 struct mount_entry {
     char *umountable;

--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -2,9 +2,14 @@
 #include <linux/fs.h>
 #include <linux/kobject.h>
 #include <linux/module.h>
+#include <linux/rcupdate.h>
+#include <linux/version.h>
 #include <linux/workqueue.h>
+#include <linux/sched.h>
+#include <linux/sched/signal.h>
 
 #include "allowlist.h"
+#include "app_profile.h"
 #include "feature.h"
 #include "klog.h" // IWYU pragma: keep
 #include "throne_tracker.h"
@@ -13,6 +18,8 @@
 #include "supercalls.h"
 #include "ksu.h"
 #include "file_wrapper.h"
+#include "kernel_umount.h"
+#include "selinux/selinux.h"
 
 struct cred *ksu_cred;
 
@@ -32,6 +39,8 @@ int __init kernelsu_init(void)
     if (!ksu_cred) {
         pr_err("prepare cred failed!\n");
     }
+
+	ksu_app_profile_init();
 
 	ksu_feature_init();
 
@@ -56,8 +65,75 @@ int __init kernelsu_init(void)
 }
 
 extern void ksu_observer_exit(void);
+
+/*
+ * Kill all zygote/usap processes so init restarts them from a clean kernel.
+ *
+ * Called after ksu_syscall_hook_manager_exit() so all hooks are removed —
+ * init cannot re-inject hooks into the restarted zygote.
+ *
+ * We identify zygote by THREE conditions (to avoid false positives like
+ * Qualcomm's qcrilNrd which also has PPID=1 and comm="main"):
+ *   1. PPID == 1 (direct child of init)
+ *   2. comm == "main" (JVM sets the main thread name)
+ *   3. exe == app_process or app_process64
+ */
+static void ksu_kill_zygote(void)
+{
+	struct task_struct *p;
+
+	rcu_read_lock();
+	for_each_process(p) {
+
+		if (p->pid <= 1)
+			continue;
+		if (!p->real_parent || p->real_parent->pid != 1)
+			continue;
+		if (strcmp(p->comm, "main"))
+			continue;
+
+		/* Verify executable is app_process/app_process64.
+		 * Access mm->exe_file directly under rcu_read_lock. */
+		if (p->mm && p->mm->exe_file) {
+			const char *name = p->mm->exe_file->f_path.dentry->d_name.name;
+			if (!strcmp(name, "app_process64") ||
+			    !strcmp(name, "app_process")) {
+				pr_info("kernelsu: killing zygote pid %d for clean restart\n",
+					p->pid);
+				send_sig(SIGKILL, p, 1);
+			}
+		}
+	}
+	rcu_read_unlock();
+}
+
 void kernelsu_exit(void)
 {
+	/* === Root trace cleanup: must happen before subsystem teardown === */
+
+	/* Unmount all module overlays (needs ksu_cred, must be first) */
+	ksu_umount_all();
+
+
+
+	/* Revert SELinux policy: set su/ksu_file domains to enforcing,
+	 * clear all avtab allow rules for these domains */
+	revert_kernelsu_rules();
+
+	/* === Normal subsystem teardown === */
+
+	/* Flush delayed fput work so __fput callbacks run while our code lives */
+	flush_workqueue(system_wq);
+
+	/* Restore kobject deleted in init to avoid NULL sd in sysfs teardown */
+#ifdef MODULE
+#ifndef CONFIG_KSU_DEBUG
+	if (kobject_add(&THIS_MODULE->mkobj.kobj, NULL,
+			"%s", THIS_MODULE->name))
+		pr_err("kernelsu: failed to restore module kobject\n");
+#endif
+#endif
+
 	ksu_allowlist_exit();
 
 	ksu_throne_tracker_exit();
@@ -72,9 +148,15 @@ void kernelsu_exit(void)
 
 	ksu_feature_exit();
 
-	if (ksu_cred) {
-		put_cred(ksu_cred);
-	}
+	/* Leak ksu_cred: revert_creds may put it after our rcu_barrier */
+	ksu_cred = NULL;
+
+	rcu_barrier();
+	flush_workqueue(system_wq);
+
+	/* Kill zygote/usap after all hooks are removed and work is flushed.
+	 * Syscall hooks are gone so init cannot re-inject the new zygote. */
+	ksu_kill_zygote();
 }
 
 module_init(kernelsu_init);

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -17,6 +17,8 @@
 #include <linux/namei.h>
 #include <linux/workqueue.h>
 #include <linux/uio.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
 
 #include "manager.h"
 #include "allowlist.h"
@@ -61,6 +63,14 @@ static void stop_input_hook();
 static struct work_struct stop_init_rc_hook_work;
 static struct work_struct stop_execve_hook_work;
 static struct work_struct stop_input_hook_work;
+
+/* Mutex-guarded kprobe registration state to prevent double-unregister
+ * between async work items and module exit */
+static DEFINE_MUTEX(kp_lock);
+static bool execve_kp_registered;
+static bool sys_read_kp_registered;
+static bool sys_fstat_kp_registered;
+static bool input_event_kp_registered;
 
 void on_post_fs_data(void)
 {
@@ -187,10 +197,9 @@ static int __maybe_unused count(struct user_arg_ptr argv, int max)
 static void on_post_fs_data_cbfun(struct callback_head *cb)
 {
 	on_post_fs_data();
+	kfree(cb); /* Dynamically allocated to avoid reuse of static callback */
+	module_put(THIS_MODULE); /* Release module ref taken before task_work_add */
 }
-
-static struct callback_head on_post_fs_data_cb = { .func =
-							on_post_fs_data_cbfun };
 
 static bool check_argv(struct user_arg_ptr argv, int index,
 			const char *expected, char *buf, size_t buf_len)
@@ -265,8 +274,21 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 			rcu_read_lock();
 			struct task_struct *init_task =
 				rcu_dereference(current->real_parent);
-			if (init_task)
-				task_work_add(init_task, &on_post_fs_data_cb, TWA_RESUME);
+			if (init_task) {
+				/* Dynamically allocate cb + pin module for safe unload */
+				struct callback_head *cb =
+					kzalloc(sizeof(*cb), GFP_ATOMIC);
+				if (cb && try_module_get(THIS_MODULE)) {
+					cb->func = on_post_fs_data_cbfun;
+					if (task_work_add(init_task, cb,
+							  TWA_RESUME)) {
+						module_put(THIS_MODULE);
+						kfree(cb);
+					}
+				} else {
+					kfree(cb);
+				}
+			}
 			rcu_read_unlock();
 			first_zygote = false;
 			stop_execve_hook();
@@ -279,6 +301,8 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 static ssize_t (*orig_read)(struct file *, char __user *, size_t, loff_t *);
 static ssize_t (*orig_read_iter)(struct kiocb *, struct iov_iter *);
 static struct file_operations fops_proxy;
+static const struct file_operations *orig_rc_fops;  /* Saved original fops for restoration on exit */
+static struct file *hooked_rc_file;                  /* Ref to hooked init.rc file */
 static ssize_t ksu_rc_pos = 0;
 const size_t ksu_rc_len = sizeof(KERNEL_SU_RC) - 1;
 
@@ -421,7 +445,9 @@ static void ksu_handle_sys_read(unsigned int fd)
 	if (orig_read_iter) {
 		fops_proxy.read_iter = read_iter_proxy;
 	}
-	// replace the file_operations
+	// replace the file_operations, saving original for restoration on exit
+	orig_rc_fops = file->f_op;
+	hooked_rc_file = get_file(file); /* Hold ref so file isn't freed */
 	file->f_op = &fops_proxy;
 
 skip:
@@ -596,18 +622,36 @@ static struct kprobe input_event_kp = {
 
 static void do_stop_init_rc_hook(struct work_struct *work)
 {
-	unregister_kprobe(&sys_read_kp);
-	unregister_kretprobe(&sys_fstat_kp);
+	mutex_lock(&kp_lock);
+	if (sys_read_kp_registered) {
+		unregister_kprobe(&sys_read_kp);
+		sys_read_kp_registered = false;
+	}
+	if (sys_fstat_kp_registered) {
+		unregister_kretprobe(&sys_fstat_kp);
+		sys_fstat_kp_registered = false;
+	}
+	mutex_unlock(&kp_lock);
 }
 
 static void do_stop_execve_hook(struct work_struct *work)
 {
-	unregister_kprobe(&execve_kp);
+	mutex_lock(&kp_lock);
+	if (execve_kp_registered) {
+		unregister_kprobe(&execve_kp);
+		execve_kp_registered = false;
+	}
+	mutex_unlock(&kp_lock);
 }
 
 static void do_stop_input_hook(struct work_struct *work)
 {
-	unregister_kprobe(&input_event_kp);
+	mutex_lock(&kp_lock);
+	if (input_event_kp_registered) {
+		unregister_kprobe(&input_event_kp);
+		input_event_kp_registered = false;
+	}
+	mutex_unlock(&kp_lock);
 }
 
 static void stop_init_rc_hook()
@@ -640,15 +684,23 @@ void ksu_ksud_init()
 
 	ret = register_kprobe(&execve_kp);
 	pr_info("ksud: execve_kp: %d\n", ret);
+	if (!ret)
+		execve_kp_registered = true;
 
 	ret = register_kprobe(&sys_read_kp);
 	pr_info("ksud: sys_read_kp: %d\n", ret);
+	if (!ret)
+		sys_read_kp_registered = true;
 
 	ret = register_kretprobe(&sys_fstat_kp);
 	pr_info("ksud: sys_fstat_kp: %d\n", ret);
+	if (!ret)
+		sys_fstat_kp_registered = true;
 
 	ret = register_kprobe(&input_event_kp);
 	pr_info("ksud: input_event_kp: %d\n", ret);
+	if (!ret)
+		input_event_kp_registered = true;
 
 	INIT_WORK(&stop_init_rc_hook_work, do_stop_init_rc_hook);
 	INIT_WORK(&stop_execve_hook_work, do_stop_execve_hook);
@@ -657,8 +709,35 @@ void ksu_ksud_init()
 
 void ksu_ksud_exit()
 {
-	unregister_kprobe(&execve_kp);
-	// this should be done before unregister sys_read_kp
-	// unregister_kprobe(&sys_read_kp);
-	unregister_kprobe(&input_event_kp);
+	/* Restore init.rc's original fops before module memory is freed */
+	if (hooked_rc_file) {
+		hooked_rc_file->f_op = orig_rc_fops;
+		fput(hooked_rc_file);
+		hooked_rc_file = NULL;
+	}
+
+	/* Flush pending work items first so they don't race with us */
+	flush_work(&stop_init_rc_hook_work);
+	flush_work(&stop_execve_hook_work);
+	flush_work(&stop_input_hook_work);
+
+	/* Now unregister anything that the work items didn't get to */
+	mutex_lock(&kp_lock);
+	if (execve_kp_registered) {
+		unregister_kprobe(&execve_kp);
+		execve_kp_registered = false;
+	}
+	if (sys_read_kp_registered) {
+		unregister_kprobe(&sys_read_kp);
+		sys_read_kp_registered = false;
+	}
+	if (sys_fstat_kp_registered) {
+		unregister_kretprobe(&sys_fstat_kp);
+		sys_fstat_kp_registered = false;
+	}
+	if (input_event_kp_registered) {
+		unregister_kprobe(&input_event_kp);
+		input_event_kp_registered = false;
+	}
+	mutex_unlock(&kp_lock);
 }

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -97,6 +97,103 @@ void apply_kernelsu_rules()
     mutex_unlock(&ksu_rules);
 }
 
+static void reset_avc_cache();
+
+void revert_kernelsu_rules()
+{
+	struct policydb *db;
+
+	mutex_lock(&ksu_rules);
+
+	db = get_policydb();
+
+	/*
+	 * We cannot safely remove the "su" type from policydb because
+	 * type_val_to_struct is indexed by type value; removing an entry
+	 * would corrupt all higher-valued types. Instead, we:
+	 * 1. Set su domain back to enforcing
+	 * 2. Clear all allow rules where su is the source type
+	 * 3. Clear the permissive bit for su
+	 * This effectively makes su a dead domain with zero permissions.
+	 */
+
+	/* 1. Make su enforcing (remove from permissive_map) */
+	ksu_enforce(db, KERNEL_SU_DOMAIN);
+
+	/* 2. Clear all avtab entries where su is the source */
+	struct type_datum *su_type = symtab_search(&db->p_types, KERNEL_SU_DOMAIN);
+	if (su_type) {
+		u32 su_val = su_type->value;
+		struct avtab_node *cur;
+		struct avtab_node *prev;
+		int i;
+
+		for (i = 0; i < db->te_avtab.nslot; i++) {
+			prev = NULL;
+			cur = db->te_avtab.htable[i];
+			while (cur) {
+				if (cur->key.source_type == su_val) {
+					/* Zero the permission data instead of unlinking
+					 * (safer: avoids corrupting the hashtable chain) */
+					if (cur->key.specified & AVTAB_XPERMS) {
+						if (cur->datum.u.xperms)
+							memset(cur->datum.u.xperms->perms.p, 0,
+							       sizeof(cur->datum.u.xperms->perms.p));
+					} else {
+						cur->datum.u.data = 0U;
+					}
+				}
+				cur = cur->next;
+			}
+		}
+	}
+
+	/* 3. Also clear allow rules where su is the target (other domains -> su) */
+	if (su_type) {
+		u32 su_val = su_type->value;
+		struct avtab_node *cur;
+		int i;
+
+		for (i = 0; i < db->te_avtab.nslot; i++) {
+			cur = db->te_avtab.htable[i];
+			while (cur) {
+				if (cur->key.target_type == su_val &&
+				    (cur->key.specified & AVTAB_ALLOWED)) {
+					cur->datum.u.data = 0U;
+				}
+				cur = cur->next;
+			}
+		}
+	}
+
+	/* 4. Also handle ksu_file type */
+	struct type_datum *ksu_file_type = symtab_search(&db->p_types, KERNEL_SU_FILE);
+	if (ksu_file_type) {
+		u32 kf_val = ksu_file_type->value;
+		struct avtab_node *cur;
+		int i;
+
+		for (i = 0; i < db->te_avtab.nslot; i++) {
+			cur = db->te_avtab.htable[i];
+			while (cur) {
+				if ((cur->key.source_type == kf_val ||
+				     cur->key.target_type == kf_val) &&
+				    (cur->key.specified & AVTAB_ALLOWED)) {
+					cur->datum.u.data = 0U;
+				}
+				cur = cur->next;
+			}
+		}
+	}
+
+	mutex_unlock(&ksu_rules);
+
+	/* Reset AVC cache so cleared rules take effect immediately */
+	reset_avc_cache();
+
+	pr_info("KernelSU: SELinux rules reverted\n");
+}
+
 #define MAX_SEPOL_LEN 128
 
 #define CMD_NORMAL_PERM 1

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -32,6 +32,8 @@ bool is_init(const struct cred *cred);
 
 void apply_kernelsu_rules();
 
+void revert_kernelsu_rules();
+
 int handle_sepolicy(unsigned long arg3, void __user *arg4);
 
 void setup_ksu_cred();

--- a/kernel/su_mount_ns.c
+++ b/kernel/su_mount_ns.c
@@ -5,6 +5,7 @@
 #include <linux/fs.h>
 #include <linux/fs_struct.h>
 #include <linux/limits.h>
+#include <linux/module.h>
 #include <linux/namei.h>
 #include <linux/proc_ns.h>
 #include <linux/pid.h>
@@ -173,6 +174,7 @@ static void ksu_setup_mount_ns_tw_func(struct callback_head *cb)
     }
     revert_creds(old_cred);
     kfree(tw);
+    module_put(THIS_MODULE); /* Release module ref taken before task_work_add */
 }
 
 void setup_mount_ns(int32_t ns_mode)
@@ -199,9 +201,15 @@ void setup_mount_ns(int32_t ns_mode)
         pr_err("no mem for tw! skip mnt_ns magic for pid: %d.\n", current->pid);
         return;
     }
+    /* Pin module so mount-ns callback code isn't freed before it runs */
+    if (!try_module_get(THIS_MODULE)) {
+        kfree(tw);
+        return;
+    }
     tw->cb.func = ksu_setup_mount_ns_tw_func;
     tw->ns_mode = ns_mode;
     if (task_work_add(current, &tw->cb, TWA_RESUME)) {
+        module_put(THIS_MODULE);
         kfree(tw);
         pr_err("add task work failed! skip mnt_ns magic for pid: %d.\n",
                current->pid);

--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -8,6 +8,8 @@
 #include <linux/slab.h>
 #include <linux/kprobes.h>
 #include <linux/syscalls.h>
+#include <linux/module.h>
+#include <linux/sched/signal.h>
 #include <linux/task_work.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
@@ -513,6 +515,54 @@ static int do_get_version_tag(void __user *arg)
 	return 0;
 }
 
+/*
+ * Prepare for module unload by killing all processes that hold KSU file
+ * descriptors (ksu_driver + fdwrapper).  Both have f_op->owner == THIS_MODULE.
+ * This is necessary because fdwrapper fds are invisible to userspace (d_dname
+ * spoofs the path), so only the kernel can find them.
+ * Skips the calling process (manager) so it can proceed with rmmod.
+ */
+static int do_prepare_unload(void __user *arg)
+{
+	struct task_struct *task;
+
+	rcu_read_lock();
+	for_each_process(task) {
+		struct files_struct *files;
+		struct fdtable *fdt;
+		unsigned int fd;
+		bool found = false;
+
+		if (task->tgid == current->tgid)
+			continue;
+
+		task_lock(task);
+		files = task->files;
+		if (!files) {
+			task_unlock(task);
+			continue;
+		}
+
+		spin_lock(&files->file_lock);
+		fdt = files_fdtable(files);
+		for (fd = 0; fd < fdt->max_fds; fd++) {
+			struct file *file = fdt->fd[fd];
+			if (file && file->f_op &&
+			    file->f_op->owner == THIS_MODULE) {
+				found = true;
+				break;
+			}
+		}
+		spin_unlock(&files->file_lock);
+		task_unlock(task);
+
+		if (found)
+			send_sig(SIGKILL, task, 1);
+	}
+	rcu_read_unlock();
+	return 0;
+}
+
 static int do_nuke_ext4_sysfs(void __user *arg)
 {
     struct ksu_nuke_ext4_sysfs_cmd cmd;
@@ -794,6 +844,10 @@ static const struct ksu_ioctl_cmd_map ksu_ioctl_handlers[] = {
 	  .name = "GET_VERSION_TAG",
 	  .handler = do_get_version_tag,
 	  .perm_check = manager_or_root },
+	{ .cmd = KSU_IOCTL_PREPARE_UNLOAD,
+	  .name = "PREPARE_UNLOAD",
+	  .handler = do_prepare_unload,
+	  .perm_check = only_manager },
     { .cmd = 0, .name = NULL, .handler = NULL, .perm_check = NULL } // Sentinel
 };
 
@@ -819,6 +873,7 @@ static void ksu_install_fd_tw_func(struct callback_head *cb)
 	}
 
 	kfree(tw);
+	module_put(THIS_MODULE); /* Release module ref taken before task_work_add */
 }
 
 static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
@@ -838,10 +893,17 @@ static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
 		if (!tw)
 			return 0;
 
+		/* Pin module so install-fd callback code isn't freed before it runs */
+		if (!try_module_get(THIS_MODULE)) {
+			kfree(tw);
+			return 0;
+		}
+
 		tw->outp = (int __user *)arg4;
 		tw->cb.func = ksu_install_fd_tw_func;
 
 		if (task_work_add(current, &tw->cb, TWA_RESUME)) {
+			module_put(THIS_MODULE);
 			kfree(tw);
 			pr_warn("install fd add task_work failed\n");
 		}
@@ -990,7 +1052,18 @@ void ksu_supercalls_init(void)
 
 void ksu_supercalls_exit(void)
 {
+    struct mount_entry *entry, *tmp;
+
     unregister_kprobe(&reboot_kp);
+
+    /* Free mount_list entries */
+    down_write(&mount_list_lock);
+    list_for_each_entry_safe(entry, tmp, &mount_list, list) {
+        list_del(&entry->list);
+        kfree(entry->umountable);
+        kfree(entry);
+    }
+    up_write(&mount_list_lock);
 }
 
 // IOCTL dispatcher

--- a/kernel/supercalls.h
+++ b/kernel/supercalls.h
@@ -153,6 +153,7 @@ struct ksu_add_try_umount_cmd {
 #define KSU_IOCTL_ADD_TRY_UMOUNT _IOC(_IOC_WRITE, 'K', 18, 0)
 #define KSU_IOCTL_GET_HOOK_MODE _IOC(_IOC_READ, 'K', 98, 0)
 #define KSU_IOCTL_GET_VERSION_TAG _IOC(_IOC_READ, 'K', 99, 0)
+#define KSU_IOCTL_PREPARE_UNLOAD _IOC(_IOC_NONE, 'K', 100, 0) /* Kill all KSU fd holders for rmmod */
 
 // IOCTL handler types
 typedef int (*ksu_ioctl_handler_t)(void __user *arg);

--- a/kernel/syscall_hook_manager.c
+++ b/kernel/syscall_hook_manager.c
@@ -366,6 +366,7 @@ void ksu_syscall_hook_manager_exit(void)
 {
     pr_info("hook_manager: ksu_hook_manager_exit called\n");
 #ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
+    ksu_unmark_all_process(); /* Clear marks before unregister to avoid stale refs */
     unregister_trace_sys_enter(ksu_sys_enter_handler, NULL);
     tracepoint_synchronize_unregister();
     pr_info("hook_manager: sys_enter tracepoint unregistered\n");

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -355,5 +355,11 @@ void ksu_throne_tracker_init()
 
 void ksu_throne_tracker_exit()
 {
-	// nothing to do
+	/* Free cached APK path hash entries */
+	struct apk_path_hash *pos, *n;
+
+	list_for_each_entry_safe(pos, n, &apk_path_hash_list, list) {
+		list_del(&pos->list);
+		kfree(pos);
+	}
 }

--- a/manager/app/src/main/cpp/jni.cc
+++ b/manager/app/src/main/cpp/jni.cc
@@ -374,6 +374,20 @@ Java_com_rifsxd_ksunext_Natives_setAvcSpoofEnabled(JNIEnv *env, jobject thiz, jb
     return set_avc_spoof_enabled(enabled);
 }
 
+/* JNI bridge for module unload preparation */
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_rifsxd_ksunext_Natives_prepareUnload(JNIEnv *env, jobject thiz) {
+    return prepare_unload();
+}
+
+/* JNI bridge for closing the cached KSU driver fd */
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_rifsxd_ksunext_Natives_closeDriverFd(JNIEnv *env, jobject thiz) {
+    close_driver_fd();
+}
+
 extern "C"
 JNIEXPORT jstring JNICALL
 Java_com_rifsxd_ksunext_Natives_getUserName(JNIEnv *env, jobject thiz, jint uid) {

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -239,3 +239,16 @@ const char* get_version_tag(void)
 bool is_zygisk_enabled() {
     return !!getenv("ZYGISK_ENABLED");
 }
+
+/* Ask kernel to SIGKILL all processes holding KSU fds, preparing for rmmod */
+bool prepare_unload() {
+    return ksuctl(KSU_IOCTL_PREPARE_UNLOAD) == 0;
+}
+
+/* Close the cached driver fd so module refcount drops to allow rmmod */
+void close_driver_fd() {
+    if (fd >= 0) {
+        close(fd);
+        fd = -1;
+    }
+}

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -187,6 +187,12 @@ bool set_avc_spoof_enabled(bool enabled);
 
 bool is_avc_spoof_enabled();
 
+// Kill all processes holding KSU fds to prepare for rmmod
+bool prepare_unload();
+
+// Close the cached KSU driver fd
+void close_driver_fd();
+
 // IOCTL command definitions
 #define KSU_IOCTL_GRANT_ROOT _IOC(_IOC_NONE, 'K', 1, 0)
 #define KSU_IOCTL_GET_INFO _IOC(_IOC_READ, 'K', 2, 0)
@@ -204,6 +210,7 @@ bool is_avc_spoof_enabled();
 #define KSU_IOCTL_SET_FEATURE _IOC(_IOC_WRITE, 'K', 14, 0)
 #define KSU_IOCTL_GET_HOOK_MODE _IOC(_IOC_READ, 'K', 98, 0)
 #define KSU_IOCTL_GET_VERSION_TAG _IOC(_IOC_READ, 'K', 99, 0)
+#define KSU_IOCTL_PREPARE_UNLOAD _IOC(_IOC_NONE, 'K', 100, 0)
 
 bool get_allow_list(struct ksu_new_get_allow_list_cmd *);
 

--- a/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
@@ -115,6 +115,16 @@ object Natives {
     external fun isAvcSpoofEnabled(): Boolean
     external fun setAvcSpoofEnabled(enabled: Boolean): Boolean
 
+    /**
+     * Kill all processes holding KSU fds (ksu_driver + fdwrapper) to prepare for rmmod.
+     */
+    external fun prepareUnload(): Boolean
+
+    /**
+     * Close the cached KSU driver fd so the module refcount drops to allow rmmod.
+     */
+    external fun closeDriverFd()
+
     external fun getSuperuserCount(): Int
 
     private const val NON_ROOT_DEFAULT_PROFILE_KEY = "$"

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
@@ -579,19 +579,72 @@ fun UninstallItem(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val uninstallConfirmDialog = rememberConfirmDialog()
-    val showTodo = {
-        Toast.makeText(context, "TODO", Toast.LENGTH_SHORT).show()
-    }
     val uninstallDialog = rememberUninstallDialog { uninstallType ->
         scope.launch {
             val result = uninstallConfirmDialog.awaitConfirm(
                 title = context.getString(uninstallType.title),
-                content = context.getString(uninstallType.message)
+                content = if (uninstallType == UninstallType.TEMPORARY) {
+                    context.getString(uninstallType.message) + "\n\n" + context.getString(R.string.settings_uninstall_temporary_ui_warning)
+                } else {
+                    context.getString(uninstallType.message)
+                }
             )
             if (result == ConfirmResult.Confirmed) {
                 withLoading {
                     when (uninstallType) {
-                        UninstallType.TEMPORARY -> showTodo()
+                        UninstallType.TEMPORARY -> {
+                            withContext(Dispatchers.IO) {
+                                // Kill all processes holding KSU fds (adb su, zygiskd, etc.)
+                                Natives.prepareUnload()
+                                // Close manager's own driver fd to release module refcount
+                                Natives.closeDriverFd()
+                                withNewRootShell(globalMnt = true) {
+                                    newJob().add(
+                                        """
+                                        # Unmount KSU module overlays and Zygisk manual mounts (using mountinfo to catch bind mounts)
+                                        cat /proc/1/mountinfo | grep -E '(/data/adb|/adb/|KSU|KSUNext)' | awk '{print ${'$'}5}' | grep -E '^/(system|vendor|product|system_ext|bionic|apex|data/adb|adb)' | sort -r | while IFS= read -r mnt; do
+                                            umount -l "${'$'}mnt" 2>/dev/null
+                                        done
+                                        # Failsafe for Zygisk Next manual mounts (which may use anonymous tmpfs)
+                                        umount -l /system/bin/app_process32 2>/dev/null
+                                        umount -l /system/bin/app_process64 2>/dev/null
+                                        killall -9 zygiskd 2>/dev/null
+                                        
+                                        # Failsafe for Certificate Modules (e.g. MoveCertificate)
+                                        # These mount anonymous tmpfs over APEX cert dirs.
+                                        # We only unmount if fs type is tmpfs (native APEX uses erofs/ext4).
+                                        # mountinfo has variable optional-tag fields, so we split on ' - ' to find fs type reliably.
+                                        cat /proc/1/mountinfo | while IFS= read -r line; do
+                                            mp=${'$'}(echo "${'$'}line" | awk '{print ${'$'}5}')
+                                            case "${'$'}mp" in
+                                                /apex/com.android.conscrypt*/cacerts)
+                                                    fstype=${'$'}(echo "${'$'}line" | sed 's/.* - //' | awk '{print ${'$'}1}')
+                                                    if [ "${'$'}fstype" = "tmpfs" ]; then
+                                                        umount -l "${'$'}mp" 2>/dev/null
+                                                    fi
+                                                    ;;
+                                            esac
+                                        done
+                                        # Daemonize: close inherited ksu fds, then rmmod.
+                                        # Zygote kill is handled by kernelsu_exit() -> ksu_kill_zygote()
+                                        # in the kernel, between umount cleanup and SELinux revert.
+                                        (
+                                          exec 0</dev/null 1>/dev/null 2>/dev/null
+                                          for fd in ${'$'}(ls /proc/self/fd/ 2>/dev/null); do
+                                            [ "${'$'}fd" -gt 2 ] && eval "exec ${'$'}fd>&-" 2>/dev/null
+                                          done
+                                          n=0; while [ ${'$'}n -lt 30 ]; do
+                                            rmmod kernelsu 2>/dev/null && break
+                                            sleep 1; n=${'$'}((n+1))
+                                          done
+                                        ) &
+                                        """.trimIndent()
+                                    ).exec()
+                                }
+                            }
+                            // Kill manager so it restarts and shows correct status
+                            android.os.Process.killProcess(android.os.Process.myPid())
+                        }
                         UninstallType.PERMANENT -> navigator.navigate(
                             FlashScreenDestination(FlashIt.FlashUninstall)
                         )
@@ -647,11 +700,14 @@ enum class UninstallType(val title: Int, val message: Int, val icon: ImageVector
 @Composable
 fun rememberUninstallDialog(onSelected: (UninstallType) -> Unit): DialogHandle {
     return rememberCustomDialog { dismiss ->
-        val options = listOf(
-            // UninstallType.TEMPORARY,
-            UninstallType.PERMANENT,
-            UninstallType.RESTORE_STOCK_IMAGE
-        )
+        val options = buildList {
+            // Temporary unload only available in LKM mode (rmmod)
+            if (Natives.isLkmMode) {
+                add(UninstallType.TEMPORARY)
+            }
+            add(UninstallType.PERMANENT)
+            add(UninstallType.RESTORE_STOCK_IMAGE)
+        }
         val listOptions = options.map {
             ListOption(
                 titleText = stringResource(it.title),

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -186,6 +186,7 @@
   <string name="settings_uninstall_permanent">永久卸载</string>
   <string name="settings_restore_stock_image">恢复原厂镜像</string>
   <string name="settings_uninstall_temporary_message">临时卸载 KernelSU Next，下次重启后恢复。</string>
+  <string name="settings_uninstall_temporary_ui_warning">⚠️ 警告：所有持有 root 权限的进程（如 adb su 终端）将被强制终止！\n\n⚠️ 界面（UI）会重启，过程中可能短暂出现开机 Logo。</string>
   <string name="flashing">刷写中</string>
   <string name="flash_success">刷写成功</string>
   <string name="flash_failed">刷写失败</string>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -185,7 +185,8 @@
   <string name="settings_uninstall_temporary">暫時卸載</string>
   <string name="settings_uninstall_permanent">永久卸載</string>
   <string name="settings_restore_stock_image">復原原廠鏡像</string>
-  <string name="settings_uninstall_temporary_message">暫時卸載 KernelSU Next， 下次重新啓動后復原至原始狀態。</string>
+  <string name="settings_uninstall_temporary_message">暫時卸載 KernelSU Next，下次重新啓動後復原至原始狀態。</string>
+  <string name="settings_uninstall_temporary_ui_warning">⚠️ 警告：所有持有 root 權限的程序（如 adb su 終端）將被強制終止！\n\n⚠️ 介面（UI）會重新啟動，過程中可能短暫出現開機 Logo。</string>
   <string name="flashing">刷入中</string>
   <string name="flash_success">刷入完成</string>
   <string name="flash_failed">刷入失敗</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_uninstall_permanent">Uninstall permanently</string>
     <string name="settings_restore_stock_image">Restore stock image</string>
     <string name="settings_uninstall_temporary_message">Temporarily uninstall KernelSU Next, restore to original state after next reboot.</string>
+    <string name="settings_uninstall_temporary_ui_warning">⚠️ WARNING: All processes holding root permissions (e.g. adb su shells) will be forcefully killed!\n\n⚠️ The UI will restart and the boot logo may briefly appear during the process.</string>
     <string name="settings_uninstall_permanent_message">Uninstalling KernelSU Next (root and all modules) completely and permanently.</string>
     <string name="settings_restore_stock_image_message">Restore the stock factory image (if a backup exists), usually used before OTA; if you need to uninstall KernelSU Next, please use \"Uninstall permanently\".</string>
     <string name="flashing">Flashing</string>


### PR DESCRIPTION
## Summary

Enable safe runtime unloading of KernelSU-Next as an LKM via `rmmod kernelsu`, with a one-click "Uninstall temporarily" option in the manager UI (LKM mode only). The module can be reloaded on next reboot.

### Kernel changes

**Root trace cleanup on exit (ksu.c)**
- On module exit, unmount all module overlays via `ksu_umount_all()` (needs `ksu_cred`, must run first).
- Revert SELinux policy via `revert_kernelsu_rules()`: set su/ksu_file domains to enforcing, clear all avtab allow rules for these domains.
- Kill all zygote/usap processes via [ksu_kill_zygote()](file:///g:/%E4%B8%8B%E8%BD%BD/KernelSU-Next-dev/kernel/ksu.c#69-109) after `flush_workqueue` so init restarts them from a clean kernel. Zygote is identified by three conditions to avoid false positives (e.g. Qualcomm's qcrilNrd): PPID==1, comm=="main", and exe==app_process/app_process64. Uses direct `mm->exe_file` access under `rcu_read_lock`.

**Module reference counting for all task_work callbacks**
- Added `try_module_get(THIS_MODULE)` / `module_put(THIS_MODULE)` guards around every `task_work_add` call site (allowlist.c, kernel_umount.c, setuid_hook.c, su_mount_ns.c, supercalls.c, ksud.c), preventing callbacks from executing freed module code after rmmod.

**put_cred_rcu UAF fix (app_profile.c)**
- Replaced static `struct group_info root_groups` with heap-allocated `groups_alloc(0)`. The static variable lived in module memory, but rooted processes retain a pointer to it in `cred->group_info`; after rmmod the pointer dangles and `put_cred_rcu` crashes when the process exits.

**Intentional ksu_cred leak (ksu.c)**
- `revert_creds()` may schedule `put_cred()` via RCU callback after our `rcu_barrier()` completes. Leaking ksu_cred (~300 bytes, reclaimed on reboot) avoids this race.

**fsnotify group leak (pkg_observer.c)**
- `fsnotify_destroy_group()` on this platform lacks `fsnotify_wait_marks_destroyed()`, causing a delayed work to access freed group memory. Instead, zero the mark mask, set `group->shutdown = true`, and intentionally leak (~1 KB, reclaimed on reboot).

**Mutex-guarded kprobe unregistration (ksud.c)**
- Track registration state of all kprobes with a mutex to prevent double-unregister between async work items and module exit. Flush pending work items before final unregistration.

**init.rc fops restoration (ksud.c)**
- Save and restore the original `file_operations` pointer for the hooked init.rc file, preventing a dangling pointer to module memory after unload.

**kobject restoration (ksu.c)**
- `kobject_del()` during init sets `kobj->sd = NULL`. Re-add the kobject before exit to avoid a NULL dereference in sysfs teardown.

**SELinux policy revert (selinux/rules.c)**
- New `revert_kernelsu_rules()`: iterates the policy's avtab, removes all allow rules for su and ksu_file type domains, then rebuilds the conditional avtab. Ensures no permissive SELinux traces remain after module unload.

**Global umount (kernel_umount.c)**
- New `ksu_umount_all()`: iterates all userspace processes and unmounts KSU module overlays from each mount namespace. Must run before subsystem teardown since it depends on `ksu_cred`.

**Resource cleanup**
- Free `mount_list` entries in `ksu_supercalls_exit()`.
- Free `apk_path_hash_list` entries in `ksu_throne_tracker_exit()`.
- Call `ksu_unmark_all_process()` before unregistering tracepoints.
- `rcu_barrier()` + `flush_workqueue(system_wq)` at the end of module exit.

**PREPARE_UNLOAD IOCTL (supercalls.c)**
- New `KSU_IOCTL_PREPARE_UNLOAD` (`'K', 100`) that iterates all processes via `for_each_process`, checks each fd's `f_op->owner == THIS_MODULE`, and sends SIGKILL to holders. This is necessary because fdwrapper fds are invisible to userspace (`ksu_wrapper_d_dname` spoofs their path in `/proc/pid/fd`).

### Manager changes

- Enabled "Uninstall temporarily" option in uninstall dialog when in LKM mode (`Natives.isLkmMode`).
- Unload flow: `prepareUnload()` → `closeDriverFd()` → root shell (umount overlays, kill zygiskd → daemonized rmmod) → kill manager process.
- Zygote kill is handled in kernel by [kernelsu_exit()](file:///g:/%E4%B8%8B%E8%BD%BD/KernelSU-Next-dev/kernel/ksu.c#110-161) → [ksu_kill_zygote()](file:///g:/%E4%B8%8B%E8%BD%BD/KernelSU-Next-dev/kernel/ksu.c#69-109) after all hooks and workqueues are flushed, so init restarts a clean zygote.
- The daemonized subprocess closes all inherited fds > 2 to avoid being killed by `prepareUnload()`.
- Warning messages (EN/zh-CN/zh-TW) moved from list subtitle to confirmation dialog only, informing users that all root processes will be forcefully terminated and the UI will restart (boot logo may briefly appear).

## Test plan

- [x] Build and flash kernel with KernelSU-Next as LKM
- [x] Verify "Uninstall temporarily" appears only in LKM mode
- [x] Test temporary unload with no active root sessions
- [x] Test temporary unload with active `adb su` sessions (should auto-kill them)
- [x] Verify `rmmod kernelsu` succeeds and module is fully unloaded (`lsmod`)
- [x] Verify root detection apps no longer detect root after unload
- [x] Verify KernelSU-Next restores fully after reboot

![](https://github.com/user-attachments/assets/5396285f-938c-4e86-8ae7-dddd10cd9895)
