### PR TITLE
Remove section overriding susfs_add_try_umount

### DIFF
--- a/kernel/supercall/supercall.c
+++ b/kernel/supercall/supercall.c
@@ -25,31 +25,6 @@
 
 #include "tiny_sulog.h"
 
-#ifdef CONFIG_KSU_SUSFS_TRY_UMOUNT
-
-#ifndef __weak
-#define __weak __attribute__((weak))
-#endif
-
-__weak void ksu_handle_umount(uid_t old_uid, uid_t new_uid)
-{
-    (void)old_uid;
-    (void)new_uid;
-}
-
-void susfs_try_umount(uid_t new_uid)
-{
-    uid_t old_uid = current_uid().val;
-    ksu_handle_umount(old_uid, new_uid);
-}
-
-int susfs_add_try_umount(void __user *arg)
-{
-    return 0;
-}
-
-#endif
-
 uint32_t ksuver_override = 0;
 
 static int anon_ksu_release(struct inode *inode, struct file *filp)


### PR DESCRIPTION
This section seems to be an attempt to make susfs_add_try_imount behave like ksu umount, I guess in case the user doesn't have the required code for this function on the kernel side.

Otherwise, this commit seems to implement this branch of the driver by @sidex15  https://github.com/sidex15/KernelSU-Next/tree/legacy-susfs-v2

However, if the user does have the kernel side code, then compilation fails because of an incompatible declaration in the included susfs.h file, specifically:

void susfs_add_try_umount(void __user **user_info)

Also, as legacy SUSFS is officially deprecated then the user will have had to seek out kernel side backports to implement it at all (not just this function), and the main source for this seems to be sidex15's work.

As such, I think it likely anyone using this will have the necessary kernel side code to support this function and so given it currently breaks compilation for those that do have the code, and given that I can't think of many users who would need this, I propose removing it?