### PR TITLE
kernel: throne_tracker: Fix OOB read; replace GFP_ATOMIC flags

### DIFF
--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -115,7 +115,7 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name,
 
 	if (d_type == DT_DIR && my_ctx->depth > 0 &&
 		(my_ctx->stop && !*my_ctx->stop)) {
-		struct data_path *data = kzalloc(sizeof(struct data_path), GFP_ATOMIC);
+		struct data_path *data = kzalloc(sizeof(struct data_path), GFP_KERNEL);
 
 		if (!data) {
 			pr_err("Failed to allocate memory for %s\n", dirpath);
@@ -149,8 +149,7 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name,
 					kfree(pos);
 				}
 			} else {
-				struct apk_path_hash *apk_data =
-					kzalloc(sizeof(struct apk_path_hash), GFP_ATOMIC);
+				struct apk_path_hash *apk_data = kzalloc(sizeof(struct apk_path_hash), GFP_KERNEL);
 				apk_data->hash = hash;
 				apk_data->exists = true;
 				list_add_tail(&apk_data->list, &apk_path_hash_list);
@@ -284,7 +283,7 @@ void track_throne(bool prune_only)
 		}
 		buf[count] = '\0';
 
-		struct uid_data *data = kzalloc(sizeof(struct uid_data), GFP_ATOMIC);
+		struct uid_data *data = kzalloc(sizeof(struct uid_data), GFP_KERNEL);
 		if (!data) {
 			filp_close(fp, 0);
 			goto out;

--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -278,7 +278,11 @@ void track_throne(bool prune_only)
 		if (chr != '\n')
 			continue;
 
-		count = kernel_read(fp, buf, sizeof(buf), &line_start);
+		count = kernel_read(fp, buf, sizeof(buf) - 1, &line_start);
+		if (count <= 0) {
+			break;
+		}
+		buf[count] = '\0';
 
 		struct uid_data *data = kzalloc(sizeof(struct uid_data), GFP_ATOMIC);
 		if (!data) {


### PR DESCRIPTION
```
Author: Wang Han <416810799@qq.com>
Date:   Sun Apr 12 18:05:04 2026 +0800
```

    kernel: Replace GFP_ATOMIC flags in throne tracker

```
Author: Kamenta <st2011_230635@qq.com>
Date:   Sun Apr 12 18:01:14 2026 +0800
```

    kernel: Fix OOB read caused by missing null terminator