### PR TITLE
kernel: Provide own stackprotector symbol if necessary; add missing attribute

### DIFF
--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -32,6 +32,7 @@ unsigned long __stack_chk_guard __ro_after_init
 
 struct cred *ksu_cred;
 
+NO_STACK_PROTECTOR_WORKAROUND
 int __init kernelsu_init(void)
 {
 #if defined(CONFIG_STACKPROTECTOR) && !defined(CONFIG_STACKPROTECTOR_PER_TASK)

--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -14,10 +14,36 @@
 #include "ksu.h"
 #include "file_wrapper.h"
 
+// workaround for A12-5.10 kernel
+// Some third-party kernel (e.g. linegaeOS) uses wrong toolchain, which supports
+// CC_HAVE_STACKPROTECTOR_SYSREG while gki's toolchain doesn't.
+// Therefore, ksu lkm, which uses gki toolchain, requires this __stack_chk_guard,
+// while those third-party kernel can't provide.
+// Thus, we manually provide it instead of using kernel's
+#if defined(CONFIG_STACKPROTECTOR) && !defined(CONFIG_STACKPROTECTOR_PER_TASK)
+#include <linux/stackprotector.h>
+#include <linux/random.h>
+unsigned long __stack_chk_guard __ro_after_init
+    __attribute__((visibility("hidden")));
+#define NO_STACK_PROTECTOR_WORKAROUND __attribute__((no_stack_protector))
+#else
+#define NO_STACK_PROTECTOR_WORKAROUND
+#endif
+
 struct cred *ksu_cred;
 
 int __init kernelsu_init(void)
 {
+#if defined(CONFIG_STACKPROTECTOR) && !defined(CONFIG_STACKPROTECTOR_PER_TASK)
+    unsigned long canary;
+
+    /* Try to get a semi random initial value. */
+    get_random_bytes(&canary, sizeof(canary));
+    canary ^= LINUX_VERSION_CODE;
+    canary &= CANARY_MASK;
+    __stack_chk_guard = canary;
+#endif
+
 #ifdef CONFIG_KSU_DEBUG
 	pr_alert("*************************************************************");
 	pr_alert("**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE    **");


### PR DESCRIPTION
kernel: Provide own stackprotector symbol if necessary

```
Author: 5ec1cff <ewtqyqyewtqyqy@gmail.com>
Date:   Sun Mar 1 21:15:56 2026 +0800
```

LineageOS uses a too new clang version to compile GKI kernel, and as a result, -mstack-protector-guard=sysreg is recognized by clang. In the end, CC_HAVE_STACKPROTECTOR_SYSREG is enabled and make __stack_chk_guard symbol not exported. Thus, provide our own symbol when necessary.

ABI compatibility can be guaranteed because no task struct symbol will be changed.

https://github.com/tiann/KernelSU/commit/baf3f7d4675b42e297262cbe1cd1ecbede5e34e5
https://github.com/tiann/KernelSU/pull/3257

kernel: add missing attribute

```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Sun Mar 8 16:21:33 2026 +0800
```

https://github.com/tiann/KernelSU/commit/6484caf138ace68a99105e1934c37d90a4ab8ec8