### PR TITLE
kernel: Only check CONFIG_STACKPROTECTOR_PER_TASK on arm64 (https://github.com/tiann/KernelSU/pull/3263)

### DIFF
--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -20,7 +20,7 @@
 // Therefore, ksu lkm, which uses gki toolchain, requires this __stack_chk_guard,
 // while those third-party kernel can't provide.
 // Thus, we manually provide it instead of using kernel's
-#if defined(CONFIG_STACKPROTECTOR) && !defined(CONFIG_STACKPROTECTOR_PER_TASK)
+#if defined(CONFIG_STACKPROTECTOR) && (defined(CONFIG_ARM64) && !defined(CONFIG_STACKPROTECTOR_PER_TASK))
 #include <linux/stackprotector.h>
 #include <linux/random.h>
 unsigned long __stack_chk_guard __ro_after_init
@@ -35,7 +35,7 @@ struct cred *ksu_cred;
 NO_STACK_PROTECTOR_WORKAROUND
 int __init kernelsu_init(void)
 {
-#if defined(CONFIG_STACKPROTECTOR) && !defined(CONFIG_STACKPROTECTOR_PER_TASK)
+#if defined(CONFIG_STACKPROTECTOR) && (defined(CONFIG_ARM64) && !defined(CONFIG_STACKPROTECTOR_PER_TASK))
     unsigned long canary;
 
     /* Try to get a semi random initial value. */


### PR DESCRIPTION
kernel: Only check CONFIG_STACKPROTECTOR_PER_TASK on arm64 (https://github.com/tiann/KernelSU/pull/3263)

```
Author: Huy Minh <39849246+hmtheboy154@users.noreply.github.com>
Date:   Mon Mar 9 22:25:10 2026 +0700
```

CONFIG_STACKPROTECTOR_PER_TASK does not exist on x86_64. This will fix building KSU on that arch.

Fixes:
https://github.com/tiann/KernelSU/commit/baf3f7d4675b42e297262cbe1cd1ecbede5e34e5