### PR TITLE
kernel: make clang-format happy; refine stackprotector workaround (https://github.com/tiann/KernelSU/pull/3264)

### DIFF
--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -20,7 +20,8 @@
 // Therefore, ksu lkm, which uses gki toolchain, requires this __stack_chk_guard,
 // while those third-party kernel can't provide.
 // Thus, we manually provide it instead of using kernel's
-#if defined(CONFIG_STACKPROTECTOR) && (defined(CONFIG_ARM64) && !defined(CONFIG_STACKPROTECTOR_PER_TASK))
+#if defined(CONFIG_STACKPROTECTOR) &&                                          \
+    (defined(CONFIG_ARM64) && !defined(CONFIG_STACKPROTECTOR_PER_TASK))
 #include <linux/stackprotector.h>
 #include <linux/random.h>
 unsigned long __stack_chk_guard __ro_after_init
@@ -35,7 +36,8 @@ struct cred *ksu_cred;
 NO_STACK_PROTECTOR_WORKAROUND
 int __init kernelsu_init(void)
 {
-#if defined(CONFIG_STACKPROTECTOR) && (defined(CONFIG_ARM64) && !defined(CONFIG_STACKPROTECTOR_PER_TASK))
+#if defined(CONFIG_STACKPROTECTOR) &&                                          \
+    (defined(CONFIG_ARM64) && !defined(CONFIG_STACKPROTECTOR_PER_TASK))
     unsigned long canary;
 
     /* Try to get a semi random initial value. */

--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -21,23 +21,15 @@
 // while those third-party kernel can't provide.
 // Thus, we manually provide it instead of using kernel's
 #if defined(CONFIG_STACKPROTECTOR) &&                                          \
-    (defined(CONFIG_ARM64) && !defined(CONFIG_STACKPROTECTOR_PER_TASK))
+    (defined(CONFIG_ARM64) && defined(MODULE) &&                               \
+     !defined(CONFIG_STACKPROTECTOR_PER_TASK))
 #include <linux/stackprotector.h>
 #include <linux/random.h>
 unsigned long __stack_chk_guard __ro_after_init
     __attribute__((visibility("hidden")));
-#define NO_STACK_PROTECTOR_WORKAROUND __attribute__((no_stack_protector))
-#else
-#define NO_STACK_PROTECTOR_WORKAROUND
-#endif
 
-struct cred *ksu_cred;
-
-NO_STACK_PROTECTOR_WORKAROUND
-int __init kernelsu_init(void)
+__attribute__((no_stack_protector)) void ksu_setup_stack_chk_guard()
 {
-#if defined(CONFIG_STACKPROTECTOR) &&                                          \
-    (defined(CONFIG_ARM64) && !defined(CONFIG_STACKPROTECTOR_PER_TASK))
     unsigned long canary;
 
     /* Try to get a semi random initial value. */
@@ -45,8 +37,24 @@ int __init kernelsu_init(void)
     canary ^= LINUX_VERSION_CODE;
     canary &= CANARY_MASK;
     __stack_chk_guard = canary;
+}
+
+__attribute__((naked)) int __init kernelsu_init_early(void)
+{
+    asm("mov x19, x30;\n"
+        "bl ksu_setup_stack_chk_guard;\n"
+        "mov x30, x19;\n"
+        "b kernelsu_init;\n");
+}
+#define NEED_OWN_STACKPROTECTOR 1
+#else
+#define NEED_OWN_STACKPROTECTOR 0
 #endif
 
+struct cred *ksu_cred;
+
+int __init kernelsu_init(void)
+{
 #ifdef CONFIG_KSU_DEBUG
 	pr_alert("*************************************************************");
 	pr_alert("**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE    **");
@@ -106,7 +114,11 @@ void kernelsu_exit(void)
 	}
 }
 
+#if NEED_OWN_STACKPROTECTOR
+module_init(kernelsu_init_early);
+#else
 module_init(kernelsu_init);
+#endif
 module_exit(kernelsu_exit);
 
 MODULE_LICENSE("GPL");


### PR DESCRIPTION
kernel: make clang-format happy

```
Author: weishu <twsxtd@gmail.com>
Date:   Tue Mar 10 19:57:34 2026 +0800
```

https://github.com/tiann/KernelSU/commit/6bac4b1bd1825a7902502425cdfb07ca6d6256a6

kernel: refine stackprotector workaround (https://github.com/tiann/KernelSU/pull/3264)

```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Wed Mar 11 11:15:58 2026 +0800
```

https://github.com/tiann/KernelSU/pull/3264
https://github.com/tiann/KernelSU/commit/221542b6972ee2355f0b7e4b7033b97702bf17c5