### PR TITLE
kernel (susfs (v2.0.0)): Introduce SuSFS

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -3,7 +3,6 @@ kernelsu-objs += allowlist.o
 kernelsu-objs += app_profile.o
 kernelsu-objs += apk_sign.o
 kernelsu-objs += sucompat.o
-kernelsu-objs += syscall_hook_manager.o
 kernelsu-objs += throne_tracker.o
 kernelsu-objs += pkg_observer.o
 kernelsu-objs += setuid_hook.o
@@ -91,5 +90,15 @@ ccflags-y += -DEXPECTED_MANAGER_HASH=\"$(KSU_NEXT_MANAGER_HASH)\"
 
 ccflags-y += -Wno-strict-prototypes -Wno-int-conversion -Wno-gcc-compat -Wno-missing-prototypes
 ccflags-y += -Wno-declaration-after-statement -Wno-unused-function -Wno-unused-variable
+
+## For susfs stuff ##
+ifeq ($(shell test -e $(srctree)/fs/susfs.c; echo $$?),0)
+$(eval SUSFS_VERSION=$(shell cat $(srctree)/include/linux/susfs.h | grep -E '^#define SUSFS_VERSION' | cut -d' ' -f3 | sed 's/"//g'))
+$(info )
+$(info -- SUSFS_VERSION: $(SUSFS_VERSION))
+else
+$(info -- You have not integrated susfs in your kernel yet.)
+$(info -- Read: https://gitlab.com/simonpunk/susfs4ksu)
+endif
 
 # Keep a new line here!! Because someone may append config

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -2,7 +2,6 @@ menu "KernelSU"
 
 config KSU
 	tristate "KernelSU function support"
-	depends on KPROBES
 	default y
 	help
 	  Enable kernel-level root privileges on Android System.
@@ -16,5 +15,95 @@ config KSU_DEBUG
 	default n
 	help
 	  Enable KernelSU debug mode.
+
+menu "KernelSU - SUSFS"
+config KSU_SUSFS
+	bool "KernelSU addon - SUSFS"
+	depends on KSU
+	depends on THREAD_INFO_IN_TASK
+	default y
+	help
+	  Patch and Enable SUSFS to kernel with KernelSU.
+
+config KSU_SUSFS_SUS_PATH
+	bool "Enable to hide suspicious path (NOT recommended)"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow hiding the user-defined path and all its sub-paths from various system calls.
+	  - Includes temp fix for the leaks of app path in /sdcard/Android/data directory.
+	  - Effective only on zygote spawned user app process.
+	  - Use with cautious as it may cause performance loss and will be vulnerable to side channel attacks,
+	    just disable this feature if it doesn't work for you or you don't need it at all.
+
+config KSU_SUSFS_SUS_MOUNT
+	bool "Enable to hide suspicious mounts"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow hiding the user-defined mount paths from /proc/self/[mounts|mountinfo|mountstat].
+	  - Effective on all processes for hiding mount entries.
+	  - mnt_id and mnt_group_id of the sus mount will be assigned to a much bigger number to solve the issue of id not being contiguous.
+
+config KSU_SUSFS_SUS_KSTAT
+	bool "Enable to spoof suspicious kstat"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow spoofing the kstat of user-defined file/directory.
+	  - Effective only on zygote spawned user app process.
+
+config KSU_SUSFS_SPOOF_UNAME
+	bool "Enable to spoof uname"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow spoofing the string returned by uname syscall to user-defined string.
+	  - Effective on all processes.
+
+config KSU_SUSFS_ENABLE_LOG
+	bool "Enable logging susfs log to kernel"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow logging susfs log to kernel, uncheck it to completely disable all susfs log.
+
+config KSU_SUSFS_HIDE_KSU_SUSFS_SYMBOLS
+	bool "Enable to automatically hide ksu and susfs symbols from /proc/kallsyms"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Automatically hide ksu and susfs symbols from '/proc/kallsyms'.
+	  - Effective on all processes.
+
+config KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG
+	bool "Enable to spoof /proc/bootconfig (gki) or /proc/cmdline (non-gki)"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Spoof the output of /proc/bootconfig (gki) or /proc/cmdline (non-gki) with a user-defined file.
+	  - Effective on all processes.
+
+config KSU_SUSFS_OPEN_REDIRECT
+	bool "Enable to redirect a path to be opened with another path (experimental)"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow redirecting a target path to be opened with another user-defined path.
+	  - Effective only on processes with uid < 2000.
+	  - Please be reminded that process with open access to the target and redirected path can be detected.
+
+config KSU_SUSFS_SUS_MAP
+	bool "Enable to hide some mmapped real file from different proc maps interfaces"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow hiding mmapped real file from /proc/<pid>/[maps|smaps|smaps_rollup|map_files|mem|pagemap]
+	  - It does NOT support hiding for anon memory.
+	  - It does NOT hide any inline hooks or plt hooks cause by the injected library itself.
+	  - It may not be able to evade detections by apps that implement a good injection detection.
+	  - Effective only on zygote spawned umounted user app process.
+
+endmenu
 
 endmenu

--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -16,7 +16,9 @@
 #include "selinux/selinux.h"
 #include "allowlist.h"
 #include "manager.h"
+#ifndef CONFIG_KSU_SUSFS
 #include "syscall_hook_manager.h"
+#endif // #ifndef CONFIG_KSU_SUSFS
 #include "su_mount_ns.h"
 
 #define FILE_MAGIC 0x7f4b5355 // ' KSU', u32
@@ -258,8 +260,10 @@ out:
 
 	if (persist) {
 		persistent_allow_list();
+#ifndef CONFIG_KSU_SUSFS
 		// FIXME: use a new flag
 		ksu_mark_running_process();
+#endif // #ifndef CONFIG_KSU_SUSFS
 	}
 
 	return result;

--- a/kernel/app_profile.c
+++ b/kernel/app_profile.c
@@ -13,7 +13,9 @@
 #include "klog.h" // IWYU pragma: keep
 #include "selinux/selinux.h"
 #include "su_mount_ns.h"
+#ifndef CONFIG_KSU_SUSFS
 #include "syscall_hook_manager.h"
+#endif // #ifndef CONFIG_KSU_SUSFS
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
 static struct group_info root_groups = { .usage = REFCOUNT_INIT(2) };
@@ -105,8 +107,10 @@ static void disable_seccomp(void)
 void escape_with_root_profile(void)
 {
     struct cred *cred;
+#ifndef CONFIG_KSU_SUSFS
     struct task_struct *p = current;
     struct task_struct *t;
+#endif // #ifndef CONFIG_KSU_SUSFS
 
     cred = prepare_creds();
     if (!cred) {
@@ -153,9 +157,11 @@ void escape_with_root_profile(void)
     disable_seccomp();
 
     setup_selinux(profile->selinux_domain);
+#ifndef CONFIG_KSU_SUSFS
     for_each_thread (p, t) {
         ksu_set_task_tracepoint_flag(t);
     }
+#endif // #ifndef CONFIG_KSU_SUSFS
 
     setup_mount_ns(profile->namespaces);
 }

--- a/kernel/kernel_umount.c
+++ b/kernel/kernel_umount.c
@@ -108,6 +108,7 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
 		return 0;
 	}
 
+#ifndef CONFIG_KSU_SUSFS
     // There are 5 scenarios:
     // 1. Normal app: zygote -> appuid
     // 2. Isolated process forked from zygote: zygote -> isolated_process
@@ -131,6 +132,8 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
 		pr_info("handle umount ignore non zygote child: %d\n", current->pid);
 		return 0;
 	}
+#endif // #ifndef CONFIG_KSU_SUSFS
+
 	// umount the target mnt
 	pr_info("handle umount for uid: %d, pid: %d\n", new_uid, current->pid);
 

--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -3,12 +3,20 @@
 #include <linux/kobject.h>
 #include <linux/module.h>
 #include <linux/workqueue.h>
+#ifdef CONFIG_KSU_SUSFS
+#include <linux/susfs.h>
+#endif // #ifdef CONFIG_KSU_SUSFS
 
 #include "allowlist.h"
 #include "feature.h"
 #include "klog.h" // IWYU pragma: keep
 #include "throne_tracker.h"
+#ifndef CONFIG_KSU_SUSFS
 #include "syscall_hook_manager.h"
+#else
+#include "setuid_hook.h"
+#include "sucompat.h"
+#endif // #ifndef CONFIG_KSU_SUSFS
 #include "ksud.h"
 #include "supercalls.h"
 #include "ksu.h"
@@ -37,13 +45,24 @@ int __init kernelsu_init(void)
 
 	ksu_supercalls_init();
 
+#ifndef CONFIG_KSU_SUSFS
 	ksu_syscall_hook_manager_init();
+#else
+	ksu_setuid_hook_init();
+	ksu_sucompat_init();
+#endif // #ifndef CONFIG_KSU_SUSFS
 
 	ksu_allowlist_init();
 
 	ksu_throne_tracker_init();
 
+#ifdef CONFIG_KSU_SUSFS
+	susfs_init();
+#endif // #ifdef CONFIG_KSU_SUSFS
+
+#ifndef CONFIG_KSU_SUSFS
 	ksu_ksud_init();
+#endif // #ifndef CONFIG_KSU_SUSFS
 
     ksu_file_wrapper_init();
 
@@ -64,9 +83,11 @@ void kernelsu_exit(void)
 
 	ksu_observer_exit();
 
+#ifndef CONFIG_KSU_SUSFS
 	ksu_ksud_exit();
 
 	ksu_syscall_hook_manager_exit();
+#endif // #ifndef CONFIG_KSU_SUSFS
 
 	ksu_supercalls_exit();
 

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -58,9 +58,15 @@ static void stop_init_rc_hook();
 static void stop_execve_hook();
 static void stop_input_hook();
 
+#ifndef CONFIG_KSU_SUSFS
 static struct work_struct stop_init_rc_hook_work;
 static struct work_struct stop_execve_hook_work;
 static struct work_struct stop_input_hook_work;
+#else
+bool ksu_init_rc_hook __read_mostly = true;
+bool ksu_execveat_hook __read_mostly = true;
+bool ksu_input_hook __read_mostly = true;
+#endif // #ifndef CONFIG_KSU_SUSFS
 
 void on_post_fs_data(void)
 {
@@ -116,6 +122,7 @@ void on_boot_completed(void)
     ksu_avc_spoof_late_init();
 }
 
+#ifndef CONFIG_KSU_SUSFS
 #define MAX_ARG_STRINGS 0x7FFFFFFF
 struct user_arg_ptr {
 #ifdef CONFIG_COMPAT
@@ -128,6 +135,7 @@ struct user_arg_ptr {
 #endif
 	} ptr;
 };
+#endif // #ifndef CONFIG_KSU_SUSFS
 
 static const char __user *get_user_arg_ptr(struct user_arg_ptr argv, int nr)
 {
@@ -217,6 +225,10 @@ fail:
 	return false;
 }
 
+#ifdef CONFIG_KSU_SUSFS
+extern int ksu_handle_execveat_init(struct filename *filename);
+#endif // #ifdef CONFIG_KSU_SUSFS
+
 // IMPORTANT NOTE: the call from execve_handler_pre WON'T provided correct value for envp and flags in GKI version
 int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 				struct user_arg_ptr *argv,
@@ -272,6 +284,11 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 			stop_execve_hook();
 		}
 	}
+
+#ifdef CONFIG_KSU_SUSFS
+	// - We need to run ksu_handle_execveat_init() at the very end in case the above checks are skipped
+	(void)ksu_handle_execveat_init(filename);
+#endif // #ifdef CONFIG_KSU_SUSFS
 
 	return 0;
 }
@@ -383,7 +400,11 @@ static bool is_init_rc(struct file *fp)
 	return true;
 }
 
+#ifndef CONFIG_KSU_SUSFS
 static void ksu_handle_sys_read(unsigned int fd)
+#else
+void ksu_handle_sys_read(unsigned int fd)
+#endif // #ifndef CONFIG_KSU_SUSFS
 {
 	struct file *file = fget(fd);
 	if (!file) {
@@ -438,6 +459,12 @@ static bool is_volumedown_enough(unsigned int count)
 int ksu_handle_input_handle_event(unsigned int *type, unsigned int *code,
 					int *value)
 {
+#ifdef CONFIG_KSU_SUSFS
+	if (!ksu_input_hook) {
+		return 0;
+	}
+#endif // #ifdef CONFIG_KSU_SUSFS
+
 	if (*type == EV_KEY && *code == KEY_VOLUMEDOWN) {
 		int val = *value;
 		pr_info("KEY_VOLUMEDOWN val: %d\n", val);
@@ -475,6 +502,7 @@ bool ksu_is_safe_mode()
 	return false;
 }
 
+#ifndef CONFIG_KSU_SUSFS
 static int sys_execve_handler_pre(struct kprobe *p, struct pt_regs *regs)
 {
 	struct pt_regs *real_regs = PT_REAL_REGS(regs);
@@ -609,17 +637,45 @@ static void do_stop_input_hook(struct work_struct *work)
 {
 	unregister_kprobe(&input_event_kp);
 }
+#endif // #ifndef CONFIG_KSU_SUSFS
+
+#ifdef CONFIG_KSU_SUSFS
+void ksu_handle_vfs_fstat(int fd, loff_t *kstat_size_ptr) {
+	loff_t new_size = *kstat_size_ptr + ksu_rc_len;
+	struct file *file = fget(fd);
+
+	if (!file)
+		return;
+
+	if (is_init_rc(file)) {
+		pr_info("stat init.rc");
+		pr_info("adding ksu_rc_len: %lld -> %lld", *kstat_size_ptr, new_size);
+		*kstat_size_ptr = new_size;
+	}
+	fput(file);
+}
+#endif // #ifdef CONFIG_KSU_SUSFS
 
 static void stop_init_rc_hook()
 {
+#ifndef CONFIG_KSU_SUSFS
 	bool ret = schedule_work(&stop_init_rc_hook_work);
 	pr_info("unregister init_rc_hook kprobe: %d!\n", ret);
+#else
+	ksu_init_rc_hook = false;
+	pr_info("stop init_rc_hook\n");
+#endif // #ifndef CONFIG_KSU_SUSFS
 }
 
 static void stop_execve_hook()
 {
+#ifndef CONFIG_KSU_SUSFS
 	bool ret = schedule_work(&stop_execve_hook_work);
 	pr_info("unregister execve kprobe: %d!\n", ret);
+#else
+	ksu_execveat_hook = false;
+	pr_info("stop execve_hook\n");
+#endif // #ifndef CONFIG_KSU_SUSFS
 }
 
 static void stop_input_hook()
@@ -629,13 +685,19 @@ static void stop_input_hook()
 		return;
 	}
 	input_hook_stopped = true;
+#ifndef CONFIG_KSU_SUSFS
 	bool ret = schedule_work(&stop_input_hook_work);
 	pr_info("unregister input kprobe: %d!\n", ret);
+#else
+	ksu_input_hook = false;
+	pr_info("stop input_hook\n");
+#endif // #ifndef CONFIG_KSU_SUSFS
 }
 
 // ksud: module support
 void ksu_ksud_init()
 {
+#ifndef CONFIG_KSU_SUSFS
 	int ret;
 
 	ret = register_kprobe(&execve_kp);
@@ -653,12 +715,15 @@ void ksu_ksud_init()
 	INIT_WORK(&stop_init_rc_hook_work, do_stop_init_rc_hook);
 	INIT_WORK(&stop_execve_hook_work, do_stop_execve_hook);
 	INIT_WORK(&stop_input_hook_work, do_stop_input_hook);
+#endif // #ifndef CONFIG_KSU_SUSFS
 }
 
 void ksu_ksud_exit()
 {
+#ifndef CONFIG_KSU_SUSFS
 	unregister_kprobe(&execve_kp);
 	// this should be done before unregister sys_read_kp
 	// unregister_kprobe(&sys_read_kp);
 	unregister_kprobe(&input_event_kp);
+#endif // #ifndef CONFIG_KSU_SUSFS
 }

--- a/kernel/ksud.h
+++ b/kernel/ksud.h
@@ -20,4 +20,23 @@ extern u32 ksu_file_sid;
 extern bool ksu_module_mounted;
 extern bool ksu_boot_completed;
 
+#ifdef CONFIG_KSU_SUSFS
+#define MAX_ARG_STRINGS 0x7FFFFFFF
+struct user_arg_ptr {
+#ifdef CONFIG_COMPAT
+	bool is_compat;
+#endif
+	union {
+		const char __user *const __user *native;
+#ifdef CONFIG_COMPAT
+	const compat_uptr_t __user *compat;
+#endif
+	} ptr;
+};
+
+int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
+				struct user_arg_ptr *argv,
+				struct user_arg_ptr *envp, int *flags);
+#endif // #ifdef CONFIG_KSU_SUSFS
+
 #endif

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -94,6 +94,15 @@ void apply_kernelsu_rules()
     ksu_allow(db, "system_server", KERNEL_SU_DOMAIN, "process", "getpgid");
     ksu_allow(db, "system_server", KERNEL_SU_DOMAIN, "process", "sigkill");
 
+#ifdef CONFIG_KSU_SUSFS
+    // Allow umount in zygote process without installing zygisk
+    //ksu_allow(db, "zygote", "labeledfs", "filesystem", "unmount");
+    susfs_set_priv_app_sid();
+    susfs_set_init_sid();
+    susfs_set_ksu_sid();
+    susfs_set_zygote_sid();
+#endif // #ifdef CONFIG_KSU_SUSFS
+
     mutex_unlock(&ksu_rules);
 }
 

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -207,3 +207,99 @@ bool is_init(const struct cred *cred)
 {
     return is_sid_match(cred, cached_init_sid, INIT_CONTEXT);
 }
+
+#ifdef CONFIG_KSU_SUSFS
+#define KERNEL_INIT_DOMAIN "u:r:init:s0"
+#define KERNEL_ZYGOTE_DOMAIN "u:r:zygote:s0"
+#define KERNEL_PRIV_APP_DOMAIN "u:r:priv_app:s0:c512,c768"
+
+u32 susfs_ksu_sid = 0;
+u32 susfs_init_sid = 0;
+u32 susfs_zygote_sid = 0;
+u32 susfs_priv_app_sid = 0;
+
+static inline void susfs_set_sid(const char *secctx_name, u32 *out_sid)
+{
+    int err;
+
+    if (!secctx_name || !out_sid) {
+        pr_err("secctx_name || out_sid is NULL\n");
+        return;
+    }
+
+    err = security_secctx_to_secid(secctx_name, strlen(secctx_name),
+                       out_sid);
+    if (err) {
+        pr_err("failed setting sid for '%s', err: %d\n", secctx_name, err);
+        return;
+    }
+    pr_info("sid '%u' is set for secctx_name '%s'\n", *out_sid, secctx_name);
+}
+
+bool susfs_is_sid_equal(const struct cred *cred, u32 sid2) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
+    const struct task_security_struct *tsec = selinux_cred(cred);
+#else
+    const struct cred_security_struct *tsec = selinux_cred(cred);
+#endif
+
+    if (!tsec) {
+        return false;
+    }
+    return tsec->sid == sid2;
+}
+
+u32 susfs_get_sid_from_name(const char *secctx_name)
+{
+    u32 out_sid = 0;
+    int err;
+
+    if (!secctx_name) {
+        pr_err("secctx_name is NULL\n");
+        return 0;
+    }
+    err = security_secctx_to_secid(secctx_name, strlen(secctx_name),
+                       &out_sid);
+    if (err) {
+        pr_err("failed getting sid from secctx_name: %s, err: %d\n", secctx_name, err);
+        return 0;
+    }
+    return out_sid;
+}
+
+u32 susfs_get_current_sid(void) {
+    return current_sid();
+}
+
+void susfs_set_zygote_sid(void)
+{
+    susfs_set_sid(KERNEL_ZYGOTE_DOMAIN, &susfs_zygote_sid);
+}
+
+bool susfs_is_current_zygote_domain(void) {
+    return unlikely(current_sid() == susfs_zygote_sid);
+}
+
+void susfs_set_ksu_sid(void)
+{
+    susfs_set_sid(KERNEL_SU_CONTEXT, &susfs_ksu_sid);
+}
+
+bool susfs_is_current_ksu_domain(void) {
+    return unlikely(current_sid() == susfs_ksu_sid);
+}
+
+void susfs_set_init_sid(void)
+{
+    susfs_set_sid(KERNEL_INIT_DOMAIN, &susfs_init_sid);
+}
+
+bool susfs_is_current_init_domain(void) {
+    return unlikely(current_sid() == susfs_init_sid);
+}
+
+void susfs_set_priv_app_sid(void)
+{
+    susfs_set_sid(KERNEL_PRIV_APP_DOMAIN, &susfs_priv_app_sid);
+}
+#endif // #ifdef CONFIG_KSU_SUSFS

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -36,4 +36,17 @@ int handle_sepolicy(unsigned long arg3, void __user *arg4);
 
 void setup_ksu_cred();
 
+#ifdef CONFIG_KSU_SUSFS
+bool susfs_is_sid_equal(const struct cred *cred, u32 sid2);
+u32 susfs_get_sid_from_name(const char *secctx_name);
+u32 susfs_get_current_sid(void);
+void susfs_set_zygote_sid(void);
+bool susfs_is_current_zygote_domain(void);
+void susfs_set_ksu_sid(void);
+bool susfs_is_current_ksu_domain(void);
+void susfs_set_init_sid(void);
+bool susfs_is_current_init_domain(void);
+void susfs_set_priv_app_sid(void);
+#endif // #ifdef CONFIG_KSU_SUSFS
+
 #endif

--- a/kernel/setuid_hook.c
+++ b/kernel/setuid_hook.c
@@ -11,6 +11,9 @@
 #include <linux/types.h>
 #include <linux/uaccess.h>
 #include <linux/uidgid.h>
+#ifdef CONFIG_KSU_SUSFS
+#include <linux/susfs_def.h>
+#endif // #ifdef CONFIG_KSU_SUSFS
 
 #include "allowlist.h"
 #include "setuid_hook.h"
@@ -19,8 +22,32 @@
 #include "selinux/selinux.h"
 #include "seccomp_cache.h"
 #include "supercalls.h"
+#ifndef CONFIG_KSU_SUSFS
 #include "syscall_hook_manager.h"
+#endif // #ifndef CONFIG_KSU_SUSFS
 #include "kernel_umount.h"
+
+#ifdef CONFIG_KSU_SUSFS
+static inline bool is_zygote_isolated_service_uid(uid_t uid)
+{
+    uid %= 100000;
+    return (uid >= 99000 && uid < 100000);
+}
+
+static inline bool is_zygote_normal_app_uid(uid_t uid)
+{
+    uid %= 100000;
+    return (uid >= 10000 && uid < 19999);
+}
+
+extern u32 susfs_zygote_sid;
+#ifdef CONFIG_KSU_SUSFS_SUS_PATH
+extern void susfs_run_sus_path_loop(uid_t uid);
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+extern void susfs_reorder_mnt_id(void);
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+#endif // #ifdef CONFIG_KSU_SUSFS
 
 static void ksu_install_manager_fd_tw_func(struct callback_head *cb)
 {
@@ -28,6 +55,7 @@ static void ksu_install_manager_fd_tw_func(struct callback_head *cb)
     kfree(cb);
 }
 
+#ifndef CONFIG_KSU_SUSFS
 int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid)
 {
     // we rely on the fact that zygote always call setresuid(3) with same uids
@@ -72,6 +100,78 @@ int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid)
 
     return 0;
 }
+#else
+int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid){
+    // we rely on the fact that zygote always call setresuid(3) with same uids
+    uid_t new_uid = ruid;
+    uid_t old_uid = current_uid().val;
+
+    // We only interest in process spwaned by zygote
+    if (!susfs_is_sid_equal(current_cred(), susfs_zygote_sid)) {
+        return 0;
+    }
+
+#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+    // Check if spawned process is isolated service first, and force to do umount if so
+    if (is_zygote_isolated_service_uid(new_uid)) {
+        goto do_umount;
+    }
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+
+    // - Since ksu maanger app uid is excluded in allow_list_arr, so ksu_uid_should_umount(manager_uid)
+    //   will always return true, that's why we need to explicitly check if new_uid belongs to
+    //   ksu manager
+    if (ksu_get_manager_appid() == new_uid % PER_USER_RANGE) {
+        spin_lock_irq(&current->sighand->siglock);
+        ksu_seccomp_allow_cache(current->seccomp.filter, __NR_reboot);
+        spin_unlock_irq(&current->sighand->siglock);
+
+        pr_info("install fd for manager: %d\n", new_uid);
+        struct callback_head *cb = kzalloc(sizeof(*cb), GFP_ATOMIC);
+        if (!cb)
+            return 0;
+        cb->func = ksu_install_manager_fd_tw_func;
+        if (task_work_add(current, cb, TWA_RESUME)) {
+            kfree(cb);
+            pr_warn("install manager fd add task_work failed\n");
+        }
+        return 0;
+    }
+
+    // Check if spawned process is normal user app and needs to be umounted
+    if (likely(is_zygote_normal_app_uid(new_uid) && ksu_uid_should_umount(new_uid))) {
+        goto do_umount;
+    }
+
+    if (ksu_is_allow_uid_for_current(new_uid)) {
+        if (current->seccomp.mode == SECCOMP_MODE_FILTER &&
+            current->seccomp.filter) {
+            spin_lock_irq(&current->sighand->siglock);
+            ksu_seccomp_allow_cache(current->seccomp.filter, __NR_reboot);
+            spin_unlock_irq(&current->sighand->siglock);
+        }
+    }
+
+    return 0;
+
+do_umount:
+    // Handle kernel umount
+    ksu_handle_umount(old_uid, new_uid);
+
+#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+    // We can reorder the mnt_id now after all sus mounts are umounted
+    susfs_reorder_mnt_id();
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+
+#ifdef CONFIG_KSU_SUSFS_SUS_PATH
+    susfs_run_sus_path_loop(new_uid);
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+
+    susfs_set_current_proc_umounted();
+
+    return 0;
+}
+#endif // #ifndef CONFIG_KSU_SUSFS
 
 void ksu_setuid_hook_init(void)
 {

--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -11,6 +11,12 @@
 #include <linux/version.h>
 #include <linux/sched/task_stack.h>
 #include <linux/ptrace.h>
+#ifdef CONFIG_KSU_SUSFS
+#include <linux/susfs_def.h>
+#include <linux/namei.h>
+#include "selinux/selinux.h"
+#include "objsec.h"
+#endif // #ifdef CONFIG_KSU_SUSFS
 
 #include "allowlist.h"
 #include "feature.h"
@@ -71,6 +77,7 @@ static char __user *ksud_user_path(void)
 	return userspace_stack_buffer(ksud_path, sizeof(ksud_path));
 }
 
+#ifndef CONFIG_KSU_SUSFS
 int ksu_handle_faccessat(int *dfd, const char __user **filename_user,
 		int *mode, int *__unused_flags)
 {
@@ -170,6 +177,150 @@ int ksu_handle_execve_sucompat(const char __user **filename_user,
 
 	return 0;
 }
+#else
+static const char sh_path[] = SH_PATH;
+static const char su_path[] = SU_PATH;
+static const char ksud_path[] = KSUD_PATH;
+
+extern bool ksu_kernel_umount_enabled;
+
+/*
+ * return 0 -> No further checks should be required afterwards
+ * return 1 -> Further checks should be continued afterwards
+ */
+int ksu_handle_execveat_init(struct filename *filename) {
+	if (current->pid != 1 && is_init(get_current_cred())) {
+		if (unlikely(strcmp(filename->name, KSUD_PATH) == 0)) {
+			pr_info("hook_manager: escape to root for init executing ksud: %d\n", current->pid);
+			escape_to_root_for_init();
+		} else if (likely(strstr(filename->name, "/app_process") == NULL &&
+				strstr(filename->name, "/adbd") == NULL) &&
+				!susfs_is_current_proc_umounted())
+		{
+			pr_info("susfs: mark no sucompat checks for pid: '%d', exec: '%s'\n", current->pid, filename->name);
+			susfs_set_current_proc_umounted();
+		}
+		return 0;
+	}
+	return 1;
+}
+
+// the call from execve_handler_pre won't provided correct value for __never_use_argument, use them after fix execve_handler_pre, keeping them for consistence for manually patched code
+int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
+			void *__never_use_argv, void *__never_use_envp,
+			int *__never_use_flags)
+{
+	struct filename *filename;
+
+	if (unlikely(!filename_ptr))
+		return 0;
+
+	filename = *filename_ptr;
+	if (IS_ERR(filename)) {
+		return 0;
+	}
+
+	if (!ksu_handle_execveat_init(filename)) {
+		return 0;
+	}
+
+	if (likely(memcmp(filename->name, su_path, sizeof(su_path))))
+		return 0;
+
+	pr_info("ksu_handle_execveat_sucompat: su found\n");
+	memcpy((void *)filename->name, ksud_path, sizeof(ksud_path));
+
+	escape_with_root_profile();
+
+	return 0;
+}
+
+int ksu_handle_execveat(int *fd, struct filename **filename_ptr, void *argv,
+		void *envp, int *flags)
+{
+	if (ksu_handle_execveat_ksud(fd, filename_ptr, argv, envp, flags)) {
+		return 0;
+	}
+	return ksu_handle_execveat_sucompat(fd, filename_ptr, argv, envp,
+				flags);
+}
+
+int ksu_handle_faccessat(int *dfd, const char __user **filename_user, int *mode,
+		int *__unused_flags)
+{
+	char path[sizeof(su_path) + 1] = {0};
+
+	strncpy_from_user_nofault(path, *filename_user, sizeof(path));
+
+	if (unlikely(!memcmp(path, su_path, sizeof(su_path)))) {
+		pr_info("ksu_handle_faccessat: su->sh!\n");
+		*filename_user = sh_user_path();
+	}
+
+	return 0;
+
+	return 0;
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+int ksu_handle_stat(int *dfd, struct filename **filename, int *flags) {
+	if (unlikely(IS_ERR(*filename) || (*filename)->name == NULL)) {
+		return 0;
+	}
+
+	if (likely(memcmp((*filename)->name, su_path, sizeof(su_path)))) {
+		return 0;
+	}
+
+	pr_info("ksu_handle_stat: su->sh!\n");
+	memcpy((void *)((*filename)->name), sh_path, sizeof(sh_path));
+	return 0;
+}
+#else
+int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags)
+{
+	if (unlikely(!filename_user)) {
+		return 0;
+	}
+
+	char path[sizeof(su_path) + 1] = {0};
+
+	strncpy_from_user_nofault(path, *filename_user, sizeof(path));
+
+	if (unlikely(!memcmp(path, su_path, sizeof(su_path)))) {
+		pr_info("ksu_handle_stat: su->sh!\n");
+		*filename_user = sh_user_path();
+	}
+
+	return 0;
+}
+#endif // #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+
+int ksu_handle_devpts(struct inode *inode)
+{
+	if (!current->mm) {
+		return 0;
+	}
+
+	uid_t uid = current_uid().val;
+	if (uid % 100000 < 10000) {
+		// not untrusted_app, ignore it
+		return 0;
+	}
+
+	if (!__ksu_is_allow_uid_for_current(uid))
+		return 0;
+
+	if (ksu_file_sid) {
+		struct inode_security_struct *sec = selinux_inode(inode);
+		if (sec) {
+			sec->sid = ksu_file_sid;
+		}
+	}
+
+	return 0;
+}
+#endif // #ifndef CONFIG_KSU_SUSFS
 
 // sucompat: permitted process can execute 'su' to gain root access.
 void ksu_sucompat_init()

--- a/kernel/sucompat.h
+++ b/kernel/sucompat.h
@@ -10,7 +10,11 @@ void ksu_sucompat_exit(void);
 // Handler functions exported for hook_manager
 int ksu_handle_faccessat(int *dfd, const char __user **filename_user, int *mode,
                          int *__unused_flags);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) && defined(CONFIG_KSU_SUSFS)
+int ksu_handle_stat(int *dfd, struct filename **filename, int *flags);
+#else
 int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags);
+#endif // #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) && defined(CONFIG_KSU_SUSFS)
 int ksu_handle_execve_sucompat(const char __user **filename_user,
                                void *__never_use_argv, void *__never_use_envp,
                                int *__never_use_flags);

--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -12,6 +12,10 @@
 #include <linux/uaccess.h>
 #include <linux/version.h>
 #include <linux/utsname.h> // utsname() and uts_sem
+#ifdef CONFIG_KSU_SUSFS
+#include <linux/namei.h>
+#include <linux/susfs.h>
+#endif // #ifdef CONFIG_KSU_SUSFS
 
 #include "supercalls.h"
 #include "arch.h"
@@ -24,7 +28,13 @@
 #include "manager.h"
 #include "selinux/selinux.h"
 #include "file_wrapper.h"
+#ifndef CONFIG_KSU_SUSFS
 #include "syscall_hook_manager.h"
+#endif // #ifndef CONFIG_KSU_SUSFS
+
+#ifdef CONFIG_KSU_SUSFS
+bool susfs_is_boot_completed_triggered __read_mostly = false;
+#endif // #ifdef CONFIG_KSU_SUSFS
 
 #include "tiny_sulog.c"
 
@@ -118,6 +128,9 @@ static int do_report_event(void __user *arg)
 			boot_complete_lock = true;
 			pr_info("boot_complete triggered\n");
 			on_boot_completed();
+#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+			susfs_is_boot_completed_triggered = true;
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
 		}
 		break;
 	}
@@ -369,6 +382,7 @@ static int do_manage_mark(void __user *arg)
 
 	switch (cmd.operation) {
 	case KSU_MARK_GET: {
+#ifndef CONFIG_KSU_SUSFS
 		// Get task mark status
 		ret = ksu_get_task_mark(cmd.pid);
 		if (ret < 0) {
@@ -377,8 +391,19 @@ static int do_manage_mark(void __user *arg)
 		}
 		cmd.result = (u32)ret;
 		break;
+#else
+	if (susfs_is_current_proc_umounted()) {
+		ret = 0; // SYSCALL_TRACEPOINT is NOT flagged
+	} else {
+		ret = 1; // SYSCALL_TRACEPOINT is flagged
+	}
+	pr_info("manage_mark: ret for pid %d: %d\n", cmd.pid, ret);
+	cmd.result = (u32)ret;
+	break;
+#endif // #ifndef CONFIG_KSU_SUSFS
 	}
 	case KSU_MARK_MARK: {
+#ifndef CONFIG_KSU_SUSFS
 		if (cmd.pid == 0) {
 			ksu_mark_all_process();
 		} else {
@@ -389,9 +414,15 @@ static int do_manage_mark(void __user *arg)
 				return ret;
 			}
 		}
+#else
+		if (cmd.pid != 0) {
+			return ret;
+		}
+#endif // #ifndef CONFIG_KSU_SUSFS
 		break;
 	}
 	case KSU_MARK_UNMARK: {
+#ifndef CONFIG_KSU_SUSFS
 		if (cmd.pid == 0) {
 			ksu_unmark_all_process();
 		} else {
@@ -402,11 +433,20 @@ static int do_manage_mark(void __user *arg)
 				return ret;
 			}
 		}
+#else
+		if (cmd.pid != 0) {
+			return ret;
+		}
+#endif // #ifndef CONFIG_KSU_SUSFS
 		break;
 	}
 	case KSU_MARK_REFRESH: {
+#ifndef CONFIG_KSU_SUSFS
 		ksu_mark_running_process();
 		pr_info("manage_mark: refreshed running processes\n");
+#else
+		pr_info("susfs: cmd: KSU_MARK_REFRESH: do nothing\n");
+#endif // #ifndef CONFIG_KSU_SUSFS
 		break;
 	}
 	default: {
@@ -750,6 +790,7 @@ static void ksu_install_fd_tw_func(struct callback_head *cb)
 	kfree(tw);
 }
 
+#ifndef CONFIG_KSU_SUSFS
 static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
 {
 	struct pt_regs *real_regs = PT_REAL_REGS(regs);
@@ -896,6 +937,121 @@ static struct kprobe reboot_kp = {
 	.symbol_name = REBOOT_SYMBOL,
 	.pre_handler = reboot_handler_pre,
 };
+#else
+int ksu_handle_sys_reboot(int magic1, int magic2, unsigned int cmd, void __user **arg)
+{
+	if (magic1 != KSU_INSTALL_MAGIC1) {
+		return -EINVAL;
+	}
+
+	// If magic2 is susfs and current process is root
+	if (magic2 == SUSFS_MAGIC && current_uid().val == 0) {
+#ifdef CONFIG_KSU_SUSFS_SUS_PATH
+		if (cmd == CMD_SUSFS_ADD_SUS_PATH) {
+			susfs_add_sus_path(arg);
+			return 0;
+		}
+		if (cmd == CMD_SUSFS_ADD_SUS_PATH_LOOP) {
+			susfs_add_sus_path_loop(arg);
+			return 0;
+		}
+		if (cmd == CMD_SUSFS_SET_ANDROID_DATA_ROOT_PATH) {
+			susfs_set_i_state_on_external_dir(arg);
+			return 0;
+		}
+		if (cmd == CMD_SUSFS_SET_SDCARD_ROOT_PATH) {
+			susfs_set_i_state_on_external_dir(arg);
+			return 0;
+		}
+#endif //#ifdef CONFIG_KSU_SUSFS_SUS_PATH
+#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+		if (cmd == CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS) {
+			susfs_set_hide_sus_mnts_for_non_su_procs(arg);
+			return 0;
+		}
+#endif //#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+#ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+		if (cmd == CMD_SUSFS_ADD_SUS_KSTAT) {
+			susfs_add_sus_kstat(arg);
+			return 0;
+		}
+		if (cmd == CMD_SUSFS_UPDATE_SUS_KSTAT) {
+			susfs_update_sus_kstat(arg);
+			return 0;
+		}
+		if (cmd == CMD_SUSFS_ADD_SUS_KSTAT_STATICALLY) {
+			susfs_add_sus_kstat(arg);
+			return 0;
+		}
+#endif //#ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+#ifdef CONFIG_KSU_SUSFS_SPOOF_UNAME
+		if (cmd == CMD_SUSFS_SET_UNAME) {
+			susfs_set_uname(arg);
+			return 0;
+		}
+#endif //#ifdef CONFIG_KSU_SUSFS_SPOOF_UNAME
+#ifdef CONFIG_KSU_SUSFS_ENABLE_LOG
+		if (cmd == CMD_SUSFS_ENABLE_LOG) {
+			susfs_enable_log(arg);
+			return 0;
+		}
+#endif //#ifdef CONFIG_KSU_SUSFS_ENABLE_LOG
+#ifdef CONFIG_KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG
+		if (cmd == CMD_SUSFS_SET_CMDLINE_OR_BOOTCONFIG) {
+			susfs_set_cmdline_or_bootconfig(arg);
+			return 0;
+		}
+#endif //#ifdef CONFIG_KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG
+#ifdef CONFIG_KSU_SUSFS_OPEN_REDIRECT
+		if (cmd == CMD_SUSFS_ADD_OPEN_REDIRECT) {
+			susfs_add_open_redirect(arg);
+			return 0;
+		}
+#endif //#ifdef CONFIG_KSU_SUSFS_OPEN_REDIRECT
+#ifdef CONFIG_KSU_SUSFS_SUS_MAP
+		if (cmd == CMD_SUSFS_ADD_SUS_MAP) {
+			susfs_add_sus_map(arg);
+			return 0;
+		}
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_MAP
+		if (cmd == CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING) {
+			susfs_set_avc_log_spoofing(arg);
+			return 0;
+		}
+		if (cmd == CMD_SUSFS_SHOW_ENABLED_FEATURES) {
+			susfs_get_enabled_features(arg);
+			return 0;
+		}
+		if (cmd == CMD_SUSFS_SHOW_VARIANT) {
+			susfs_show_variant(arg);
+			return 0;
+		}
+		if (cmd == CMD_SUSFS_SHOW_VERSION) {
+			susfs_show_version(arg);
+			return 0;
+		}
+		return 0;
+	}
+
+	// Check if this is a request to install KSU fd
+	if (magic2 == KSU_INSTALL_MAGIC2) {
+		struct ksu_install_fd_tw *tw;
+
+		tw = kzalloc(sizeof(*tw), GFP_ATOMIC);
+		if (!tw)
+			return 0;
+
+		tw->outp = (int __user *)(*arg);
+		tw->cb.func = ksu_install_fd_tw_func;
+
+		if (task_work_add(current, &tw->cb, TWA_RESUME)) {
+			kfree(tw);
+			pr_warn("install fd add task_work failed\n");
+		}
+	}
+	return 0;
+}
+#endif // #ifndef CONFIG_KSU_SUSFS
 
 void ksu_supercalls_init(void)
 {
@@ -907,19 +1063,25 @@ void ksu_supercalls_init(void)
                 ksu_ioctl_handlers[i].cmd);
     }
 
+#ifndef CONFIG_KSU_SUSFS
 	int rc = register_kprobe(&reboot_kp);
 	if (rc) {
 		pr_err("reboot kprobe failed: %d\n", rc);
 	} else {
 		pr_info("reboot kprobe registered successfully\n");
 	}
+#endif // #ifndef CONFIG_KSU_SUSFS
 
     sulog_init_heap(); // grab heap memory
 }
 
 void ksu_supercalls_exit(void)
 {
+#ifndef CONFIG_KSU_SUSFS
     unregister_kprobe(&reboot_kp);
+#else
+    pr_info("susfs: do nothing\n");
+#endif // #ifndef CONFIG_KSU_SUSFS
 }
 
 // IOCTL dispatcher


### PR DESCRIPTION
-Cherry-picked and squashed from:
 https://github.com/pershoot/KernelSU-Next/tree/dev-susfs

.....

kernel (susfs (v2.0.0)): Synced with official KernelSU main repo

Author: simonpunk <simonpunk2016@gmail.com>
Date:   Mon Dec 15 20:03:01 2025 +0800

- See https://github.com/tiann/KernelSU/commit/c95c2d7956a23f4bf23713eb1a4ca86b8ad04569

-Makefile -> Kbuild (build-time info.)
-Accommodate:
 'Add mount namespace support 添加挂载命名空间支持 (#2909)'
 'kernel: fix root_groups defs (#3028)'
 'sulogv2'
 'kernel, ksud, manager: Remove enhanced security feature'
 (https://github.com/KernelSU-Next/KernelSU-Next/pull/1035/commits)
 'Explicitly check zygote start in execve hook'
 'selinux: Cache SID lookups for domain checks'
 'kernel: ksud: Refine rc injection'
 'kernel: supercalls: expose spoof uname function to userspace'

-https://gitlab.com/simonpunk/susfs4ksu/-/tree/gki-android14-6.1

kernel (susfs (v2.0.0)): Let ksud bootstrap

Author: pershoot <190600+pershoot@users.noreply.github.com>
Date:   Mon Dec 29 21:36:12 2025 -0500

-Do not short-circuit; this will cause loss of root if this returns
 early (like on my / few specific device(s)) due to timing differences
 during init.

kernel (susfs (v2.0.0)): Fixed ksu features not enabled and ksu fd not released

Author: simonpunk <simonpunk2016@gmail.com>
Date:   Wed Dec 17 00:16:34 2025 +0800

-Synced with official KernelSU main repo

- See https://github.com/tiann/KernelSU/commit/91ed4eaf670fa86ea42b383fbe9721eadc171461

-https://gitlab.com/simonpunk/susfs4ksu/-/tree/gki-android14-6.1

KernelSU (susfs (v2.0.0)): Fixed compile error

Author: simonpunk <simonpunk2016@gmail.com>
Date:   Sun Dec 21 01:30:55 2025 +0800

-Synced with official KernelSU main repo

- See https://github.com/tiann/KernelSU/commit/3d73f892e1261e2dcfb85e5f04dece877771f285

-https://gitlab.com/simonpunk/susfs4ksu/-/tree/gki-android14-6.1

kernel (susfs (v2.0.0)): Synchronize with upstream

Author: pershoot <190600+pershoot@users.noreply.github.com>
Date:   Tue Dec 30 06:39:56 2025 -0500

-'kernel (susfs (v2.0.0)): Let ksud bootstrap' ->
 'KernelSU: Fixed root not accessible on some Samsung devices and AOSP devices'
 -Init. call at end; amend / add comments

-https://gitlab.com/simonpunk/susfs4ksu/-/tree/gki-android14-6.1

KernelSU (susfs (v2.0.0)): Fixed selinux issues by the fix from upstream

Author: simonpunk <simonpunk2016@gmail.com>
Date:   Wed Dec 31 09:05:32 2025 +0800

-Remove ksu_enhanced_security_enabled check in ksu_handle_setresuid()
 since it may lead to side channel detection

- For selinux issues, see https://github.com/tiann/KernelSU/commit/f71d0115157e7df6a42d918856bae308a9923e19

- For ksu_enhanced_security_enabled issue, Now no matter what value is set for the toggle "Enable enhanced security" in ksu manager, it will NOT be effective nor used to check in ksu_handle_setresuid()

-Note: This was partially taken care of in:
       'kernel (susfs (v2.0.0)): Synced with official KernelSU main repo'
       coinciding with:
       'kernel, ksud, manager: Remove enhanced security feature'
       (https://github.com/KernelSU-Next/KernelSU-Next/pull/1035/commits)

-https://gitlab.com/simonpunk/susfs4ksu/-/tree/gki-android14-6.1

kernel & KernelSU (susfs (v2.0.0)): Added newfstatat syscall hook for handling latest Android Canary

Author: simonpunk <simonpunk2016@gmail.com>
Date:   Sun Jan 11 21:48:35 2026 +0800

-Sycned with official KernelSU main repo

- See https://github.com/tiann/KernelSU/commit/df640917d11dd0eff1b34ea53ec3c0dc49667002

-Note: Some of this was taken care of in:
       'kernel (susfs (v2.0.0)): Synced with official KernelSU main repo'
       to coincide with:
       'kernel: ksud: Refine rc injection, fix issue of Android Canary 2601'

-https://gitlab.com/simonpunk/susfs4ksu/-/tree/gki-android14-6.1

kernel (susfs (v2.0.0)): Fix stat issue when injecting to init.rc for latest Android Canary and qpr3 beta2

Author: simonpunk <simonpunk2016@gmail.com>
Date:   Sat Jan 17 21:38:43 2026 +0800

- Sorry for my blinded eyes again since I did not read the references by the upstream fix carefully, it should hook fstat instead of newfstatat, and by hooking vfs_fstat we do not need to care which syscall family it uses

-https://gitlab.com/simonpunk/susfs4ksu/-/tree/gki-android14-6.1

kernel (susfs (v2.0.0)): Refined and renamed hide_sus_mnts_for_all_procs to hide_sus_mnts_for_non_su_procs

Author: simonpunk <simonpunk2016@gmail.com>
Date:   Tue Jan 20 11:53:55 2026 +0800

- There is no good reason to even hide the sus mounts for su process at all and it makes ReZygisk not able to determine what to umount.

- Now it can prevent zygote itself from caching the sus mounts while at the same time ReZyisk can still see them simply because the job is done by its daemon process which is running with su context.

- So now the scenarios become like this: 1. No Zygisk enabled / ReZygisk enabled but without TreatWheel module => Enable hide_sus_mnts_for_non_su_procs in post-fs-data.sh, then disable hide_sus_mnts_for_non_su_procs in boot-completed.sh or leave it enabled. 2. [Zygisk Next|Rezygisk + TreatWheel|NeoZygisk] enabled => No need to enable/disable hide_sus_mnts_for_non_su_procs since they can handle traces left by zygote already.

** Friendly reminder **
- It is suggested to disable hide_sus_mnts_for_non_su_procs in boot-completed.sh since having it enabled will cause a bit more overheads unless there are sus mounts you do not want them to be umounted but do want them to be just hidden from proc mounts.

-https://gitlab.com/simonpunk/susfs4ksu/-/tree/gki-android14-6.1

KernelSU (susfs (v2.0.0)): Remove duplicated log and changed to a proper log message

Author: simonpunk <simonpunk2016@gmail.com>
Date:   Wed Jan 21 12:56:39 2026 +0800

-https://gitlab.com/simonpunk/susfs4ksu/-/tree/gki-android14-6.1