### PR TITLE
kernel: Resolve dotted CFI symbol variants in symbol lookup; refine symbol_resolver; Prefer hashed .cfi_jt variants before bare symbols

### DIFF
--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -22,6 +22,7 @@
 #include "selinux/selinux.h"
 #include "hook/syscall_hook.h"
 #include "feature/selinux_hide.h"
+#include "infra/symbol_resolver.h"
 
 #if defined(__x86_64__)
 #include <asm/cpufeature.h>
@@ -120,6 +121,7 @@ int __init kernelsu_init(void)
 		pr_err("prepare cred failed!\n");
 	}
 
+	ksu_init_symbol_resolver();
 	ksu_syscall_hook_init();
 
 	ksu_feature_init();

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -1,4 +1,5 @@
 #include "selinux_hide.h"
+#include "infra/symbol_resolver.h"
 #include "selinux/sepolicy.h"
 #include <linux/cred.h>
 #include <linux/cpu.h>
@@ -245,18 +246,18 @@ static int ksu_selinux_hide_enable()
         pr_err("no backup sepolicy available, please save feature and reboot to retry!\n");
         return -EAGAIN;
     }
-    selinux_write_op = kallsyms_lookup_name("write_op");
+    selinux_write_op = find_kernel_symbol_exact("write_op");
     if (!selinux_write_op) {
         pr_err("selinux_hide: no write_op found!\n");
         return -ENOSYS;
     }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
-    security_dump_masked_av_fn = kallsyms_lookup_name("security_dump_masked_av");
+    security_dump_masked_av_fn = find_kernel_symbol_exact("security_dump_masked_av");
     if (!security_dump_masked_av_fn) {
         pr_warn("security_dump_masked_av not found!\n");
     }
-    context_struct_compute_av_fn = kallsyms_lookup_name("context_struct_compute_av");
+    context_struct_compute_av_fn = find_kernel_symbol_exact("context_struct_compute_av");
     if (!context_struct_compute_av_fn) {
         pr_warn("context_struct_compute_av not found!\n");
     }

--- a/kernel/hook/arm64/syscall_hook.c
+++ b/kernel/hook/arm64/syscall_hook.c
@@ -125,7 +125,7 @@ static int __init ksu_find_ni_syscall_slots(int *out_slots, int max_slots)
     if (!ksu_syscall_table || max_slots <= 0)
         return 0;
 
-    ni_syscall = (unsigned long)ksu_lookup_symbol("__arm64_sys_ni_syscall");
+    ni_syscall = (unsigned long)ksu_resolve_symbol_for_functable_hook("__arm64_sys_ni_syscall");
 
     pr_info("sys_ni_syscall: 0x%lx\n", ni_syscall);
 
@@ -206,7 +206,7 @@ void __init ksu_syscall_hook_init(void)
 
     memset(syscall_hooks, 0, sizeof(syscall_hooks));
 
-    ksu_syscall_table = (syscall_fn_t *)ksu_lookup_symbol("sys_call_table");
+    ksu_syscall_table = (syscall_fn_t *)ksu_resolve_symbol_for_functable_hook("sys_call_table");
     pr_info("sys_call_table=0x%lx", (unsigned long)ksu_syscall_table);
 
     if (!ksu_syscall_table)

--- a/kernel/hook/lsm_hook.c
+++ b/kernel/hook/lsm_hook.c
@@ -127,7 +127,7 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
 
     target = hook->original;
     if (!target)
-        target = ksu_lookup_symbol(target_name);
+        target = ksu_resolve_symbol_for_functable_hook(target_name);
     if (!target) {
         pr_err("lsm_hook: failed to resolve target for %s\n", hook->head_name ?: "unknown");
         ret = -ENOENT;
@@ -137,7 +137,7 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
     if (!scalls_addr) {
-        scalls_addr = kallsyms_lookup_name("static_calls_table");
+        scalls_addr = find_kernel_symbol_exact("static_calls_table");
     }
     if (!scalls_addr) {
         pr_err("lsm_hook: failed to resolve static_calls_table\n");
@@ -151,7 +151,7 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
         if (!kallsyms_lookup_size_offset(scalls_addr, &sym_size, NULL)) {
             pr_err("failed to get size\n");
         }
-        unsigned long addr = kallsyms_lookup_name("lsm_active_cnt");
+        unsigned long addr = find_kernel_symbol_exact("lsm_active_cnt");
         if (!addr) {
             pr_err("failed to get lsm_active_cnt\n");
         } else {
@@ -277,7 +277,7 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
     pr_info("lsm_hook: patched %s hook slot %px from %px to %px\n", hook->head_name ?: "unknown", selected_slot,
             selected_origin, hook->replacement);
 #else
-    heads_addr = kallsyms_lookup_name("security_hook_heads");
+    heads_addr = find_kernel_symbol_exact("security_hook_heads");
     if (!heads_addr) {
         pr_err("lsm_hook: failed to resolve security_hook_heads\n");
         ret = -ENOENT;

--- a/kernel/hook/x86_64/syscall_hook.c
+++ b/kernel/hook/x86_64/syscall_hook.c
@@ -125,7 +125,7 @@ static int ksu_find_ni_syscall_slots(int *out_slots, int max_slots)
     if (!ksu_syscall_table || max_slots <= 0)
         return 0;
 
-    ni_syscall = (unsigned long)ksu_lookup_symbol("__x64_sys_ni_syscall");
+    ni_syscall = (unsigned long)ksu_resolve_symbol_for_functable_hook("__x64_sys_ni_syscall");
 
     pr_info("sys_ni_syscall: 0x%lx\n", ni_syscall);
 
@@ -207,7 +207,7 @@ void __init ksu_syscall_hook_init(void)
 
     memset(syscall_hooks, 0, sizeof(syscall_hooks));
 
-    ksu_syscall_table = (sys_call_ptr_t *)ksu_lookup_symbol("sys_call_table");
+    ksu_syscall_table = (sys_call_ptr_t *)ksu_resolve_symbol_for_functable_hook("sys_call_table");
     pr_info("sys_call_table=0x%lx", (unsigned long)ksu_syscall_table);
 
     if (!ksu_syscall_table)

--- a/kernel/infra/symbol_resolver.c
+++ b/kernel/infra/symbol_resolver.c
@@ -1,29 +1,77 @@
 #include <linux/kallsyms.h>
+#include <linux/module.h>
 #include <linux/string.h>
+#include <linux/version.h>
 
 #include "infra/symbol_resolver.h"
 
+static const char cfi_suffix[] = ".cfi_jt";
+static const size_t cfi_suffix_len = sizeof(cfi_suffix) - 1;
+
+struct ksu_lookup_symbol_ctx {
+    const char *symbol_name;
+    size_t symbol_len;
+    void *match;
+};
+
+static bool ksu_symbol_has_suffix(const char *name, size_t name_len, const char *suffix, size_t suffix_len)
+{
+    return name_len >= suffix_len && strcmp(name + name_len - suffix_len, suffix) == 0;
+}
+
+static int ksu_lookup_symbol_handle_match(void *data, const char *name, unsigned long addr)
+{
+    struct ksu_lookup_symbol_ctx *ctx = data;
+    size_t name_len;
+
+    if (!name || !addr)
+        return 0;
+
+    name_len = strlen(name);
+
+    if (strcmp(name, ctx->symbol_name) != 0) {
+        if (name_len <= ctx->symbol_len || strncmp(name, ctx->symbol_name, ctx->symbol_len) != 0 ||
+            name[ctx->symbol_len] != '.')
+            return 0;
+    }
+
+    if (ksu_symbol_has_suffix(name, name_len, cfi_suffix, cfi_suffix_len)) {
+        ctx->match = (void *)addr;
+        return 1;
+    }
+
+    if (!ctx->match)
+        ctx->match = (void *)addr;
+
+    return 0;
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+static int ksu_lookup_symbol_cb(void *data, const char *name, unsigned long addr)
+{
+    return ksu_lookup_symbol_handle_match(data, name, addr);
+}
+#else
+static int ksu_lookup_symbol_cb(void *data, const char *name, struct module *mod, unsigned long addr)
+{
+    if (mod)
+        return 0;
+
+    return ksu_lookup_symbol_handle_match(data, name, addr);
+}
+#endif
+
 void *ksu_lookup_symbol(const char *symbol_name)
 {
-    char cfi_name[KSYM_NAME_LEN];
-    void *addr;
-    size_t symbol_len;
-    static const char cfi_suffix[] = ".cfi_jt";
-    size_t cfi_suffix_len = sizeof(cfi_suffix) - 1;
+    struct ksu_lookup_symbol_ctx ctx = {
+        .symbol_name = symbol_name,
+    };
 
     if (!symbol_name || !symbol_name[0])
         return NULL;
 
-    symbol_len = strlen(symbol_name);
+    ctx.symbol_len = strlen(symbol_name);
 
-    if ((symbol_len < cfi_suffix_len || strcmp(symbol_name + symbol_len - cfi_suffix_len, cfi_suffix) != 0) &&
-        strscpy(cfi_name, symbol_name, sizeof(cfi_name)) > 0 &&
-        strlen(cfi_name) + strlen(".cfi_jt") + 1 <= sizeof(cfi_name)) {
-        strlcat(cfi_name, ".cfi_jt", sizeof(cfi_name));
-        addr = (void *)kallsyms_lookup_name(cfi_name);
-        if (addr)
-            return addr;
-    }
-
-    return (void *)kallsyms_lookup_name(symbol_name);
+    kallsyms_on_each_symbol(ksu_lookup_symbol_cb, &ctx);
+    return ctx.match;
 }

--- a/kernel/infra/symbol_resolver.c
+++ b/kernel/infra/symbol_resolver.c
@@ -5,8 +5,48 @@
 
 #include "infra/symbol_resolver.h"
 
+// https://github.com/torvalds/linux/commit/89245600941e4e0f87d77f60ee269b5e61ef4e49
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#define USE_KCFI 1
+#else
+#define USE_KCFI 0
+#endif
+
+#if !USE_KCFI
 static const char cfi_suffix[] = ".cfi_jt";
 static const size_t cfi_suffix_len = sizeof(cfi_suffix) - 1;
+#endif
+
+// It's not guaranteed to have this symbol exist in 5.x kernel
+// https://github.com/torvalds/linux/commit/d721def7392a7348ffb9f3583b264239cbd3702c
+// https://github.com/gregkh/linux/commit/2aa861ec72908b4bdc20d74725dc1c8c71a8d214
+// https://github.com/gregkh/linux/commit/318a206633c248d876ea72f7133d2a2e50ad7e35
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 0)
+#define ALWAYS_HAVE_ON_EACH_SYMBOL 1
+#else
+#define ALWAYS_HAVE_ON_EACH_SYMBOL 0
+#endif
+
+#if !ALWAYS_HAVE_ON_EACH_SYMBOL
+static int (*kallsyms_on_each_symbol_fn)(int (*fn)(void *, const char *, struct module *, unsigned long),
+                                         void *data) = NULL;
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#define HAVE_ON_EACH_MATCH_SYMBOL 1
+#else
+#define HAVE_ON_EACH_MATCH_SYMBOL 0
+#endif
+
+// https://github.com/torvalds/linux/commit/4dc533e0f2c04174e1ae4aa98e7cffc1c04b9998
+#if HAVE_ON_EACH_MATCH_SYMBOL
+static int (*kallsyms_on_each_match_symbol_fn)(int (*fn)(void *, unsigned long), const char *name, void *data) = NULL;
+static int find_kernel_symbol_exact_cb(void *data, unsigned long addr)
+{
+    *(unsigned long *)data = addr;
+    return 0;
+}
+#endif
 
 struct ksu_lookup_symbol_ctx {
     const char *symbol_name;
@@ -14,12 +54,38 @@ struct ksu_lookup_symbol_ctx {
     void *match;
 };
 
-static bool ksu_symbol_has_suffix(const char *name, size_t name_len, const char *suffix, size_t suffix_len)
+unsigned long __nocfi find_kernel_symbol_exact(const char *symbol_name)
+{
+    unsigned long addr = 0;
+#if HAVE_ON_EACH_MATCH_SYMBOL
+    if (likely(kallsyms_on_each_match_symbol_fn)) {
+        kallsyms_on_each_match_symbol_fn(find_kernel_symbol_exact_cb, symbol_name, &addr);
+        return addr;
+    }
+#endif
+    char *module_name = NULL;
+    char buf[KSYM_SYMBOL_LEN];
+
+    addr = kallsyms_lookup_name(symbol_name);
+    // check if it is kernel symbol
+    kallsyms_lookup(addr, NULL, NULL, &module_name, buf);
+    if (unlikely(module_name)) {
+        pr_warn("ignore symbol %s of module %s\n", symbol_name, module_name);
+        return 0;
+    }
+    return addr;
+}
+
+static inline bool ksu_symbol_has_suffix(const char *name, size_t name_len, const char *suffix, size_t suffix_len)
 {
     return name_len >= suffix_len && strcmp(name + name_len - suffix_len, suffix) == 0;
 }
 
-static int ksu_lookup_symbol_handle_match(void *data, const char *name, unsigned long addr)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+static int lookup_symbol_variant_cb(void *data, const char *name, unsigned long addr)
+#else
+static int lookup_symbol_variant_cb(void *data, const char *name, struct module *mod, unsigned long addr)
+#endif
 {
     struct ksu_lookup_symbol_ctx *ctx = data;
     size_t name_len;
@@ -35,43 +101,83 @@ static int ksu_lookup_symbol_handle_match(void *data, const char *name, unsigned
             return 0;
     }
 
+#if !USE_KCFI
     if (ksu_symbol_has_suffix(name, name_len, cfi_suffix, cfi_suffix_len)) {
         ctx->match = (void *)addr;
+        pr_info("use .cfi_jt variant: %s\n", name);
         return 1;
     }
+#endif
 
-    if (!ctx->match)
+    if (!ctx->match) {
         ctx->match = (void *)addr;
+        pr_info("found variant: %s\n", name);
+#if USE_KCFI
+        return 1;
+#endif
+    }
 
     return 0;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
-static int ksu_lookup_symbol_cb(void *data, const char *name, unsigned long addr)
-{
-    return ksu_lookup_symbol_handle_match(data, name, addr);
-}
-#else
-static int ksu_lookup_symbol_cb(void *data, const char *name, struct module *mod, unsigned long addr)
-{
-    if (mod)
-        return 0;
-
-    return ksu_lookup_symbol_handle_match(data, name, addr);
-}
-#endif
-
-void *ksu_lookup_symbol(const char *symbol_name)
+static __nocfi void *resolve_symbol_variant(const char *symbol_name, size_t symbol_len)
 {
     struct ksu_lookup_symbol_ctx ctx = {
         .symbol_name = symbol_name,
+        .symbol_len = symbol_len,
     };
+
+#if !ALWAYS_HAVE_ON_EACH_SYMBOL
+    if (kallsyms_on_each_symbol_fn) {
+        kallsyms_on_each_symbol_fn(lookup_symbol_variant_cb, &ctx);
+    }
+    // TODO: iterate kallsyms by sprint_symbol
+#else
+    kallsyms_on_each_symbol(lookup_symbol_variant_cb, &ctx);
+#endif
+    return ctx.match;
+}
+
+void *ksu_resolve_symbol_for_functable_hook(const char *symbol_name)
+{
+    void *addr;
+    size_t symbol_len;
 
     if (!symbol_name || !symbol_name[0])
         return NULL;
 
-    ctx.symbol_len = strlen(symbol_name);
+    symbol_len = strlen(symbol_name);
 
-    kallsyms_on_each_symbol(ksu_lookup_symbol_cb, &ctx);
-    return ctx.match;
+    // Prefer find_kernel_symbol_exact since it uses binary search in higher kernel version
+
+#if !USE_KCFI
+    // Try .cfi_jt suffix first
+    char cfi_name[KSYM_NAME_LEN];
+    snprintf(cfi_name, sizeof(cfi_name), "%s.cfi_jt", symbol_name);
+    addr = (void *)find_kernel_symbol_exact(cfi_name);
+    if (addr)
+        return addr;
+#endif
+
+    addr = (void *)find_kernel_symbol_exact(symbol_name);
+    if (addr)
+        return addr;
+
+    return resolve_symbol_variant(symbol_name, symbol_len);
+}
+
+void __init ksu_init_symbol_resolver()
+{
+#if !ALWAYS_HAVE_ON_EACH_SYMBOL
+    kallsyms_on_each_symbol_fn = find_kernel_symbol_exact("kallsyms_on_each_symbol");
+    if (!kallsyms_on_each_symbol_fn) {
+        pr_warn("kallsyms_on_each_symbol not found!\n");
+    }
+#endif
+#if HAVE_ON_EACH_MATCH_SYMBOL
+    kallsyms_on_each_match_symbol_fn = find_kernel_symbol_exact("kallsyms_on_each_match_symbol");
+    if (!kallsyms_on_each_match_symbol_fn) {
+        pr_warn("kallsyms_on_each_match_symbol not found!\n");
+    }
+#endif
 }

--- a/kernel/infra/symbol_resolver.c
+++ b/kernel/infra/symbol_resolver.c
@@ -157,13 +157,19 @@ void *ksu_resolve_symbol_for_functable_hook(const char *symbol_name)
     addr = (void *)find_kernel_symbol_exact(cfi_name);
     if (addr)
         return addr;
-#endif
 
+    addr = resolve_symbol_variant(symbol_name, symbol_len);
+    if (addr)
+        return addr;
+
+    return (void *)find_kernel_symbol_exact(symbol_name);
+#else
     addr = (void *)find_kernel_symbol_exact(symbol_name);
     if (addr)
         return addr;
 
     return resolve_symbol_variant(symbol_name, symbol_len);
+#endif
 }
 
 void __init ksu_init_symbol_resolver()

--- a/kernel/infra/symbol_resolver.h
+++ b/kernel/infra/symbol_resolver.h
@@ -1,6 +1,8 @@
 #ifndef __KSU_SYMBOL_RESOLVER_H
 #define __KSU_SYMBOL_RESOLVER_H
 
-void *ksu_lookup_symbol(const char *symbol_name);
+void *ksu_resolve_symbol_for_functable_hook(const char *symbol_name);
+unsigned long find_kernel_symbol_exact(const char *symbol_name);
+void ksu_init_symbol_resolver();
 
 #endif


### PR DESCRIPTION
```
Author: 小潼 <110387028+XiaoTong6666@users.noreply.github.com>
Date:   Thu May 14 17:52:13 2026 +0800
```
```
kernel: Resolve dotted CFI symbol variants in symbol lookup (https://github.com/tiann/KernelSU/pull/3461)

Prefer .cfi_jt matches and walk kernel kallsyms for exact and dotted
symbol variants while ignoring module symbols.

This fixes hook target resolution when a symbol is exposed through
variants such as selinux_setprocattr.<hash>.cfi_jt instead of the bare
selinux_setprocattr name, which previously caused selinux_hide
setprocattr hook installation to fail.
```
```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Sun May 17 17:31:44 2026 +0800
```
```
kernel: refine symbol_resolver (https://github.com/tiann/KernelSU/pull/3469)
```
```
Author: 小潼 <110387028+XiaoTong6666@users.noreply.github.com>
Date:   Wed May 20 13:16:53 2026 +0800
```
```
kernel: Prefer hashed .cfi_jt variants before bare symbols (https://github.com/tiann/KernelSU/pull/3475)
```