### PR TITLE
kernel: add missing init_session_keyring variable for legacy kernels

### DIFF
--- a/kernel/lsm_hooks.c
+++ b/kernel/lsm_hooks.c
@@ -15,6 +15,8 @@
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) ||                           \
 	defined(CONFIG_IS_HW_HISI) || defined(CONFIG_KSU_ALLOWLIST_WORKAROUND)
+struct key *init_session_keyring = NULL;
+
 static int ksu_key_permission(key_ref_t key_ref, const struct cred *cred,
 			      unsigned perm)
 {


### PR DESCRIPTION
# Description:

Fixed Issue #1199 

On kernels < 4.10 or Huawei HiSilicon platforms (CONFIG_IS_HW_HISI), the compatibility code in ksu_key_permission() references a global pointer init_session_keyring which was never defined. This causes a linking error:

undefined reference to init_session_keyring

Fix the issue by defining the missing variable as NULL.

To avoid unnecessary global symbols on newer kernels, the definition is placed inside the same preprocessor condition that guards the compatibility code.