### PR TITLE
feature: selinux hide; fix attr/current detection (https://github.com/tiann/KernelSU/pull/3457; https://github.com/tiann/KernelSU/pull/3459)

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -44,6 +44,8 @@ kernelsu-objs += supercall/dispatch.o
 kernelsu-objs += supercall/perm.o
 kernelsu-objs += supercall/supercall.o
 
+kernelsu-objs += feature/selinux_hide.o
+
 ifdef KBUILD_EXTMOD
 ifeq ($(CONFIG_KSU_DISABLE_MANAGER),y)
 ccflags-y += -DCONFIG_KSU_DISABLE_MANAGER=1

--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -13,6 +13,7 @@
 #include "manager/manager_observer.h"
 #include "manager/throne_tracker.h"
 #include "hook/syscall_hook_manager.h"
+#include "hook/lsm_hook.h"
 #include "runtime/ksud.h"
 #include "runtime/ksud_boot.h"
 #include "supercall/supercall.h"
@@ -123,6 +124,8 @@ int __init kernelsu_init(void)
 
 	ksu_feature_init();
 
+	ksu_lsm_hook_init();
+
 	ksu_selinux_hide_init();
 
 	ksu_supercalls_init();
@@ -197,6 +200,8 @@ void __exit kernelsu_exit(void)
 	ksu_allowlist_exit();
 
 	ksu_selinux_hide_exit();
+
+	ksu_lsm_hook_exit();
 
 	ksu_feature_exit();
 

--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -20,6 +20,7 @@
 #include "infra/file_wrapper.h"
 #include "selinux/selinux.h"
 #include "hook/syscall_hook.h"
+#include "feature/selinux_hide.h"
 
 #if defined(__x86_64__)
 #include <asm/cpufeature.h>
@@ -122,6 +123,8 @@ int __init kernelsu_init(void)
 
 	ksu_feature_init();
 
+	ksu_selinux_hide_init();
+
 	ksu_supercalls_init();
 
 	if (ksu_late_loaded) {
@@ -192,6 +195,8 @@ void __exit kernelsu_exit(void)
 	ksu_throne_tracker_exit();
 
 	ksu_allowlist_exit();
+
+	ksu_selinux_hide_exit();
 
 	ksu_feature_exit();
 

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -1,0 +1,952 @@
+#include "selinux_hide.h"
+#include "selinux/sepolicy.h"
+#include <linux/cred.h>
+#include <linux/cpu.h>
+#include <linux/memory.h>
+#include <linux/uaccess.h>
+#include <linux/init.h>
+#include <linux/printk.h>
+#include <linux/string.h>
+#include <linux/fs.h>
+#include <asm-generic/errno-base.h>
+#include <net/genetlink.h>
+#include <linux/moduleparam.h>
+#include <linux/mutex.h>
+// security/selinux/include/security.h
+#include <security.h>
+#include <ss/context.h>
+#include <ss/services.h>
+#include <ss/mls.h>
+#include <ss/conditional.h>
+#include "avc.h"
+#include "klog.h" // IWYU pragma: keep
+#include "linux/kallsyms.h"
+#include "objsec.h"
+#include "hook/patch_memory.h"
+#include "ksu.h"
+#include "policy/feature.h"
+
+enum sel_inos {
+    SEL_ROOT_INO = 2,
+    SEL_LOAD, /* load policy */
+    SEL_ENFORCE, /* get or set enforcing status */
+    SEL_CONTEXT, /* validate context */
+    SEL_ACCESS, /* compute access decision */
+    SEL_CREATE, /* compute create labeling decision */
+    SEL_RELABEL, /* compute relabeling decision */
+    SEL_USER, /* compute reachable user contexts */
+    SEL_POLICYVERS, /* return policy version for this kernel */
+    SEL_COMMIT_BOOLS, /* commit new boolean values */
+    SEL_MLS, /* return if MLS policy is enabled */
+    SEL_DISABLE, /* disable SELinux until next reboot */
+    SEL_MEMBER, /* compute polyinstantiation membership decision */
+    SEL_CHECKREQPROT, /* check requested protection, not kernel-applied one */
+    SEL_COMPAT_NET, /* whether to use old compat network packet controls */
+    SEL_REJECT_UNKNOWN, /* export unknown reject handling to userspace */
+    SEL_DENY_UNKNOWN, /* export unknown deny handling to userspace */
+    SEL_STATUS, /* export current status using mmap() */
+    SEL_POLICY, /* allow userspace to read the in kernel policy */
+    SEL_VALIDATE_TRANS, /* compute validatetrans decision */
+    SEL_INO_NEXT, /* The next inode number to use */
+};
+
+typedef ssize_t (*write_op_fn)(struct file *, char *, size_t);
+
+static write_op_fn *selinux_write_op;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+static int security_context_to_sid_with_policy(struct selinux_policy *policy, const char *scontext, u32 scontext_len,
+                                               u32 *sid, u32 def_sid, gfp_t gfp_flags);
+static int security_sid_to_context_with_policy(struct selinux_policy *policy, u32 sid, char **scontext,
+                                               u32 *scontext_len);
+static void security_compute_av_user_with_policy(struct selinux_policy *policy, u32 ssid, u32 tsid, u16 tclass,
+                                                 struct av_decision *avd);
+static void (*security_dump_masked_av_fn)(struct policydb *policydb, struct context *scontext, struct context *tcontext,
+                                          u16 tclass, u32 permissions, const char *reason) = NULL;
+static void (*context_struct_compute_av_fn)(struct policydb *policydb, struct context *scontext,
+                                            struct context *tcontext, u16 tclass, struct av_decision *avd,
+                                            struct extended_perms *xperms) = NULL;
+#else
+static struct selinux_state fake_state;
+#endif
+
+static write_op_fn *context_write, *access_write;
+static write_op_fn orig_context_write, orig_access_write;
+
+static ssize_t my_write_context(struct file *file, char *buf, size_t size)
+{
+    // apply to all app uids
+    if (likely(current_uid().val < 10000)) {
+        return orig_context_write(file, buf, size);
+    }
+    char *canon = NULL;
+    u32 sid, len;
+    ssize_t length;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+    length = avc_has_perm(current_sid(), SECINITSID_SECURITY, SECCLASS_SECURITY, SECURITY__CHECK_CONTEXT, NULL);
+    if (length)
+        goto out;
+    length = security_context_to_sid_with_policy(backup_sepolicy, buf, size, &sid, SECSID_NULL, GFP_KERNEL);
+    if (length)
+        goto out;
+
+    length = security_sid_to_context_with_policy(backup_sepolicy, sid, &canon, &len);
+    if (length)
+        goto out;
+
+    length = -ERANGE;
+    if (len > SIMPLE_TRANSACTION_LIMIT) {
+        pr_err("SELinux: %s:  context size (%u) exceeds "
+               "payload max\n",
+               __func__, len);
+        goto out;
+    }
+#else
+    length = avc_has_perm(&selinux_state, current_sid(), SECINITSID_SECURITY, SECCLASS_SECURITY,
+                          SECURITY__CHECK_CONTEXT, NULL);
+    if (length)
+        goto out;
+
+    length = security_context_to_sid(&fake_state, buf, size, &sid, GFP_KERNEL);
+    if (length)
+        goto out;
+
+    length = security_sid_to_context(&fake_state, sid, &canon, &len);
+    if (length)
+        goto out;
+#endif
+
+    memcpy(buf, canon, len);
+    length = len;
+out:
+    kfree(canon);
+    return length;
+}
+
+static ssize_t my_write_access(struct file *file, char *buf, size_t size)
+{
+    // apply to all app uids
+    if (likely(current_uid().val < 10000)) {
+        return orig_access_write(file, buf, size);
+    }
+    char *scon = NULL, *tcon = NULL;
+    u32 ssid, tsid;
+    u16 tclass;
+    struct av_decision avd;
+    ssize_t length;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+    length = avc_has_perm(current_sid(), SECINITSID_SECURITY, SECCLASS_SECURITY, SECURITY__COMPUTE_AV, NULL);
+#else
+    length =
+        avc_has_perm(&selinux_state, current_sid(), SECINITSID_SECURITY, SECCLASS_SECURITY, SECURITY__COMPUTE_AV, NULL);
+#endif
+    if (length)
+        goto out;
+
+    length = -ENOMEM;
+    scon = kzalloc(size + 1, GFP_KERNEL);
+    if (!scon)
+        goto out;
+
+    length = -ENOMEM;
+    tcon = kzalloc(size + 1, GFP_KERNEL);
+    if (!tcon)
+        goto out;
+
+    length = -EINVAL;
+    if (sscanf(buf, "%s %s %hu", scon, tcon, &tclass) != 3)
+        goto out;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+    length = security_context_to_sid_with_policy(backup_sepolicy, scon, strlen(scon), &ssid, SECSID_NULL, GFP_KERNEL);
+    if (length)
+        goto out;
+
+    length = security_context_to_sid_with_policy(backup_sepolicy, tcon, strlen(tcon), &tsid, SECSID_NULL, GFP_KERNEL);
+    if (length)
+        goto out;
+
+    security_compute_av_user_with_policy(backup_sepolicy, ssid, tsid, tclass, &avd);
+#else
+    length = security_context_str_to_sid(&fake_state, scon, &ssid, GFP_KERNEL);
+    if (length)
+        goto out;
+
+    length = security_context_str_to_sid(&fake_state, tcon, &tsid, GFP_KERNEL);
+    if (length)
+        goto out;
+
+    security_compute_av_user(&fake_state, ssid, tsid, tclass, &avd);
+#endif
+
+    length = scnprintf(buf, SIMPLE_TRANSACTION_LIMIT, "%x %x %x %x %u %x", avd.allowed, 0xffffffff, avd.auditallow,
+                       avd.auditdeny, avd.seqno, avd.flags);
+out:
+    kfree(tcon);
+    kfree(scon);
+    return length;
+}
+
+static void ksu_selinux_hide_unhook();
+static int ksu_selinux_hide_enable()
+{
+    int ret;
+    pr_info("selinux_hide: init selinux hide\n");
+    if (!backup_sepolicy) {
+        pr_err("no backup sepolicy available, please save feature and reboot to retry!\n");
+        return -EAGAIN;
+    }
+    selinux_write_op = kallsyms_lookup_name("write_op");
+    if (!selinux_write_op) {
+        pr_err("selinux_hide: no write_op found!\n");
+        return -ENOSYS;
+    }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+    security_dump_masked_av_fn = kallsyms_lookup_name("security_dump_masked_av");
+    if (!security_dump_masked_av_fn) {
+        pr_warn("security_dump_masked_av not found!\n");
+    }
+    context_struct_compute_av_fn = kallsyms_lookup_name("context_struct_compute_av");
+    if (!context_struct_compute_av_fn) {
+        pr_warn("context_struct_compute_av not found!\n");
+    }
+#else
+    fake_state.initialized = true;
+    fake_state.policy = backup_sepolicy;
+#endif
+
+    context_write = &selinux_write_op[SEL_CONTEXT];
+    pr_info("selinux_hide: context_write: 0x%lx [%pSb]\n", (unsigned long)*context_write, *context_write);
+    write_op_fn my = my_write_context;
+    orig_context_write = *context_write;
+    ret = ksu_patch_text(context_write, &my, sizeof(my), KSU_PATCH_TEXT_FLUSH_DCACHE);
+    if (ret) {
+        pr_err("selinux_hide: init: patch_text context_write err: %d\n", ret);
+        goto unhook;
+    }
+
+    access_write = &selinux_write_op[SEL_ACCESS];
+    pr_info("selinux_hide: access_write: 0x%lx [%pSb]\n", (unsigned long)*access_write, *access_write);
+    my = my_write_access;
+    orig_access_write = *access_write;
+    ret = ksu_patch_text(access_write, &my, sizeof(my), KSU_PATCH_TEXT_FLUSH_DCACHE);
+    if (ret) {
+        pr_err("selinux_hide: init: patch_text access_write err: %d\n", ret);
+        goto unhook;
+    }
+
+    return 0;
+
+unhook:
+    ksu_selinux_hide_unhook();
+    return -ENOSYS;
+}
+
+static void ksu_selinux_hide_unhook()
+{
+    int ret;
+    if (orig_context_write) {
+        ret =
+            ksu_patch_text(context_write, &orig_context_write, sizeof(orig_context_write), KSU_PATCH_TEXT_FLUSH_DCACHE);
+        orig_context_write = NULL;
+        if (ret) {
+            pr_err("selinux_hide: exit: patch_text context_write err: %d\n", ret);
+        }
+    }
+    if (orig_access_write) {
+        ret = ksu_patch_text(access_write, &orig_access_write, sizeof(orig_access_write), KSU_PATCH_TEXT_FLUSH_DCACHE);
+        orig_access_write = NULL;
+        if (ret) {
+            pr_err("selinux_hide: exit: patch_text access_write err: %d\n", ret);
+        }
+    }
+}
+
+static void ksu_selinux_hide_disable()
+{
+    pr_info("selinux_hide: exit selinux hide\n");
+    ksu_selinux_hide_unhook();
+}
+
+static DEFINE_MUTEX(selinux_hide_mutex);
+static bool ksu_selinux_hide_enabled __read_mostly = false;
+static bool ksu_selinux_hide_running __read_mostly = false;
+
+static int selinux_hide_feature_get(u64 *value)
+{
+    *value = ksu_selinux_hide_enabled ? 1 : 0;
+    return 0;
+}
+
+static int selinux_hide_feature_set(u64 value)
+{
+    bool enable = value != 0;
+    int ret = 0;
+    pr_info("selinux_hide: set to %d\n", enable);
+    mutex_lock(&selinux_hide_mutex);
+    ksu_selinux_hide_enabled = enable;
+    if (enable) {
+        if (!ksu_selinux_hide_running) {
+            ret = ksu_selinux_hide_enable();
+            if (!ret) {
+                ksu_selinux_hide_running = true;
+            }
+        }
+    } else {
+        if (ksu_selinux_hide_running) {
+            ksu_selinux_hide_disable();
+            ksu_selinux_hide_running = false;
+        }
+    }
+    mutex_unlock(&selinux_hide_mutex);
+    return ret;
+}
+
+static const struct ksu_feature_handler selinux_hide_handler = {
+    .feature_id = KSU_FEATURE_SELINUX_HIDE,
+    .name = "selinux_hide",
+    .get_handler = selinux_hide_feature_get,
+    .set_handler = selinux_hide_feature_set,
+};
+
+void __init ksu_selinux_hide_init()
+{
+    if (ksu_register_feature_handler(&selinux_hide_handler)) {
+        pr_err("Failed to register selinux_hide feature handler\n");
+    }
+}
+
+void __exit ksu_selinux_hide_exit()
+{
+    mutex_lock(&selinux_hide_mutex);
+    if (ksu_selinux_hide_running) {
+        ksu_selinux_hide_disable();
+        ksu_selinux_hide_running = false;
+    }
+    mutex_unlock(&selinux_hide_mutex);
+    ksu_unregister_feature_handler(KSU_FEATURE_SELINUX_HIDE);
+}
+
+void ksu_selinux_hide_drop_backup_if_unused()
+{
+    mutex_lock(&selinux_hide_mutex);
+    if (!ksu_selinux_hide_running && backup_sepolicy) {
+        pr_info("selinux_hide is not enabled - drop backup_sepolicy\n");
+        sidtab_destroy(backup_sepolicy->sidtab);
+        kfree(backup_sepolicy->sidtab);
+        ksu_destroy_sepolicy(backup_sepolicy);
+        backup_sepolicy = NULL;
+    }
+    mutex_unlock(&selinux_hide_mutex);
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+/*
+ * Caveat:  Mutates scontext.
+ */
+static int string_to_context_struct(struct policydb *pol, struct sidtab *sidtabp, char *scontext, struct context *ctx,
+                                    u32 def_sid)
+{
+    struct role_datum *role;
+    struct type_datum *typdatum;
+    struct user_datum *usrdatum;
+    char *scontextp, *p, oldc;
+    int rc = 0;
+
+    context_init(ctx);
+
+    /* Parse the security context. */
+
+    rc = -EINVAL;
+    scontextp = scontext;
+
+    /* Extract the user. */
+    p = scontextp;
+    while (*p && *p != ':')
+        p++;
+
+    if (*p == 0)
+        goto out;
+
+    *p++ = 0;
+
+    usrdatum = symtab_search(&pol->p_users, scontextp);
+    if (!usrdatum)
+        goto out;
+
+    ctx->user = usrdatum->value;
+
+    /* Extract role. */
+    scontextp = p;
+    while (*p && *p != ':')
+        p++;
+
+    if (*p == 0)
+        goto out;
+
+    *p++ = 0;
+
+    role = symtab_search(&pol->p_roles, scontextp);
+    if (!role)
+        goto out;
+    ctx->role = role->value;
+
+    /* Extract type. */
+    scontextp = p;
+    while (*p && *p != ':')
+        p++;
+    oldc = *p;
+    *p++ = 0;
+
+    typdatum = symtab_search(&pol->p_types, scontextp);
+    if (!typdatum || typdatum->attribute)
+        goto out;
+
+    ctx->type = typdatum->value;
+
+    rc = mls_context_to_sid(pol, oldc, p, ctx, sidtabp, def_sid);
+    if (rc)
+        goto out;
+
+    /* Check the validity of the new context. */
+    rc = -EINVAL;
+    if (!policydb_context_isvalid(pol, ctx))
+        goto out;
+    rc = 0;
+out:
+    if (rc)
+        context_destroy(ctx);
+    return rc;
+}
+
+static int security_context_to_sid_with_policy(struct selinux_policy *policy, const char *scontext, u32 scontext_len,
+                                               u32 *sid, u32 def_sid, gfp_t gfp_flags)
+{
+    struct policydb *policydb;
+    struct sidtab *sidtab;
+    char *scontext2, *str = NULL;
+    struct context context;
+    int rc = 0;
+
+    /* An empty security context is never valid. */
+    if (!scontext_len)
+        return -EINVAL;
+
+    /* Copy the string to allow changes and ensure a NUL terminator */
+    scontext2 = kmemdup_nul(scontext, scontext_len, gfp_flags);
+    if (!scontext2)
+        return -ENOMEM;
+
+    // removed: if (!selinux_initialized())
+    *sid = SECSID_NULL;
+
+    // removed: if (force)
+    // removed: rcu lock
+    policydb = &policy->policydb;
+    sidtab = policy->sidtab;
+    rc = string_to_context_struct(policydb, sidtab, scontext2, &context, def_sid);
+    if (rc)
+        goto out;
+    rc = sidtab_context_to_sid(sidtab, &context, sid);
+    // rc should not be frozen
+    if (rc)
+        goto out;
+    // removed: if (rc == -ESTALE)
+    context_destroy(&context);
+out:
+    kfree(scontext2);
+    kfree(str);
+    return rc;
+}
+
+/*
+ * Write the security context string representation of
+ * the context structure `context' into a dynamically
+ * allocated string of the correct size.  Set `*scontext'
+ * to point to this string and set `*scontext_len' to
+ * the length of the string.
+ */
+static int context_struct_to_string(struct policydb *p, struct context *context, char **scontext, u32 *scontext_len)
+{
+    char *scontextp;
+
+    if (scontext)
+        *scontext = NULL;
+    *scontext_len = 0;
+
+    if (context->len) {
+        *scontext_len = context->len;
+        if (scontext) {
+            *scontext = kstrdup(context->str, GFP_ATOMIC);
+            if (!(*scontext))
+                return -ENOMEM;
+        }
+        return 0;
+    }
+
+    /* Compute the size of the context. */
+    *scontext_len += strlen(sym_name(p, SYM_USERS, context->user - 1)) + 1;
+    *scontext_len += strlen(sym_name(p, SYM_ROLES, context->role - 1)) + 1;
+    *scontext_len += strlen(sym_name(p, SYM_TYPES, context->type - 1)) + 1;
+    *scontext_len += mls_compute_context_len(p, context);
+
+    if (!scontext)
+        return 0;
+
+    /* Allocate space for the context; caller must free this space. */
+    scontextp = kmalloc(*scontext_len, GFP_ATOMIC);
+    if (!scontextp)
+        return -ENOMEM;
+    *scontext = scontextp;
+
+    /*
+     * Copy the user name, role name and type name into the context.
+     */
+    scontextp += sprintf(scontextp, "%s:%s:%s", sym_name(p, SYM_USERS, context->user - 1),
+                         sym_name(p, SYM_ROLES, context->role - 1), sym_name(p, SYM_TYPES, context->type - 1));
+
+    mls_sid_to_context(p, context, &scontextp);
+
+    *scontextp = 0;
+
+    return 0;
+}
+
+static int sidtab_entry_to_string(struct policydb *p, struct sidtab *sidtab, struct sidtab_entry *entry,
+                                  char **scontext, u32 *scontext_len)
+{
+    int rc = sidtab_sid2str_get(sidtab, entry, scontext, scontext_len);
+
+    if (rc != -ENOENT)
+        return rc;
+
+    rc = context_struct_to_string(p, &entry->context, scontext, scontext_len);
+    if (!rc && scontext)
+        sidtab_sid2str_put(sidtab, entry, *scontext, *scontext_len);
+    return rc;
+}
+
+static int security_sid_to_context_with_policy(struct selinux_policy *policy, u32 sid, char **scontext,
+                                               u32 *scontext_len)
+{
+    struct policydb *policydb;
+    struct sidtab *sidtab;
+    struct sidtab_entry *entry;
+    int rc = 0;
+
+    if (scontext)
+        *scontext = NULL;
+    *scontext_len = 0;
+
+    // removed: if (!selinux_initialized())
+    // removed: rcu lock
+    policydb = &policy->policydb;
+    sidtab = policy->sidtab;
+
+    // removed: force
+    entry = sidtab_search_entry(sidtab, sid);
+    if (!entry) {
+        pr_err("SELinux: %s:  unrecognized SID %d\n", __func__, sid);
+        rc = -EINVAL;
+        goto out_unlock;
+    }
+    // removed: only_invalid
+
+    rc = sidtab_entry_to_string(policydb, sidtab, entry, scontext, scontext_len);
+
+out_unlock:
+    return rc;
+}
+
+static void avd_init(struct selinux_policy *policy, struct av_decision *avd)
+{
+    avd->allowed = 0;
+    avd->auditallow = 0;
+    avd->auditdeny = 0xffffffff;
+    if (policy)
+        avd->seqno = policy->latest_granting;
+    else
+        avd->seqno = 0;
+    avd->flags = 0;
+}
+
+static void context_struct_compute_av(struct policydb *policydb, struct context *scontext, struct context *tcontext,
+                                      u16 tclass, struct av_decision *avd, struct extended_perms *xperms);
+
+/*
+ * security_boundary_permission - drops violated permissions
+ * on boundary constraint.
+ */
+static void __nocfi type_attribute_bounds_av(struct policydb *policydb, struct context *scontext,
+                                             struct context *tcontext, u16 tclass, struct av_decision *avd)
+{
+    struct context lo_scontext;
+    struct context lo_tcontext, *tcontextp = tcontext;
+    struct av_decision lo_avd;
+    struct type_datum *source;
+    struct type_datum *target;
+    u32 masked = 0;
+
+    source = policydb->type_val_to_struct[scontext->type - 1];
+    BUG_ON(!source);
+
+    if (!source->bounds)
+        return;
+
+    target = policydb->type_val_to_struct[tcontext->type - 1];
+    BUG_ON(!target);
+
+    memset(&lo_avd, 0, sizeof(lo_avd));
+
+    memcpy(&lo_scontext, scontext, sizeof(lo_scontext));
+    lo_scontext.type = source->bounds;
+
+    if (target->bounds) {
+        memcpy(&lo_tcontext, tcontext, sizeof(lo_tcontext));
+        lo_tcontext.type = target->bounds;
+        tcontextp = &lo_tcontext;
+    }
+
+    context_struct_compute_av(policydb, &lo_scontext, tcontextp, tclass, &lo_avd, NULL);
+
+    masked = ~lo_avd.allowed & avd->allowed;
+
+    if (likely(!masked))
+        return; /* no masked permission */
+
+    /* mask violated permissions */
+    avd->allowed &= ~masked;
+
+    /* audit masked permissions */
+    if (security_dump_masked_av_fn)
+        security_dump_masked_av_fn(policydb, scontext, tcontext, tclass, masked, "bounds");
+}
+
+/*
+ * Return the boolean value of a constraint expression
+ * when it is applied to the specified source and target
+ * security contexts.
+ *
+ * xcontext is a special beast...  It is used by the validatetrans rules
+ * only.  For these rules, scontext is the context before the transition,
+ * tcontext is the context after the transition, and xcontext is the context
+ * of the process performing the transition.  All other callers of
+ * constraint_expr_eval should pass in NULL for xcontext.
+ */
+static int constraint_expr_eval(struct policydb *policydb, struct context *scontext, struct context *tcontext,
+                                struct context *xcontext, struct constraint_expr *cexpr)
+{
+    u32 val1, val2;
+    struct context *c;
+    struct role_datum *r1, *r2;
+    struct mls_level *l1, *l2;
+    struct constraint_expr *e;
+    int s[CEXPR_MAXDEPTH];
+    int sp = -1;
+
+    for (e = cexpr; e; e = e->next) {
+        switch (e->expr_type) {
+        case CEXPR_NOT:
+            BUG_ON(sp < 0);
+            s[sp] = !s[sp];
+            break;
+        case CEXPR_AND:
+            BUG_ON(sp < 1);
+            sp--;
+            s[sp] &= s[sp + 1];
+            break;
+        case CEXPR_OR:
+            BUG_ON(sp < 1);
+            sp--;
+            s[sp] |= s[sp + 1];
+            break;
+        case CEXPR_ATTR:
+            if (sp == (CEXPR_MAXDEPTH - 1))
+                return 0;
+            switch (e->attr) {
+            case CEXPR_USER:
+                val1 = scontext->user;
+                val2 = tcontext->user;
+                break;
+            case CEXPR_TYPE:
+                val1 = scontext->type;
+                val2 = tcontext->type;
+                break;
+            case CEXPR_ROLE:
+                val1 = scontext->role;
+                val2 = tcontext->role;
+                r1 = policydb->role_val_to_struct[val1 - 1];
+                r2 = policydb->role_val_to_struct[val2 - 1];
+                switch (e->op) {
+                case CEXPR_DOM:
+                    s[++sp] = ebitmap_get_bit(&r1->dominates, val2 - 1);
+                    continue;
+                case CEXPR_DOMBY:
+                    s[++sp] = ebitmap_get_bit(&r2->dominates, val1 - 1);
+                    continue;
+                case CEXPR_INCOMP:
+                    s[++sp] =
+                        (!ebitmap_get_bit(&r1->dominates, val2 - 1) && !ebitmap_get_bit(&r2->dominates, val1 - 1));
+                    continue;
+                default:
+                    break;
+                }
+                break;
+            case CEXPR_L1L2:
+                l1 = &(scontext->range.level[0]);
+                l2 = &(tcontext->range.level[0]);
+                goto mls_ops;
+            case CEXPR_L1H2:
+                l1 = &(scontext->range.level[0]);
+                l2 = &(tcontext->range.level[1]);
+                goto mls_ops;
+            case CEXPR_H1L2:
+                l1 = &(scontext->range.level[1]);
+                l2 = &(tcontext->range.level[0]);
+                goto mls_ops;
+            case CEXPR_H1H2:
+                l1 = &(scontext->range.level[1]);
+                l2 = &(tcontext->range.level[1]);
+                goto mls_ops;
+            case CEXPR_L1H1:
+                l1 = &(scontext->range.level[0]);
+                l2 = &(scontext->range.level[1]);
+                goto mls_ops;
+            case CEXPR_L2H2:
+                l1 = &(tcontext->range.level[0]);
+                l2 = &(tcontext->range.level[1]);
+                goto mls_ops;
+            mls_ops:
+                switch (e->op) {
+                case CEXPR_EQ:
+                    s[++sp] = mls_level_eq(l1, l2);
+                    continue;
+                case CEXPR_NEQ:
+                    s[++sp] = !mls_level_eq(l1, l2);
+                    continue;
+                case CEXPR_DOM:
+                    s[++sp] = mls_level_dom(l1, l2);
+                    continue;
+                case CEXPR_DOMBY:
+                    s[++sp] = mls_level_dom(l2, l1);
+                    continue;
+                case CEXPR_INCOMP:
+                    s[++sp] = mls_level_incomp(l2, l1);
+                    continue;
+                default:
+                    BUG();
+                    return 0;
+                }
+                break;
+            default:
+                BUG();
+                return 0;
+            }
+
+            switch (e->op) {
+            case CEXPR_EQ:
+                s[++sp] = (val1 == val2);
+                break;
+            case CEXPR_NEQ:
+                s[++sp] = (val1 != val2);
+                break;
+            default:
+                BUG();
+                return 0;
+            }
+            break;
+        case CEXPR_NAMES:
+            if (sp == (CEXPR_MAXDEPTH - 1))
+                return 0;
+            c = scontext;
+            if (e->attr & CEXPR_TARGET)
+                c = tcontext;
+            else if (e->attr & CEXPR_XTARGET) {
+                c = xcontext;
+                if (!c) {
+                    BUG();
+                    return 0;
+                }
+            }
+            if (e->attr & CEXPR_USER)
+                val1 = c->user;
+            else if (e->attr & CEXPR_ROLE)
+                val1 = c->role;
+            else if (e->attr & CEXPR_TYPE)
+                val1 = c->type;
+            else {
+                BUG();
+                return 0;
+            }
+
+            switch (e->op) {
+            case CEXPR_EQ:
+                s[++sp] = ebitmap_get_bit(&e->names, val1 - 1);
+                break;
+            case CEXPR_NEQ:
+                s[++sp] = !ebitmap_get_bit(&e->names, val1 - 1);
+                break;
+            default:
+                BUG();
+                return 0;
+            }
+            break;
+        default:
+            BUG();
+            return 0;
+        }
+    }
+
+    BUG_ON(sp != 0);
+    return s[0];
+}
+
+/*
+ * Compute access vectors and extended permissions based on a context
+ * structure pair for the permissions in a particular class.
+ */
+static void context_struct_compute_av(struct policydb *policydb, struct context *scontext, struct context *tcontext,
+                                      u16 tclass, struct av_decision *avd, struct extended_perms *xperms)
+{
+    struct constraint_node *constraint;
+    struct role_allow *ra;
+    struct avtab_key avkey;
+    struct avtab_node *node;
+    struct class_datum *tclass_datum;
+    struct ebitmap *sattr, *tattr;
+    struct ebitmap_node *snode, *tnode;
+    unsigned int i, j;
+
+    avd->allowed = 0;
+    avd->auditallow = 0;
+    avd->auditdeny = 0xffffffff;
+    if (xperms) {
+        memset(&xperms->drivers, 0, sizeof(xperms->drivers));
+        xperms->len = 0;
+    }
+
+    if (unlikely(!tclass || tclass > policydb->p_classes.nprim)) {
+        pr_warn_ratelimited("SELinux:  Invalid class %u\n", tclass);
+        return;
+    }
+
+    tclass_datum = policydb->class_val_to_struct[tclass - 1];
+
+    /*
+     * If a specific type enforcement rule was defined for
+     * this permission check, then use it.
+     */
+    avkey.target_class = tclass;
+    avkey.specified = AVTAB_AV | AVTAB_XPERMS;
+    sattr = &policydb->type_attr_map_array[scontext->type - 1];
+    tattr = &policydb->type_attr_map_array[tcontext->type - 1];
+    ebitmap_for_each_positive_bit(sattr, snode, i)
+    {
+        ebitmap_for_each_positive_bit(tattr, tnode, j)
+        {
+            avkey.source_type = i + 1;
+            avkey.target_type = j + 1;
+            for (node = avtab_search_node(&policydb->te_avtab, &avkey); node;
+                 node = avtab_search_node_next(node, avkey.specified)) {
+                if (node->key.specified == AVTAB_ALLOWED)
+                    avd->allowed |= node->datum.u.data;
+                else if (node->key.specified == AVTAB_AUDITALLOW)
+                    avd->auditallow |= node->datum.u.data;
+                else if (node->key.specified == AVTAB_AUDITDENY)
+                    avd->auditdeny &= node->datum.u.data;
+                else if (xperms && (node->key.specified & AVTAB_XPERMS))
+                    services_compute_xperms_drivers(xperms, node);
+            }
+
+            /* Check conditional av table for additional permissions */
+            cond_compute_av(&policydb->te_cond_avtab, &avkey, avd, xperms);
+        }
+    }
+
+    /*
+     * Remove any permissions prohibited by a constraint (this includes
+     * the MLS policy).
+     */
+    constraint = tclass_datum->constraints;
+    while (constraint) {
+        if ((constraint->permissions & (avd->allowed)) &&
+            !constraint_expr_eval(policydb, scontext, tcontext, NULL, constraint->expr)) {
+            avd->allowed &= ~(constraint->permissions);
+        }
+        constraint = constraint->next;
+    }
+
+    /*
+     * If checking process transition permission and the
+     * role is changing, then check the (current_role, new_role)
+     * pair.
+     */
+    if (tclass == policydb->process_class && (avd->allowed & policydb->process_trans_perms) &&
+        scontext->role != tcontext->role) {
+        for (ra = policydb->role_allow; ra; ra = ra->next) {
+            if (scontext->role == ra->role && tcontext->role == ra->new_role)
+                break;
+        }
+        if (!ra)
+            avd->allowed &= ~policydb->process_trans_perms;
+    }
+
+    /*
+     * If the given source and target types have boundary
+     * constraint, lazy checks have to mask any violated
+     * permission and notice it to userspace via audit.
+     */
+    type_attribute_bounds_av(policydb, scontext, tcontext, tclass, avd);
+}
+
+static void __nocfi security_compute_av_user_with_policy(struct selinux_policy *policy, u32 ssid, u32 tsid, u16 tclass,
+                                                         struct av_decision *avd)
+{
+    struct policydb *policydb;
+    struct sidtab *sidtab;
+    struct context *scontext = NULL, *tcontext = NULL;
+
+    // remove: rcu lock
+    avd_init(policy, avd);
+    // remove: if (!selinux_initialized())
+
+    policydb = &policy->policydb;
+    sidtab = policy->sidtab;
+
+    scontext = sidtab_search(sidtab, ssid);
+    if (!scontext) {
+        pr_err("SELinux: %s:  unrecognized SID %d\n", __func__, ssid);
+        goto out;
+    }
+
+    /* permissive domain? */
+    if (ebitmap_get_bit(&policydb->permissive_map, scontext->type))
+        avd->flags |= AVD_FLAGS_PERMISSIVE;
+
+    tcontext = sidtab_search(sidtab, tsid);
+    if (!tcontext) {
+        pr_err("SELinux: %s:  unrecognized SID %d\n", __func__, tsid);
+        goto out;
+    }
+
+    if (unlikely(!tclass)) {
+        if (policydb->allow_unknown)
+            goto allow;
+        goto out;
+    }
+
+    if (context_struct_compute_av_fn) {
+        context_struct_compute_av_fn(policydb, scontext, tcontext, tclass, avd, NULL);
+    } else {
+        context_struct_compute_av(policydb, scontext, tcontext, tclass, avd, NULL);
+    }
+out:
+    return;
+allow:
+    avd->allowed = 0xffffffff;
+    goto out;
+}
+#endif

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -25,6 +25,7 @@
 #include "hook/patch_memory.h"
 #include "ksu.h"
 #include "policy/feature.h"
+#include "hook/lsm_hook.h"
 
 enum sel_inos {
     SEL_ROOT_INO = 2,
@@ -189,6 +190,52 @@ out:
     return length;
 }
 
+static int my_setprocattr(const char *name, void *value, size_t size);
+struct ksu_lsm_hook selinux_setprocattr_hook = KSU_LSM_HOOK_INIT(setprocattr, "selinux_setprocattr", my_setprocattr, 0);
+
+typedef int (*setprocattr_fn)(const char *name, void *value, size_t size);
+static int __nocfi my_setprocattr(const char *name, void *value, size_t size)
+{
+    int error;
+    u32 mysid, sid;
+    char *str = value;
+    if (likely(current_uid().val < 10000)) {
+        goto call_orig;
+    }
+
+    if (strcmp(name, "current")) {
+        goto call_orig;
+    }
+    mysid = current_sid();
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+    error = avc_has_perm(mysid, mysid, SECCLASS_PROCESS, PROCESS__SETCURRENT, NULL);
+#else
+    error = avc_has_perm(&selinux_state, mysid, mysid, SECCLASS_PROCESS, PROCESS__SETCURRENT, NULL);
+#endif
+    if (error) {
+        return error;
+    }
+
+    if (size && str[0] && str[0] != '\n') {
+        if (str[size - 1] == '\n') {
+            str[size - 1] = 0;
+            size--;
+        }
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+        error = security_context_to_sid_with_policy(backup_sepolicy, str, size, &sid, SECSID_NULL, GFP_KERNEL);
+#else
+        error = security_context_to_sid(&fake_state, str, size, &sid, GFP_KERNEL);
+#endif
+        if (error) {
+            return error;
+        }
+    }
+
+call_orig:
+    return ((setprocattr_fn)selinux_setprocattr_hook.original)(name, value, size);
+}
+
 static void ksu_selinux_hide_unhook();
 static int ksu_selinux_hide_enable()
 {
@@ -238,6 +285,12 @@ static int ksu_selinux_hide_enable()
         goto unhook;
     }
 
+    ret = ksu_lsm_hook(&selinux_setprocattr_hook);
+    if (ret) {
+        pr_err("selinux_hide: init: selinux_setprocattr_hook err: %d\n", ret);
+        goto unhook;
+    }
+
     return 0;
 
 unhook:
@@ -263,6 +316,7 @@ static void ksu_selinux_hide_unhook()
             pr_err("selinux_hide: exit: patch_text access_write err: %d\n", ret);
         }
     }
+    ksu_lsm_unhook(&selinux_setprocattr_hook);
 }
 
 static void ksu_selinux_hide_disable()

--- a/kernel/feature/selinux_hide.h
+++ b/kernel/feature/selinux_hide.h
@@ -1,0 +1,8 @@
+#ifndef __KSU_H_SELINUX_HIDE
+#define __KSU_H_SELINUX_HIDE
+
+void ksu_selinux_hide_init();
+void ksu_selinux_hide_exit();
+void ksu_selinux_hide_drop_backup_if_unused();
+
+#endif

--- a/kernel/hook/lsm_hook.c
+++ b/kernel/hook/lsm_hook.c
@@ -61,20 +61,6 @@ static void ksu_lsm_hook_untrack(struct ksu_lsm_hook *hook)
     }
 }
 
-static const char *ksu_lsm_hook_target_name(struct ksu_lsm_hook *hook, char *buf, size_t buf_size)
-{
-    int ret;
-
-    if (hook->target_name)
-        return hook->target_name;
-
-    ret = scnprintf(buf, buf_size, "bpf_lsm_%s", hook->head_name);
-    if (ret <= 0 || ret >= buf_size)
-        return NULL;
-
-    return buf;
-}
-
 static int ksu_lsm_hook_patch_slot(void **slot, void *value)
 {
     void *patched = value;
@@ -87,45 +73,8 @@ static int ksu_lsm_hook_patch_slot(void **slot, void *value)
     return ret;
 }
 
-static bool ksu_lsm_hook_is_bpf_target(struct ksu_lsm_hook *hook)
-{
-    return hook && !hook->target_name;
-}
-
-static bool ksu_lsm_hook_matches_entry(struct ksu_lsm_hook *hook, struct security_hook_list *entry, void *current_hook,
-                                       void *target)
-{
-    char sym[KSYM_NAME_LEN];
-
-    (void)hook;
-    (void)entry;
-
-    if (target)
-        return current_hook == target;
-
-    if (!hook || !hook->target_name || !current_hook)
-        return false;
-
-    if (!sprint_symbol_no_offset(sym, (unsigned long)current_hook))
-        return false;
-
-    return !strcmp(sym, hook->target_name);
-}
-
-static void ksu_lsm_hook_log_entry(struct ksu_lsm_hook *hook, struct security_hook_list *entry, void *current_hook)
-{
-    (void)entry;
-
-    pr_info("lsm_hook: candidate head=%s hook=%px [%pSb]\n", hook->head_name ?: "unknown", current_hook, current_hook);
-}
-
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 typedef void (*ksu_static_call_update_t)(struct static_call_key *key, void *tramp, void *func);
-
-static size_t ksu_lsm_hook_scall_count(void)
-{
-    return sizeof(struct lsm_static_calls_table) / sizeof(struct lsm_static_call);
-}
 
 static int ksu_lsm_hook_update_scall(struct lsm_static_call *scall, void *value)
 {
@@ -141,25 +90,22 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
     struct security_hook_list *entry;
     void *target;
     const char *target_name;
-    char bpf_name[KSYM_NAME_LEN];
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
-    unsigned long scalls_addr;
-    struct lsm_static_call *scalls;
-    size_t scalls_count;
+    static unsigned long scalls_addr = 0;
+    struct lsm_static_call *scalls = NULL;
+    static size_t scalls_count = 0;
+    static u32 lsm_max_cnt = 5;
     struct security_hook_list *selected_entry = NULL;
     struct lsm_static_call *selected_scall = NULL;
     void **selected_slot = NULL;
-    void *selected_hook = NULL;
+    void *selected_origin = NULL;
     size_t i;
 #else
     unsigned long heads_addr;
     struct hlist_head *head;
     struct security_hook_list *selected_entry = NULL;
     void **selected_slot = NULL;
-    void *selected_hook = NULL;
-    struct security_hook_list *last_entry = NULL;
-    void **last_slot = NULL;
-    void *last_hook = NULL;
+    void *selected_origin = NULL;
 #endif
 
     if (!hook || !hook->replacement)
@@ -172,9 +118,9 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
         goto out_unlock;
     }
 
-    target_name = ksu_lsm_hook_target_name(hook, bpf_name, sizeof(bpf_name));
+    target_name = hook->target_name;
     if (!target_name) {
-        pr_err("lsm_hook: failed to build target name for %s\n", hook->head_name ?: "unknown");
+        pr_err("lsm_hook: hook %s: target_name is required\n", hook->head_name ?: "unknown");
         ret = -EINVAL;
         goto out_unlock;
     }
@@ -182,67 +128,121 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
     target = hook->original;
     if (!target)
         target = ksu_lookup_symbol(target_name);
-    if (!target && !ksu_lsm_hook_is_bpf_target(hook)) {
+    if (!target) {
         pr_err("lsm_hook: failed to resolve target for %s\n", hook->head_name ?: "unknown");
         ret = -ENOENT;
         goto out_unlock;
     }
-    if (!target && ksu_lsm_hook_is_bpf_target(hook)) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
-        pr_info("lsm_hook: %s symbol missing for %s, registration will be rejected\n", target_name,
-                hook->head_name ?: "unknown");
-#elif IS_ENABLED(CONFIG_BPF_LSM)
-        pr_info("lsm_hook: %s symbol missing for %s, registration will be rejected\n", target_name,
-                hook->head_name ?: "unknown");
-#else
-        pr_info("lsm_hook: %s symbol missing for %s, best-effort fallback is enabled\n", target_name,
-                hook->head_name ?: "unknown");
-#endif
-    }
+    pr_info("target: 0x%lx %pSb\n", (unsigned long)target, target);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
-    scalls_addr = kallsyms_lookup_name("static_calls_table");
+    if (!scalls_addr) {
+        scalls_addr = kallsyms_lookup_name("static_calls_table");
+    }
     if (!scalls_addr) {
         pr_err("lsm_hook: failed to resolve static_calls_table\n");
-        ret = -ENOENT;
+        ret = -ENOSYS;
+        goto out_unlock;
+    }
+
+    if (scalls_count == 0) {
+        unsigned long sym_size = sizeof(struct lsm_static_calls_table);
+        u32 lsm_active_cnt = 5;
+        if (!kallsyms_lookup_size_offset(scalls_addr, &sym_size, NULL)) {
+            pr_err("failed to get size\n");
+        }
+        unsigned long addr = kallsyms_lookup_name("lsm_active_cnt");
+        if (!addr) {
+            pr_err("failed to get lsm_active_cnt\n");
+        } else {
+            lsm_active_cnt = *(u32 *)addr;
+        }
+        pr_info("lsm_active_cnt = %d\n", lsm_active_cnt);
+        if (lsm_active_cnt == 0 || lsm_active_cnt > 20) {
+            pr_err("invalid lsm_active_cnt\n");
+        } else {
+            lsm_max_cnt = lsm_active_cnt;
+            if (sym_size % (lsm_active_cnt * sizeof(struct lsm_static_call)) != 0) {
+                pr_warn("invalid struct size\n");
+            }
+            scalls_count = sym_size / sizeof(struct lsm_static_call);
+            pr_info("scalls_count = %zu\n", scalls_count);
+        }
+    }
+
+    if (scalls_count == 0) {
+        pr_err("no scalls_count found!\n");
+        ret = -ENOSYS;
         goto out_unlock;
     }
 
     scalls = (struct lsm_static_call *)scalls_addr;
-    scalls_count = ksu_lsm_hook_scall_count();
     for (i = 0; i < scalls_count; i++) {
         struct lsm_static_call *scall = &scalls[i];
         void **slot;
-        void *current_hook;
+        void *current_origin;
 
         entry = READ_ONCE(scall->hl);
         if (!entry)
             continue;
 
         slot = (void **)((char *)entry + hook->hook_offset);
-        current_hook = READ_ONCE(*slot);
+        current_origin = READ_ONCE(*slot);
 
-        if (current_hook == hook->replacement) {
+        int j;
+        for (j = 0; j < ksu_lsm_hook_count; j++) {
+            if (ksu_lsm_hook_entries[j].hook->replacement == current_origin) {
+                current_origin = ksu_lsm_hook_entries[j].hook->original;
+                break;
+            }
+        }
+
+        if (current_origin == hook->replacement) {
             ret = -EALREADY;
             goto out_unlock;
         }
-        if (!ksu_lsm_hook_is_bpf_target(hook)) {
-            pr_debug("finding %zu: 0x%lx [%pSb]\n", i, (unsigned long)current_hook, current_hook);
-        }
-        if (!ksu_lsm_hook_matches_entry(hook, entry, current_hook, target))
+
+        if (current_origin != target) {
             continue;
+        }
 
-        if (ksu_lsm_hook_is_bpf_target(hook))
-            ksu_lsm_hook_log_entry(hook, entry, current_hook);
+        pr_info("found slot %ld orig %pSb\n", i, current_origin);
 
-        selected_entry = entry;
-        selected_scall = scall;
-        selected_slot = slot;
-        selected_hook = current_hook;
+        if (!hook->offset) {
+            selected_entry = entry;
+            selected_scall = scall;
+            selected_slot = slot;
+            selected_origin = current_origin;
+        } else {
+            size_t hook_idx = (i / lsm_max_cnt + hook->offset) * lsm_max_cnt;
+            if (hook_idx >= scalls_count) {
+                pr_err("last lsm hook reached\n");
+                ret = -EINVAL;
+                goto out_unlock;
+            }
+            scall = &scalls[hook_idx];
+            entry = READ_ONCE(scall->hl);
+            if (entry) {
+                slot = (void **)((char *)entry + hook->hook_offset);
+                current_origin = READ_ONCE(*slot);
+            } else {
+                current_origin = NULL;
+            }
+            pr_info("found real slot %ld orig %pSb\n", i, current_origin);
+
+            if (current_origin == hook->replacement) {
+                ret = -EALREADY;
+                goto out_unlock;
+            }
+            selected_entry = entry;
+            selected_scall = scall;
+            selected_slot = slot;
+            selected_origin = current_origin;
+        }
         break;
     }
 
-    if (!selected_entry) {
+    if (!selected_scall) {
         pr_err("lsm_hook: target %s not found in head %s\n", target_name, hook->head_name ?: "unknown");
         ret = -ENOENT;
         goto out_unlock;
@@ -261,18 +261,21 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
     }
 
     if (ksu_lsm_hook_update_scall(selected_scall, hook->replacement)) {
-        if (ksu_lsm_hook_patch_slot(selected_slot, selected_hook)) {
+        if (ksu_lsm_hook_patch_slot(selected_slot, selected_origin)) {
             pr_err("lsm_hook: failed to roll back %s after static call update failure\n", hook->head_name ?: "unknown");
         }
         ret = -EFAULT;
         goto out_untrack;
     }
 
+    if (!selected_origin)
+        static_branch_enable(selected_scall->active);
+
     hook->entry = selected_entry;
     hook->scall = selected_scall;
-    hook->original = selected_hook;
+    hook->original = selected_origin;
     pr_info("lsm_hook: patched %s hook slot %px from %px to %px\n", hook->head_name ?: "unknown", selected_slot,
-            selected_hook, hook->replacement);
+            selected_origin, hook->replacement);
 #else
     heads_addr = kallsyms_lookup_name("security_hook_heads");
     if (!heads_addr) {
@@ -280,40 +283,75 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
         ret = -ENOENT;
         goto out_unlock;
     }
-
-    head = (struct hlist_head *)(heads_addr + hook->head_offset);
-    hlist_for_each_entry (entry, head, list) {
-        void **slot = (void **)((char *)entry + hook->hook_offset);
-        void *current_hook = READ_ONCE(*slot);
-
-        if (current_hook == hook->replacement) {
-            ret = -EALREADY;
-            goto out_unlock;
-        }
-        if (ksu_lsm_hook_is_bpf_target(hook)) {
-            ksu_lsm_hook_log_entry(hook, entry, current_hook);
-            last_entry = entry;
-            last_slot = slot;
-            last_hook = current_hook;
-        }
-        if (!ksu_lsm_hook_matches_entry(hook, entry, current_hook, target))
-            continue;
-
-        selected_entry = entry;
-        selected_slot = slot;
-        selected_hook = current_hook;
-        break;
+    unsigned long heads_size = sizeof(struct security_hook_heads);
+    if (!kallsyms_lookup_size_offset(heads_addr, &heads_size, NULL)) {
+        pr_warn("lookup head size failed");
     }
 
-#if !IS_ENABLED(CONFIG_BPF_LSM)
-    if (!selected_entry && !target && ksu_lsm_hook_is_bpf_target(hook) && last_entry) {
-        selected_entry = last_entry;
-        selected_slot = last_slot;
-        selected_hook = last_hook;
-        pr_info("lsm_hook: %s unresolved and CONFIG_BPF_LSM is off, fallback to last candidate %px [%pSb]\n",
-                target_name, selected_hook, selected_hook);
+    head = (struct hlist_head *)heads_addr;
+    struct hlist_head *head_end = (struct hlist_head *)(heads_addr + heads_size);
+    pr_info("heads_addr 0x%lx head_offset 0x%lx heads_size %ld hook_offset 0x%lx\n", (unsigned long)heads_addr,
+            hook->head_offset, heads_size, hook->hook_offset);
+
+    for (; head < head_end; head++) {
+        hlist_for_each_entry (entry, head, list) {
+            void **slot = (void **)((char *)entry + hook->hook_offset);
+            void *current_origin = READ_ONCE(*slot);
+            int j;
+            for (j = 0; j < ksu_lsm_hook_count; j++) {
+                if (ksu_lsm_hook_entries[j].hook->replacement == current_origin) {
+                    current_origin = ksu_lsm_hook_entries[j].hook->original;
+                    break;
+                }
+            }
+            if (current_origin == hook->replacement) {
+                ret = -EALREADY;
+                goto out_unlock;
+            }
+            if (current_origin == target) {
+                pr_info("found %s (target %s) at head offset %ld (provided %ld)\n", hook->head_name, hook->target_name,
+                        (unsigned long)head - heads_addr, hook->head_offset);
+                selected_entry = entry;
+                selected_slot = slot;
+                selected_origin = current_origin;
+                break;
+            }
+        }
+        if (selected_entry) {
+            if (hook->offset) {
+                head += hook->offset;
+                if (head < (struct hlist_head *)heads_addr || head >= head_end) {
+                    pr_err("invalid offset\n");
+                    ret = -EINVAL;
+                    goto out_unlock;
+                }
+                // just check if already hooked
+                hlist_for_each_entry (entry, head, list) {
+                    void **slot = (void **)((char *)entry + hook->hook_offset);
+                    void *current_origin = READ_ONCE(*slot);
+                    if (current_origin == hook->replacement) {
+                        ret = -EALREADY;
+                        goto out_unlock;
+                    }
+                }
+                if (head->first) {
+                    selected_entry = hlist_entry(head->first, struct security_hook_list, list);
+                    selected_slot = (void **)((char *)selected_entry + hook->hook_offset);
+                    selected_origin = *selected_slot;
+                } else {
+                    selected_entry = &hook->list;
+                    hook->list.head = head;
+                    hook->list.list.next = NULL;
+                    hook->list.list.pprev = &head->first;
+                    hook->list.lsm = "ksu";
+                    *(void **)((char *)selected_entry + hook->hook_offset) = hook->replacement;
+                    selected_slot = (void **)&head->first;
+                    selected_origin = NULL;
+                }
+            }
+            break;
+        }
     }
-#endif
 
     if (!selected_entry) {
         pr_err("lsm_hook: target %s not found in head %s\n", target_name, hook->head_name ?: "unknown");
@@ -327,16 +365,24 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
         goto out_unlock;
     }
 
-    if (ksu_lsm_hook_patch_slot(selected_slot, hook->replacement)) {
+    if (selected_origin) {
+        pr_info("patch func addr\n");
+        ret = ksu_lsm_hook_patch_slot(selected_slot, hook->replacement);
+    } else {
+        pr_info("patch head->first\n");
+        ret = ksu_lsm_hook_patch_slot(selected_slot, &hook->list);
+    }
+
+    if (ret) {
         pr_err("lsm_hook: failed to patch %s\n", hook->head_name ?: "unknown");
         ret = -EFAULT;
         goto out_untrack;
     }
 
     hook->entry = selected_entry;
-    hook->original = selected_hook;
+    hook->original = selected_origin;
     pr_info("lsm_hook: patched %s hook slot %px from %px to %px\n", hook->head_name ?: "unknown", selected_slot,
-            selected_hook, hook->replacement);
+            selected_origin, hook->replacement);
 #endif
     goto out_unlock;
 out_untrack:
@@ -350,27 +396,28 @@ out_unlock:
 void ksu_lsm_unhook(struct ksu_lsm_hook *hook)
 {
     void **slot;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
-    if (!hook || !hook->entry || !hook->original || !hook->scall)
-        return;
-#else
-    if (!hook || !hook->entry || !hook->original)
-        return;
-#endif
-
     mutex_lock(&ksu_lsm_hook_lock);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
-    if (!hook->entry || !hook->original || !hook->scall) {
+    if (!hook->entry || !hook->scall) {
 #else
-    if (!hook->entry || !hook->original) {
+    if (!hook->entry) {
 #endif
         mutex_unlock(&ksu_lsm_hook_lock);
         return;
     }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
     slot = (void **)((char *)hook->entry + hook->hook_offset);
+#else
+    if (hook->entry == &hook->list) {
+        slot = (void **)&hook->list.head->first;
+        pr_info("unhook patch head->first\n");
+    } else {
+        slot = (void **)((char *)hook->entry + hook->hook_offset);
+        pr_info("unhook patch slot\n");
+    }
+#endif
     if (ksu_lsm_hook_patch_slot(slot, hook->original)) {
         pr_err("lsm_hook: failed to restore %s\n", hook->head_name ?: "unknown");
         mutex_unlock(&ksu_lsm_hook_lock);

--- a/kernel/hook/lsm_hook.h
+++ b/kernel/hook/lsm_hook.h
@@ -21,22 +21,22 @@ struct ksu_lsm_hook {
     struct security_hook_list *entry;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
     struct lsm_static_call *scall;
+#else
+    struct security_hook_list list;
 #endif
+    // the offset from target_name to the real hook target
+    // for example, we'd like to hook task_free, but no target_name can be found
+    // (because none of lsm hook it), then we can find task_alloc and set offset
+    // to 1
+    int offset;
 };
 
-// clang-format off
-#define KSU_LSM_HOOK_INIT(head_member, hook_member, target_symbol, replacement_fn)                                     \
+#define KSU_LSM_HOOK_INIT(member, target_symbol, replacement_fn, off)                                                  \
     {                                                                                                                  \
-        .head_name = #head_member,                                                                                     \
-        .target_name = target_symbol,                                                                                  \
-        .head_offset = offsetof(KSU_LSM_HOOK_HEADS_TYPE, head_member),                                                 \
-        .hook_offset = offsetof(struct security_hook_list, hook.hook_member),                                          \
-        .replacement = (void *)(replacement_fn),                                                                       \
+        .head_name = #member, .target_name = target_symbol, .head_offset = offsetof(KSU_LSM_HOOK_HEADS_TYPE, member),  \
+        .hook_offset = offsetof(struct security_hook_list, hook.member), .replacement = (void *)(replacement_fn),      \
+        .offset = off,                                                                                                 \
     }
-// clang-format on
-
-#define KSU_LSM_HOOK_BPF_INIT(head_member, hook_member, replacement_fn)                                                \
-    KSU_LSM_HOOK_INIT(head_member, hook_member, NULL, replacement_fn)
 
 // This API implements runtime patching of existing LSM hook slots. It is a
 // workaround for out-of-tree modules, not the normal LSM registration path via
@@ -68,7 +68,7 @@ void ksu_unregister_lsm_hook(struct ksu_lsm_hook *hook);
 
 // --- Global lifecycle for tracked hooks ---
 // Initialize the internal tracking state used by hook/unhook and
-// register/unregister.
+// register/unregister. Safe to call more than once.
 void ksu_lsm_hook_init(void);
 
 // Restore all currently tracked LSM hooks in reverse order and clear the

--- a/kernel/include/ksu.h
+++ b/kernel/include/ksu.h
@@ -11,6 +11,7 @@
 extern struct cred *ksu_cred;
 extern bool ksu_late_loaded;
 extern bool allow_shell;
+extern struct selinux_policy *backup_sepolicy;
 
 static inline int startswith(char *s, char *prefix)
 {

--- a/kernel/runtime/boot_event.c
+++ b/kernel/runtime/boot_event.c
@@ -1,3 +1,4 @@
+#include "feature/selinux_hide.h"
 #include <linux/err.h>
 #include <linux/fs.h>
 #include <linux/namei.h>
@@ -67,5 +68,6 @@ void on_boot_completed(void)
     ksu_boot_completed = true;
     pr_info("on_boot_completed!\n");
     track_throne(true);
+    ksu_selinux_hide_drop_backup_if_unused();
     ksu_avc_spoof_late_init();
 }

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -15,6 +15,8 @@
 #include "linux/lsm_audit.h" // IWYU pragma: keep
 #include "xfrm.h"
 
+struct selinux_policy *backup_sepolicy;
+
 #define SELINUX_POLICY_INSTEAD_SELINUX_SS
 
 #define ALL NULL
@@ -50,6 +52,29 @@ void apply_kernelsu_rules()
     }
 
     mutex_lock(&selinux_state.policy_mutex);
+    backup_sepolicy =
+        ksu_dup_sepolicy(rcu_dereference_protected(old_pol, lockdep_is_held(&selinux_state.policy_mutex)));
+    if (IS_ERR(backup_sepolicy)) {
+        pr_err("failed to create backup sepolicy: %ld\n", PTR_ERR(backup_sepolicy));
+        backup_sepolicy = NULL;
+    } else {
+        backup_sepolicy->sidtab = kzalloc(sizeof(*backup_sepolicy->sidtab), GFP_KERNEL);
+        if (!backup_sepolicy->sidtab) {
+            pr_err("failed to alloc backup sidtab\n");
+            ksu_destroy_sepolicy(backup_sepolicy);
+            backup_sepolicy = NULL;
+        } else {
+            int ret = policydb_load_isids(&backup_sepolicy->policydb, backup_sepolicy->sidtab);
+            if (ret) {
+                pr_err("failed to load isids for backup sepolicy: %d!\n", ret);
+                kfree(backup_sepolicy->sidtab);
+                ksu_destroy_sepolicy(backup_sepolicy);
+                backup_sepolicy = NULL;
+            } else {
+                pr_info("backup sepolicy success!\n");
+            }
+        }
+    }
     pol = ksu_dup_sepolicy(rcu_dereference_protected(
         old_pol, lockdep_is_held(&selinux_state.policy_mutex)));
     if (IS_ERR(pol)) {

--- a/manager/app/src/main/cpp/jni.cc
+++ b/manager/app/src/main/cpp/jni.cc
@@ -381,6 +381,18 @@ Java_com_rifsxd_ksunext_Natives_setAvcSpoofEnabled(JNIEnv *env, jobject thiz, jb
 }
 
 extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_rifsxd_ksunext_Natives_isSelinuxHideEnabled(JNIEnv *env, jobject thiz) {
+    return is_selinux_hide_enabled();
+}
+
+extern "C"
+JNIEXPORT jint JNICALL
+Java_com_rifsxd_ksunext_Natives_setSelinuxHideEnabled(JNIEnv *env, jobject thiz, jboolean enabled) {
+    return set_selinux_hide_enabled(enabled);
+}
+
+extern "C"
 JNIEXPORT jstring JNICALL
 Java_com_rifsxd_ksunext_Natives_getUserName(JNIEnv *env, jobject thiz, jint uid) {
     struct passwd *pw = getpwuid((uid_t) uid);

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <climits>
 #include <sys/syscall.h>
+#include <cerrno>
 #include "ksu.h"
 
 static int fd = -1;
@@ -206,6 +207,25 @@ bool is_kernel_umount_enabled() {
     uint64_t value = 0;
     bool supported = false;
     if (!get_feature(KSU_FEATURE_KERNEL_UMOUNT, &value, &supported)) {
+        return false;
+    }
+    if (!supported) {
+        return false;
+    }
+    return value != 0;
+}
+
+int set_selinux_hide_enabled(bool enabled) {
+    if (!set_feature(KSU_FEATURE_SELINUX_HIDE, enabled ? 1 : 0)) {
+        return -errno;
+    }
+    return 0;
+}
+
+bool is_selinux_hide_enabled() {
+    uint64_t value = 0;
+    bool supported = false;
+    if (!get_feature(KSU_FEATURE_SELINUX_HIDE, &value, &supported)) {
         return false;
     }
     if (!supported) {

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -56,6 +56,11 @@ bool set_avc_spoof_enabled(bool enabled);
 
 bool is_avc_spoof_enabled();
 
+// SELinux hide
+int set_selinux_hide_enabled(bool enabled);
+
+bool is_selinux_hide_enabled();
+
 bool get_allow_list(struct ksu_new_get_allow_list_cmd *);
 
 inline std::pair<int, int> legacy_get_info() {

--- a/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
@@ -108,6 +108,15 @@ object Natives {
     external fun setKernelUmountEnabled(enabled: Boolean): Boolean
 
     /**
+     * SELinux hide can be disabled temporarily.
+     *  0: disabled
+     *  1: enabled
+     *  negative : error
+     */
+    external fun isSelinuxHideEnabled(): Boolean
+    external fun setSelinuxHideEnabled(enabled: Boolean): Int
+
+    /**
      * Get the user name for the uid.
      */
     external fun getUserName(uid: Int): String?

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
@@ -3,6 +3,7 @@ package com.rifsxd.ksunext.ui.screen
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.system.OsConstants
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -115,11 +116,13 @@ fun SettingScreen(navigator: DestinationsNavigator) {
     var avcSpoofStatus by rememberSaveable { mutableStateOf("") }
     var suCompatStatus by rememberSaveable { mutableStateOf("") }
     var kernelUmountStatus by rememberSaveable { mutableStateOf("") }
+    var selinuxHideStatus by rememberSaveable { mutableStateOf("") }
 
     LaunchedEffect(Unit) {
         avcSpoofStatus = getFeatureStatus("avc_spoof")
         suCompatStatus = getFeatureStatus("su_compat")
         kernelUmountStatus = getFeatureStatus("kernel_umount")
+        selinuxHideStatus = getFeatureStatus("selinux_hide")
     }
 
     Scaffold(
@@ -151,7 +154,9 @@ fun SettingScreen(navigator: DestinationsNavigator) {
                 KernelFeaturesCard(
                     suCompatStatus = suCompatStatus,
                     kernelUmountStatus = kernelUmountStatus,
-                    avcSpoofStatus = avcSpoofStatus
+                    avcSpoofStatus = avcSpoofStatus,
+                    selinuxHideStatus = selinuxHideStatus,
+                    scope = scope
                 )
                 SecurityCard(
                     navigator = navigator,
@@ -178,7 +183,9 @@ fun SettingScreen(navigator: DestinationsNavigator) {
 private fun KernelFeaturesCard(
     suCompatStatus: String,
     kernelUmountStatus: String,
-    avcSpoofStatus: String
+    avcSpoofStatus: String,
+    selinuxHideStatus: String,
+    scope: kotlinx.coroutines.CoroutineScope
 ) {
     val context = LocalContext.current
 
@@ -242,6 +249,43 @@ private fun KernelFeaturesCard(
                         execKsud("feature save", true)
                         prefsLocal.edit { putInt("kernel_umount_mode", if (checked) 0 else 2) }
                         isKernelUmountEnabled = checked
+                    }
+                }
+            }
+
+            if (selinuxHideStatus == "supported") {
+                var isSelinuxHideEnabled by rememberSaveable {
+                    mutableStateOf(Natives.isSelinuxHideEnabled())
+                }
+                SwitchItem(
+                    icon = Icons.Filled.Policy,
+                    title = stringResource(id = R.string.settings_selinux_hide),
+                    summary = stringResource(id = R.string.settings_selinux_hide_summary),
+                    checked = isSelinuxHideEnabled,
+                    modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp)),
+                    colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+                ) { checked ->
+                    scope.launch(Dispatchers.IO) {
+                        val prefsLocal = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
+                        val status = Natives.setSelinuxHideEnabled(checked)
+                        execKsud("feature save", true)
+                        prefsLocal.edit { putInt("selinux_hide_mode", if (checked) 0 else 2) }
+                        isSelinuxHideEnabled = checked
+                        when (status) {
+                            0 -> {}
+                            -OsConstants.EAGAIN -> {
+                                withContext(Dispatchers.Main) {
+                                    Toast.makeText(context, R.string.settings_selinux_hide_reboot_required,
+                                        Toast.LENGTH_LONG).show()
+                                }
+                            }
+                            else -> {
+                                withContext(Dispatchers.Main) {
+                                    Toast.makeText(context, context.getString(R.string.settings_selinux_hide_failed, status),
+                                        Toast.LENGTH_LONG).show()
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -254,7 +254,7 @@
   <string name="advanced_options">高级选项</string>
   <string name="expand">展开</string>
   <string name="settings_selinux_hide">隐藏 SELinux 修改</string>
-  <string name="settings_selinux_hide_summary">阻止应用通过 selinuxfs 检测 SELinux 修改</string>
+  <string name="settings_selinux_hide_summary">阻止应用检测 SELinux 修改</string>
   <string name="settings_selinux_hide_reboot_required">重启生效</string>
   <string name="settings_selinux_hide_failed">错误： %d</string>
 </resources>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -253,4 +253,8 @@
   <string name="enable_adb_summary">强制允许 USB 调试并取消 adb 认证，非必要请勿开启。</string>
   <string name="advanced_options">高级选项</string>
   <string name="expand">展开</string>
+  <string name="settings_selinux_hide">隐藏 SELinux 修改</string>
+  <string name="settings_selinux_hide_summary">阻止应用通过 selinuxfs 检测 SELinux 修改</string>
+  <string name="settings_selinux_hide_reboot_required">重启生效</string>
+  <string name="settings_selinux_hide_failed">错误： %d</string>
 </resources>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -204,7 +204,7 @@
     <string name="settings_enable_kernel_umount">Kernel umount</string>
     <string name="settings_enable_kernel_umount_summary">Umount modules at kernel-level.</string>
     <string name="settings_selinux_hide">Hide SELinux modification</string>
-    <string name="settings_selinux_hide_summary">Prevent applications from detecting SELinux modifications via selinuxfs</string>
+    <string name="settings_selinux_hide_summary">Prevent applications from detecting SELinux modifications</string>
     <string name="settings_selinux_hide_reboot_required">Reboot to take effect</string>
     <string name="settings_selinux_hide_failed">Error: %d</string>
     <string name="settings_enable_avc_spoof">AVC spoofing</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -203,6 +203,10 @@
     <string name="module_sort_webui_first">Sort (WebUI first)</string>
     <string name="settings_enable_kernel_umount">Kernel umount</string>
     <string name="settings_enable_kernel_umount_summary">Umount modules at kernel-level.</string>
+    <string name="settings_selinux_hide">Hide SELinux modification</string>
+    <string name="settings_selinux_hide_summary">Prevent applications from detecting SELinux modifications via selinuxfs</string>
+    <string name="settings_selinux_hide_reboot_required">Reboot to take effect</string>
+    <string name="settings_selinux_hide_failed">Error: %d</string>
     <string name="settings_enable_avc_spoof">AVC spoofing</string>
     <string name="settings_enable_avc_spoof_summary">Fix selinux context leak caused by avc denial in audit log.</string>
     <string name="meta_module">Meta</string>

--- a/uapi/feature.h
+++ b/uapi/feature.h
@@ -4,6 +4,7 @@
 enum ksu_feature_id {
     KSU_FEATURE_SU_COMPAT = 0,
     KSU_FEATURE_KERNEL_UMOUNT = 1,
+    KSU_FEATURE_SELINUX_HIDE = 4,
 
     // custom extensions
     KSU_FEATURE_AVC_SPOOF = 10003,

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -370,7 +370,7 @@ enum Profile {
 enum Feature {
     /// Get feature value and support status
     Get {
-        /// Feature ID or name (su_compat, kernel_umount)
+        /// Feature ID or name (su_compat, kernel_umount, sulog, adb_root, selinux_hide)
         id: String,
         /// Read from config file
         #[arg(long, default_value_t = false)]
@@ -390,7 +390,7 @@ enum Feature {
 
     /// Check feature status (supported/unsupported/managed)
     Check {
-        /// Feature ID or name (su_compat, kernel_umount)
+        /// Feature ID or name (su_compat, kernel_umount, sulog, adb_root, selinux_hide)
         id: String,
     },
 

--- a/userspace/ksud/src/feature.rs
+++ b/userspace/ksud/src/feature.rs
@@ -19,6 +19,7 @@ pub enum FeatureId {
     SuCompat = 0,
     KernelUmount = 1,
     EnhancedSecurity = 2,
+    SelinuxHide = 4,
     AvcSpoof = 10003,
 }
 
@@ -28,6 +29,7 @@ impl FeatureId {
             0 => Some(Self::SuCompat),
             1 => Some(Self::KernelUmount),
             2 => Some(Self::EnhancedSecurity),
+            4 => Some(Self::SelinuxHide),
             10003 => Some(Self::AvcSpoof),
             _ => None,
         }
@@ -38,6 +40,7 @@ impl FeatureId {
             Self::SuCompat => "su_compat",
             Self::KernelUmount => "kernel_umount",
             Self::EnhancedSecurity => "enhanced_security",
+            Self::SelinuxHide => "selinux_hide",
             Self::AvcSpoof => "avc_spoof",
         }
     }
@@ -53,6 +56,9 @@ impl FeatureId {
             Self::EnhancedSecurity => {
                 "Enhanced Security - disable non‑KSU root elevation and unauthorized UID downgrades"
             }
+            Self::SelinuxHide => {
+                "SELinux Hide - sanitize /sys/fs/selinux access results for app UIDs"
+            }
             Self::AvcSpoof => {
                 "AVC Spoof - fix selinux context leak due to avc denial"
             }
@@ -65,6 +71,7 @@ fn parse_feature_id(name: &str) -> Result<FeatureId> {
         "su_compat" | "0" => Ok(FeatureId::SuCompat),
         "kernel_umount" | "1" => Ok(FeatureId::KernelUmount),
         "enhanced_security" | "2" => Ok(FeatureId::EnhancedSecurity),
+        "selinux_hide" | "4" => Ok(FeatureId::SelinuxHide),
         "avc_spoof" | "10003" => Ok(FeatureId::AvcSpoof),
         _ => bail!("Unknown feature: {name}"),
     }
@@ -290,6 +297,7 @@ pub fn list_features() {
         FeatureId::SuCompat,
         FeatureId::KernelUmount,
         FeatureId::EnhancedSecurity,
+        FeatureId::SelinuxHide,
         FeatureId::AvcSpoof,
     ];
 
@@ -352,6 +360,7 @@ pub fn save_config() -> Result<()> {
         FeatureId::SuCompat,
         FeatureId::KernelUmount,
         FeatureId::EnhancedSecurity,
+        FeatureId::SelinuxHide,
         FeatureId::AvcSpoof,
     ];
 


### PR DESCRIPTION
```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Mon May 11 17:33:41 2026 +0800
```

```
    feature: selinux hide (https://github.com/tiann/KernelSU/pull/3457)

    - Add selinux_hide feature, which can be enable/disable at runtime.
    - It requires backing up the policydb at boot, which consumes a certain amount of memory (approximately a few MB). Therefore, if this feature is not enabled at boot, the backed-up policydb will be released, and the user will need to reboot for the changes to take effect after enabling it.

    Co-authored-by: KOWX712 <leecc0503@gmail.com>

    -Settings: Update SharedPreferences
```

```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Mon May 11 23:13:14 2026 +0800
```

```
selinux_hide: fix attr/current detection (https://github.com/tiann/KernelSU/pull/3459)
```