### PR TITLE
Fix the issue where the linux/sched/types.h header file cannot be found in kernel versions below 4.12

### DIFF
--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -5,7 +5,9 @@
 #include <linux/version.h>
 #include <linux/slab.h>
 #include <linux/string.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
 #include <linux/sched/types.h>
+#endif
 #include <linux/stop_machine.h>
 
 #include "../klog.h" // IWYU pragma: keep


### PR DESCRIPTION
# Fix the issue where the `linux/sched/types.h` header file cannot be found in kernel versions below 4.12

Fix Issue #1192 

## Problem description:

In `kernel/selinux/rules.c`, the `linux/sched/types.h` header file is directly included, but this header file was added only in kernel version 4.12, causing kernels below version 4.12 to fail to compile KernelSU-Next.

## Changes:

Add kernel version check in the `kernel/selinux/rules.c` header file.