### PR TITLE
manager: webui: Add WebUI BackHandler Support

### DIFF
--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/WebUIActivity.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/WebUIActivity.kt
@@ -15,6 +15,7 @@ import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -284,6 +285,10 @@ class WebUIActivity : ComponentActivity() {
                     return assetLoader.shouldInterceptRequest(request.url)
                 }
 
+                override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                    return false
+                }
+
                 override fun onPageFinished(view: WebView?, url: String?) {
                     if (developerOptionsEnabled && enableWebDebugging) {
                         view?.evaluateJavascript(erudaConsole(this@WebUIActivity), null)
@@ -295,6 +300,8 @@ class WebUIActivity : ComponentActivity() {
             loadUrl("https://mui.kernelsu.org/index.html")
         }
 
+        setupWebUIBackHandler()
+        
         container.addView(webView)
         setContentView(container)
 
@@ -311,6 +318,21 @@ class WebUIActivity : ComponentActivity() {
                 }
             }
         }
+    }
+    private fun setupWebUIBackHandler() {
+        val backCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                val currentWebView = webView
+                if (currentWebView != null && currentWebView.canGoBack()) {
+                    currentWebView.goBack()
+                } else {
+                    isEnabled = false
+                    finish()
+                }
+            }
+        }
+
+        onBackPressedDispatcher.addCallback(this, backCallback)
     }
 
     private fun extractMimeTypeAndBase64Data(dataUrl: String): Pair<String, String>? {

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/WebViewInterface.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/WebViewInterface.kt
@@ -227,6 +227,16 @@ class WebViewInterface(
         return currentModuleInfo.toString()
     }
 
+    fun canGoBack(): Boolean {
+        return webView.canGoBack()
+    }
+
+    fun goBack() {
+        webView.post {
+            webView.goBack()
+        }
+    }
+
     @JavascriptInterface
     fun createShortcut(): Boolean {
         return try {


### PR DESCRIPTION
Previously, pressing back immediately closed the WebUI. Now it properly respects history for router-based UIs (Vue/React/etc.) and only exits when there's no more history left.

- Use OnBackPressedCallback for reliable hardware back/gesture handling
- Automatically call webView.goBack() when history exists (Vue Router, React Router, etc.)
- Exit WebUI only when on the first page
- Add shouldOverrideUrlLoading to improve SPA navigation compatibility
- Minor WebView settings cleanup