### PR TITLE
kernel / userspace: Synchronize with upstream

### DIFF
--- a/kernel/hook/patch_memory.h
+++ b/kernel/hook/patch_memory.h
@@ -9,7 +9,9 @@
 #include <linux/types.h>
 #include "linux/version.h"
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+#include "asm/text-patching.h" // IWYU pragma: keep
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
 #include "asm/patching.h" // IWYU pragma: keep
 #else
 #include "asm/insn.h" // IWYU pragma: keep

--- a/kernel/hook/patch_memory.h
+++ b/kernel/hook/patch_memory.h
@@ -9,12 +9,18 @@
 #include <linux/types.h>
 #include "linux/version.h"
 
+#ifdef __aarch64__
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 #include "asm/text-patching.h" // IWYU pragma: keep
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
 #include "asm/patching.h" // IWYU pragma: keep
 #else
 #include "asm/insn.h" // IWYU pragma: keep
+#endif
+#elif __x86_64__
+#include "asm/text-patching.h" // IWYU pragma: keep
+#else
+#error "Unsupported arch"
 #endif
 
 #define KSU_PATCH_TEXT_FLUSH_DCACHE 1

--- a/kernel/kernel_umount.c
+++ b/kernel/kernel_umount.c
@@ -43,11 +43,11 @@ static const struct ksu_feature_handler kernel_umount_handler = {
 
 extern int path_umount(struct path *path, int flags);
 
-static void ksu_umount_mnt(struct path *path, int flags)
+static void ksu_umount_mnt(const char *mnt, struct path *path, int flags)
 {
 	int err = path_umount(path, flags);
 	if (err) {
-		pr_info("umount %s failed: %d\n", path->dentry->d_iname, err);
+		pr_info("umount %s failed: %d\n", mnt, err);
 	}
 }
 
@@ -65,7 +65,7 @@ static void try_umount(const char *mnt, int flags)
 		return;
 	}
 
-    ksu_umount_mnt(&path, flags);
+	ksu_umount_mnt(mnt, &path, flags);
 }
 
 struct umount_tw {
@@ -118,8 +118,7 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
 	struct mount_entry *entry;
 	down_read(&mount_list_lock);
 	list_for_each_entry (entry, &mount_list, list) {
-		pr_info("%s: unmounting: %s flags 0x%x\n", __func__, entry->umountable,
-			 entry->flags);
+		pr_info("%s: unmounting: %s flags: 0x%x\n", __func__, entry->umountable, entry->flags);
 		try_umount(entry->umountable, entry->flags);
 	}
 	up_read(&mount_list_lock);

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -66,7 +66,7 @@ void apply_kernelsu_rules()
     // Create unconstrained file type
     ksu_type(db, KERNEL_SU_FILE, "file_type");
     ksu_typeattribute(db, KERNEL_SU_FILE, "mlstrustedobject");
-    ksu_allow(db, ALL, KERNEL_SU_FILE, ALL, ALL);
+    ksu_allow(db, "domain", KERNEL_SU_FILE, ALL, ALL);
 
     // allow all!
     ksu_allow(db, KERNEL_SU_DOMAIN, ALL, ALL, ALL);
@@ -89,7 +89,7 @@ void apply_kernelsu_rules()
     ksu_allow(db, "servicemanager", KERNEL_SU_DOMAIN, "file", "open");
     ksu_allow(db, "servicemanager", KERNEL_SU_DOMAIN, "file", "read");
     ksu_allow(db, "servicemanager", KERNEL_SU_DOMAIN, "process", "getattr");
-    ksu_allow(db, ALL, KERNEL_SU_DOMAIN, "process", "sigchld");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "process", "sigchld");
 
     // allowLog
     ksu_allow(db, "logd", KERNEL_SU_DOMAIN, "dir", "search");
@@ -97,12 +97,12 @@ void apply_kernelsu_rules()
     ksu_allow(db, "logd", KERNEL_SU_DOMAIN, "file", "open");
     ksu_allow(db, "logd", KERNEL_SU_DOMAIN, "file", "getattr");
 
-    // dumpsys
-    ksu_allow(db, ALL, KERNEL_SU_DOMAIN, "fd", "use");
-    ksu_allow(db, ALL, KERNEL_SU_DOMAIN, "fifo_file", "write");
-    ksu_allow(db, ALL, KERNEL_SU_DOMAIN, "fifo_file", "read");
-    ksu_allow(db, ALL, KERNEL_SU_DOMAIN, "fifo_file", "open");
-    ksu_allow(db, ALL, KERNEL_SU_DOMAIN, "fifo_file", "getattr");
+    // dumpsys, send fd
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fd", "use");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fifo_file", "write");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fifo_file", "read");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fifo_file", "open");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fifo_file", "getattr");
 
     // bootctl
     ksu_allow(db, "hwservicemanager", KERNEL_SU_DOMAIN, "dir", "search");
@@ -111,7 +111,7 @@ void apply_kernelsu_rules()
     ksu_allow(db, "hwservicemanager", KERNEL_SU_DOMAIN, "process", "getattr");
 
     // Allow all binder transactions
-    ksu_allow(db, ALL, KERNEL_SU_DOMAIN, "binder", ALL);
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "binder", ALL);
 
     // Allow system server kill su process
     ksu_allow(db, "system_server", KERNEL_SU_DOMAIN, "process", "getpgid");

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -1009,6 +1009,8 @@ static int copy_avtab(struct avtab *new_avtab, struct avtab *old_avtab)
     ret = avtab_alloc_dup(new_avtab, old_avtab);
     if (ret < 0)
         return ret;
+    // avtab_alloc_dup didn't zero it
+    new_avtab->nel = 0;
 
     for (i = 0; i < old_avtab->nslot; i++) {
         n = old_avtab->htable[i];

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -166,6 +166,12 @@ enum Debug {
         path: PathBuf,
     },
 
+    /// Load a kernel module from disk
+    Insmod {
+        /// kernel module path
+        module: PathBuf,
+    },
+
     /// Process mark management
     Mark {
         #[command(subcommand)]
@@ -614,6 +620,7 @@ pub fn run() -> Result<()> {
                 let data = assets::get_asset_data(&name)?;
                 utils::ensure_binary(&path, &data, false)
             }
+            Debug::Insmod { module } => debug::insmod(&module),
             Debug::Mark { command } => match command {
                 MarkCommand::Get { pid } => debug::mark_get(pid),
                 MarkCommand::Mark { pid } => debug::mark_set(pid),

--- a/userspace/ksud/src/debug.rs
+++ b/userspace/ksud/src/debug.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Ok, Result, bail, ensure};
 use std::{
+    fs,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -46,6 +47,20 @@ pub fn set_manager(pkg: &str) -> Result<()> {
     set_kernel_param(uid)?;
     // force-stop it
     let _ = Command::new("am").args(["force-stop", pkg]).status();
+    Ok(())
+}
+
+pub fn insmod(module: &Path) -> Result<()> {
+    let module = module
+        .canonicalize()
+        .with_context(|| format!("resolve module path failed: {}", module.display()))?;
+    let module_data =
+        fs::read(&module).with_context(|| format!("read module failed: {}", module.display()))?;
+
+    ksuinit::load_module(&module_data)
+        .with_context(|| format!("load module failed: {}", module.display()))?;
+
+    println!("Loaded kernel module: {}", module.display());
     Ok(())
 }
 

--- a/userspace/ksud/src/late_load.rs
+++ b/userspace/ksud/src/late_load.rs
@@ -60,6 +60,10 @@ pub fn run() -> Result<()> {
         dump_process_info("after load_module");
     }
 
+    // We need to reset stdin/stdout/stderr; otherwise, sending file descriptors via cmd transactions
+    // will be blocked by SELinux because its fsec->sid is still u:r:su:s0 instead of u:r:ksu:s0.
+    utils::reset_std()?;
+
     utils::umask(0);
 
     if let Err(e) = crate::module_config::clear_all_temp_configs() {

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -237,6 +237,14 @@ pub fn uninstall(magiskboot_path: Option<PathBuf>) -> Result<()> {
     Ok(())
 }
 
+pub fn reset_std() -> Result<()> {
+    let null_fd = open("/dev/null", OFlags::RDWR, Mode::empty())?;
+    dup2_stdin(&null_fd)?;
+    dup2_stdout(&null_fd)?;
+    dup2_stderr(&null_fd)?;
+    Ok(())
+}
+
 pub fn daemonize<F: FnOnce() -> Result<()>>(configure: F) -> Result<()> {
     unsafe {
         let pid = libc::fork();
@@ -259,12 +267,7 @@ pub fn daemonize<F: FnOnce() -> Result<()>>(configure: F) -> Result<()> {
     setpgid(None, None)?;
     switch_cgroups();
     configure()?;
-    {
-        let null_fd = open("/dev/null", OFlags::RDWR, Mode::empty())?;
-        dup2_stdin(&null_fd)?;
-        dup2_stdout(&null_fd)?;
-        dup2_stderr(&null_fd)?;
-    }
+    reset_std()?;
 
     unsafe {
         let pid = libc::fork();


### PR DESCRIPTION
```
Author: Ylarod <me@ylarod.cn>
Date:   Fri Mar 27 21:04:04 2026 +0800
```

    ksud: add debug insmod

```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Sat Mar 28 11:15:21 2026 +0800
```

    ksud: late-load: reopen fd to reset selinux file context after LKM loaded (https://github.com/tiann/KernelSU/pull/3354)

    This should solve cmd failure transaction.

```
Author: 5ec1cff <ewtqyqyewtqyqy@gmail.com>
Date:   Sat Mar 28 12:36:43 2026 +0800
```

    kernel: selinux: minify rules

    Restricting the scope of some allow rules from ALL to `domain` , since these rules only apply to process domains. This reduces the allocation of avtab.

```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Sat Mar 28 00:12:44 2026 +0800
```

    kernel: fix copy avtab (https://github.com/tiann/KernelSU/pull/3352)

    Fix https://github.com/tiann/KernelSU/issues/3345 .

```
Author: AlexLiuDev233 <wzylin11@outlook.com>
Date:   Fri Mar 27 14:02:03 2026 +0000
```

    kernel: fix compile for x86-64 linux kernel v6.13- (https://github.com/tiann/KernelSU/pull/3351)

```
Author: Ylarod <me@ylarod.cn>
Date:   Sun Mar 22 20:44:13 2026 +0800
```

    [PARTIAL] ksu: drop official x86_64 support (https://github.com/tiann/KernelSU/pull/3316)

    -Note: ARCH guard (patch_memory / syscall_hook) was rolled in to:
           '[PARTIAL] Bring back x86_64 support with a catch (tiann/KernelSU#3328)'

```
Author: backslashxx <118538522+backslashxx@users.noreply.github.com>
Date:   Thu Mar 26 15:55:07 2026 +0800
```

    kernel_umount: fixup printout and avoid UAF (https://github.com/tiann/KernelSU/pull/3338)

    theres actually a UAF here: path->dentry after dput
    but umount mostly always succeeds or normally unused.
    its kinda unreachable.

    ```
    int path_umount(struct path *path, int flags) {
        ...
        dput(path->dentry);
        ...
    }
    ```

    but yeah, this is better anyway as we see the full mountpoint, not just
    the dentry.

    Signed-off-by: backslashxx
    <118538522+backslashxx@users.noreply.github.com>

    Signed-off-by: backslashxx <118538522+backslashxx@users.noreply.github.com>