### PR TITLE
kernel: Use ksu cred to save allowlist (https://github.com/tiann/KernelSU/pull/3243) (legacy branch)

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -23,6 +23,7 @@
 #endif
 
 #include "klog.h" // IWYU pragma: keep
+#include "ksu.h"
 #include "ksud.h"
 #include "selinux/selinux.h"
 #include "allowlist.h"
@@ -400,6 +401,7 @@ static void do_persistent_allow_list(struct callback_head *_cb)
     struct perm_data *p = NULL;
     loff_t off = 0;
 
+    const struct cred *saved = override_creds(ksu_cred);
     struct file *fp =
         filp_open(KERNEL_SU_ALLOWLIST, O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (IS_ERR(fp)) {
@@ -430,6 +432,7 @@ static void do_persistent_allow_list(struct callback_head *_cb)
 close_file:
     filp_close(fp, 0);
 out:
+    revert_creds(saved);
     kfree(_cb);
 }
 


### PR DESCRIPTION
Some modules mess up allowlist context, which makes init not able to modify it. This workarounds https://github.com/tiann/KernelSU/issues/3234.