### PR TITLE
fix: backport scheduler header for legacy kernel compatibility

### DIFF
--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -6,11 +6,14 @@
 #include <linux/lockdep.h>
 #include <linux/slab.h>
 #include <linux/string.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
+#include <uapi/linux/sched/types.h>
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
 #include <linux/sched/types.h>
+#else
+#include <linux/sched.h>
 #endif
 #include <linux/stop_machine.h>
-#include <uapi/linux/sched/types.h>
 
 #include "uapi/selinux.h"
 #include "klog.h" // IWYU pragma: keep


### PR DESCRIPTION
The header <uapi/linux/sched/types.h> was introduced in Linux 4.13. 
For older kernels, scheduler types like 'struct sched_param' are 
contained within <linux/sched.h>.

This patch adds a version check to include the correct header based 
on the kernel version, preventing "file not found" errors during 
compilation on legacy 4.9 branches.