### PR TITLE
kernel: fix process marking for built-in mode (https://github.com/tiann/KernelSU/pull/3284)

### DIFF
--- a/kernel/syscall_hook_manager.c
+++ b/kernel/syscall_hook_manager.c
@@ -67,7 +67,8 @@ static void ksu_mark_running_process_locked()
     struct task_struct *p, *t;
     read_lock(&tasklist_lock);
     for_each_process_thread (p, t) {
-        if (!t->mm) { // only user processes
+        if (t->pid != 1 && !t->mm) {
+            // skip kernel threads, but always allow pid 1
             continue;
         }
         int uid = task_uid(t).val;
@@ -265,6 +266,11 @@ int ksu_handle_init_mark_tracker(const char __user **filename_user)
 		ret = strncpy_from_user_nofault(path, fn, sizeof(path));
 		pr_info("ksu_handle_init_mark_tracker: %ld\n", ret);
 	}
+
+    if (ret < 0) {
+        // unreadable path; keep mark to avoid wrongly unmarking zygote
+        return 0;
+    }
 
     if (unlikely(strcmp(path, KSUD_PATH) == 0)) {
         pr_info("hook_manager: escape to root for init executing ksud: %d\n",


### PR DESCRIPTION
kernel: fix process marking for built-in mode (https://github.com/tiann/KernelSU/pull/3284)

```
Author: Mohammed Riad <1@mhmrdd.me>
Date:   Sun Mar 22 09:42:27 2026 +0100
```

Allow pid 1 to be marked before it execs into init, and avoid blindly unmarking processes when exec path is unreadable.