### PR TITLE
kernel: Use ksu cred to save allowlist (https://github.com/tiann/KernelSU/pull/3243)

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -15,6 +15,7 @@
 #include <linux/compiler_types.h>
 
 #include "klog.h" // IWYU pragma: keep
+#include "ksu.h"
 #include "ksud.h"
 #include "selinux/selinux.h"
 #include "allowlist.h"
@@ -391,6 +392,7 @@ static void do_persistent_allow_list(struct callback_head *_cb)
     struct perm_data *p = NULL;
     loff_t off = 0;
 
+    const struct cred *saved = override_creds(ksu_cred);
     struct file *fp =
         filp_open(KERNEL_SU_ALLOWLIST, O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (IS_ERR(fp)) {
@@ -421,6 +423,7 @@ static void do_persistent_allow_list(struct callback_head *_cb)
 close_file:
     filp_close(fp, 0);
 out:
+    revert_creds(saved);
     kfree(_cb);
 }
 


### PR DESCRIPTION
kernel: Use ksu cred to save allowlist (https://github.com/tiann/KernelSU/pull/3243)

```
Author: Wang Han <416810799@qq.com>
Date:   Sun Mar 1 23:36:42 2026 +0800
```

Some modules mess up allowlist context, which makes init not able to modify it. This workarounds https://github.com/tiann/KernelSU/issues/3234.