### PR TITLE
ci: disable cache-bin in ksud-extra to fix macOS build (https://github.com/tiann/KernelSU/pull/3463)

### DIFF
--- a/.github/workflows/ksud.yml
+++ b/.github/workflows/ksud.yml
@@ -52,6 +52,7 @@ jobs:
       with:
         workspaces: userspace/ksud
         cache-targets: false
+        cache-bin: false
 
     - name: Install cross
       run: |


### PR DESCRIPTION
```
Author: 小潼 <110387028+XiaoTong6666@users.noreply.github.com>
Date:   Thu May 14 20:08:21 2026 +0800
```
```
ci: disable cache-bin in ksud-extra to fix macOS build (https://github.com/tiann/KernelSU/pull/3463)

On macOS runners, rust-cache restores ~/.cargo/bin which overwrites
rustup's cargo proxy shim with a cached rustup-init binary, causing
"unexpected argument 'install' found" when running cargo install.

Setting cache-bin: false prevents rust-cache from saving/restoring
~/.cargo/bin. This is the documented workaround from rust-cache:
https://github.com/Swatinem/rust-cache#known-issues

-workflows/ksud
```