### PR TITLE
kernel: do not abort build because of ksu_handle_sys_reboot

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -106,7 +106,7 @@ endif
 endif
 
 ifneq ($(HAVE_KSU_HOOK),0)
-$(error -- KernelSU-Next: No hooks were defined, please integrate manual hooks in your kernel!)
+$(warning -- KernelSU-Next: Manual hooks aren't properly hooked. You may have issues, Consider hooking it properly.)
 endif
 
 # some backports


### PR DESCRIPTION
Hi, after the integration of Non-GKI kernel from RKSU, I would like to do a small improvement for **ksu_handle_sys_reboot** hook.

Previously, it would abort whole Kernel build if **ksu_handle_sys_reboot** is not hooked. So that, consider returning a warning instead of error as KernelSU-Next almost works fine without it expect the Modules side.