### PR TITLE
userspace: ksud: susfsd: Add a return code for programmatic use

### DIFF
--- a/userspace/ksud/src/susfsd.rs
+++ b/userspace/ksud/src/susfsd.rs
@@ -1,5 +1,5 @@
 use std::ffi::CStr;
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use libc::{syscall, SYS_reboot, c_char};
 
 // Constants from susfsd.c
@@ -44,16 +44,15 @@ pub fn show_version() -> Result<()> {
         syscall(SYS_reboot, KSU_INSTALL_MAGIC1, SUSFS_MAGIC, CMD_SUSFS_SHOW_VERSION, &mut cmd as *mut _);
     }
 
-    check_unsupported(cmd.err, CMD_SUSFS_SHOW_VERSION);
+    check_unsupported(cmd.err, CMD_SUSFS_SHOW_VERSION)?;
 
     if cmd.err == 0 {
         let version = unsafe { CStr::from_ptr(cmd.version.as_ptr() as *const c_char) }.to_string_lossy();
         println!("{}", version);
+        Ok(())
     } else {
-        println!("Invalid");
+        Err(anyhow!("Invalid (Error: {})", cmd.err))
     }
-
-    Ok(())
 }
 
 pub fn show_variant() -> Result<()> {
@@ -66,15 +65,15 @@ pub fn show_variant() -> Result<()> {
         syscall(SYS_reboot, KSU_INSTALL_MAGIC1, SUSFS_MAGIC, CMD_SUSFS_SHOW_VARIANT, &mut cmd as *mut _);
     }
 
-    check_unsupported(cmd.err, CMD_SUSFS_SHOW_VARIANT);
+    check_unsupported(cmd.err, CMD_SUSFS_SHOW_VARIANT)?;
 
     if cmd.err == 0 {
         let variant = unsafe { CStr::from_ptr(cmd.variant.as_ptr() as *const c_char) }.to_string_lossy();
         println!("{}", variant);
+        Ok(())
     } else {
-        println!("Invalid");
+        Err(anyhow!("Invalid (Error: {})", cmd.err))
     }
-    Ok(())
 }
 
 pub fn show_features(check_only: bool) -> Result<()> {
@@ -87,7 +86,7 @@ pub fn show_features(check_only: bool) -> Result<()> {
         syscall(SYS_reboot, KSU_INSTALL_MAGIC1, SUSFS_MAGIC, CMD_SUSFS_SHOW_ENABLED_FEATURES, &mut cmd as *mut _);
     }
 
-    check_unsupported(cmd.err, CMD_SUSFS_SHOW_ENABLED_FEATURES);
+    check_unsupported(cmd.err, CMD_SUSFS_SHOW_ENABLED_FEATURES)?;
 
     let features_cstr = unsafe { CStr::from_ptr(cmd.features.as_ptr() as *const c_char) };
     let has_features = cmd.err == 0 && !features_cstr.to_bytes().is_empty();
@@ -95,19 +94,21 @@ pub fn show_features(check_only: bool) -> Result<()> {
     if check_only {
         if has_features {
             println!("Supported");
+            Ok(())
         } else {
-            println!("Unsupported");
+            Err(anyhow!("Unsupported"))
         }
     } else if has_features {
         print!("{}", features_cstr.to_string_lossy());
+        Ok(())
     } else {
-        println!("Invalid");
+        Err(anyhow!("Invalid (Error: {})", cmd.err))
     }
-    Ok(())
 }
 
-fn check_unsupported(err: i32, cmd: u64) {
+fn check_unsupported(err: i32, cmd: u64) -> Result<()> {
     if err == ERR_CMD_NOT_SUPPORTED {
-        eprintln!("[-] CMD: '0x{:x}', SUSFS operation not supported, please enable it in kernel", cmd);
+        return Err(anyhow!("CMD: '0x{:x}', SUSFS operation not supported, please enable it in kernel", cmd));
     }
+    Ok(())
 }


### PR DESCRIPTION
-Revert:
 'userspace: ksud: susfsd: only print error instead of return it'
-Use Err for return/logging

```
# ksud susfs support
Supported
# echo $?
0
# ksud susfs version
v2.1.0
# echo $?
0
# ksud susfs variant
GKI
# ksud susfs features | wc -l
9
# echo $?
0

.....

# ksud susfs support
Error: CMD: '0x555e2', SUSFS operation not supported, please enable it in kernel
# echo $?
1
# ksud susfs version
Error: CMD: '0x555e1', SUSFS operation not supported, please enable it in kernel
# echo $?
1
# ksud susfs variant
Error: CMD: '0x555e3', SUSFS operation not supported, please enable it in kernel
# echo $?
1
# ksud susfs features
Error: CMD: '0x555e2', SUSFS operation not supported, please enable it in kernel
# echo $?
1
```

<img width="1068" height="946" alt="Screenshot_20260412-222732" src="https://github.com/user-attachments/assets/3c968c08-f820-4a89-9021-df0cf6cf1ab8" />
<img width="1065" height="752" alt="Screenshot_20260412-220858" src="https://github.com/user-attachments/assets/37820382-fba2-4ece-991b-66888a27fabb" />