### PR TITLE
ksud & ksuinit: fix wrong GetInfoCmd struct (https://github.com/tiann/KernelSU/pull/3256)

### DIFF
--- a/userspace/ksud/src/ksucalls.rs
+++ b/userspace/ksud/src/ksucalls.rs
@@ -27,6 +27,7 @@ const KSU_IOCTL_ADD_TRY_UMOUNT: i32 = _IOW::<()>(K, 18);
 struct GetInfoCmd {
     version: u32,
     flags: u32,
+    features: u32,
 }
 
 #[repr(C)]
@@ -168,6 +169,7 @@ fn get_info() -> GetInfoCmd {
         let mut cmd = GetInfoCmd {
             version: 0,
             flags: 0,
+            features: 0,
         };
         let _ = ksuctl(KSU_IOCTL_GET_INFO, &raw mut cmd);
         cmd

--- a/userspace/ksuinit/src/init.rs
+++ b/userspace/ksuinit/src/init.rs
@@ -161,6 +161,7 @@ fn has_kernelsu_v2() -> bool {
     struct GetInfoCmd {
         version: u32,
         flags: u32,
+        features: u32,
     }
 
     // Try new method: get driver fd using reboot syscall with magic numbers


### PR DESCRIPTION
ksud & ksuinit: fix wrong GetInfoCmd struct (https://github.com/tiann/KernelSU/pull/3256)

```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Sat Mar 7 19:14:54 2026 +0800
```