### PR TITLE
Call switch_cgroups() for WebUI debug su shells

### DIFF
--- a/userspace/ksud/src/su.rs
+++ b/userspace/ksud/src/su.rs
@@ -27,6 +27,9 @@ pub fn grant_root(global_mnt: bool) -> Result<()> {
     let mut command = Command::new("sh");
     let command = unsafe {
         command.pre_exec(move || {
+            // WebUI shells are launched from the manager app process, so make sure
+            // children escape its app cgroups just like module actions do.
+            utils::switch_cgroups();
             if global_mnt {
                 let _ = utils::switch_mnt_ns(1);
             }


### PR DESCRIPTION
## Summary
Module WebUI root shells go through `libksud.so debug su -g`, which ends up in `grant_root()`. Unlike `module action` and the regular `root_shell()` path, `grant_root()` did not call `switch_cgroups()` before `exec("sh")`.

That leaves long-running children inside the manager app cgroup even after they are reparented to PID 1, so Android kills them when the Manager/WebUI process exits.

This patch calls `utils::switch_cgroups()` in `grant_root()` before launching the shell, aligning WebUI behavior with the other launch paths.

Fixes #1180

## Validation
- Reproduced with a long-running root process started from Module WebUI
- Before this change, the child process stayed in the manager app cgroup (`com.rifsxd.ksunext`)
- The same process started through module Action escaped the app cgroup and survived UI shutdown
- I tested this on-device with a custom Manager build
- After this change, the WebUI-launched `nfqws` process no longer dies when Manager/WebUI is closed
- This resolves the issue for me in real use

## Notes
- This fixes cgroup inheritance rather than daemonization. `nohup`, `setsid`, `start-stop-daemon`, etc. do not solve the root cause on their own.
- The behavior change was confirmed by on-device testing.
