### PR TITLE
ksud: su: support parsing arguments after user; fix some module scripts won't add KSU_MODULE environment var

### DIFF
--- a/userspace/ksud/src/metamodule.rs
+++ b/userspace/ksud/src/metamodule.rs
@@ -66,6 +66,15 @@ pub fn get_metamodule_path() -> Option<PathBuf> {
     result
 }
 
+/// Get Metamodule Id
+pub fn get_metamodule_id() -> Option<String> {
+    get_metamodule_path().and_then(|path| {
+        path.file_name()
+            .and_then(|os_str| os_str.to_str())
+            .map(ToString::to_string)
+    })
+}
+
 /// Check if metamodule exists
 pub fn has_metamodule() -> bool {
     get_metamodule_path().is_some()
@@ -227,7 +236,9 @@ pub fn exec_metauninstall_script(module_id: &str) -> Result<()> {
     let result = Command::new(assets::BUSYBOX_PATH)
         .args(["sh", metauninstall_path.to_str().unwrap()])
         .current_dir(metauninstall_path.parent().unwrap())
-        .envs(crate::module::get_common_script_envs())
+        .envs(crate::module::get_common_script_envs(
+            get_metamodule_id().as_deref(),
+        ))
         .env("MODULE_ID", module_id)
         .status()?;
 
@@ -250,7 +261,9 @@ pub fn exec_mount_script(module_dir: &str) -> Result<()> {
 
     let result = Command::new(assets::BUSYBOX_PATH)
         .args(["sh", mount_script.to_str().unwrap()])
-        .envs(crate::module::get_common_script_envs())
+        .envs(crate::module::get_common_script_envs(
+            get_metamodule_id().as_deref(),
+        ))
         .env("MODULE_DIR", module_dir)
         .status()?;
 

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result, anyhow, bail, ensure};
 use const_format::concatcp;
 use is_executable::is_executable;
 use java_properties::PropertiesIter;
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 use regex_lite::Regex;
 
 use std::fs::{copy, rename};
@@ -57,7 +57,7 @@ pub fn validate_module_id(module_id: &str) -> Result<()> {
 }
 
 /// Get common environment variables for script execution
-pub fn get_common_script_envs() -> Vec<(&'static str, String)> {
+pub fn get_common_script_envs(module_id: Option<&str>) -> Vec<(&'static str, String)> {
     let mut envs = vec![
         ("ASH_STANDALONE", "1".to_string()),
         ("KSU", "true".to_string()),
@@ -74,6 +74,14 @@ pub fn get_common_script_envs() -> Vec<(&'static str, String)> {
         ),
     ];
 
+    if let Some(id) = module_id {
+        if validate_module_id(id).is_ok() {
+            envs.push(("KSU_MODULE", id.to_string()));
+        } else {
+            error!("Invalid module_id provided: {id}");
+        }
+    }
+
     if ksucalls::is_late_load() {
         envs.push(("KSU_LATE_LOAD", "1".to_string()));
     }
@@ -81,7 +89,7 @@ pub fn get_common_script_envs() -> Vec<(&'static str, String)> {
     envs
 }
 
-fn exec_install_script(module_file: &str, is_metamodule: bool) -> Result<()> {
+fn exec_install_script(module_file: &str, is_metamodule: bool, module_id: &str) -> Result<()> {
     let realpath = std::fs::canonicalize(module_file)
         .with_context(|| format!("realpath: {module_file} failed"))?;
 
@@ -91,7 +99,7 @@ fn exec_install_script(module_file: &str, is_metamodule: bool) -> Result<()> {
 
     let result = Command::new(assets::BUSYBOX_PATH)
         .args(["sh", "-c", &install_script])
-        .envs(get_common_script_envs())
+        .envs(get_common_script_envs(Some(module_id)))
         .env("OUTFD", "1")
         .env("ZIPFILE", realpath)
         .status()?;
@@ -227,12 +235,7 @@ pub fn exec_script<T: AsRef<Path>>(path: T, wait: bool) -> Result<()> {
         .current_dir(path.as_ref().parent().unwrap())
         .arg("sh")
         .arg(path.as_ref())
-        .envs(get_common_script_envs());
-
-    // Set KSU_MODULE environment variable if module_id was validated successfully
-    if let Some(id) = validated_module_id {
-        command = command.env("KSU_MODULE", id);
-    }
+        .envs(get_common_script_envs(validated_module_id));
 
     let result = if wait {
         command.status().map(|_| ())
@@ -518,7 +521,7 @@ fn install_module_to_system(zip: &str) -> Result<()> {
 
     // Execute install script
     println!("- Running module installer");
-    exec_install_script(zip, is_metamodule)?;
+    exec_install_script(zip, is_metamodule, module_id)?;
 
     let module_dir = Path::new(MODULE_DIR).join(module_id);
     ensure_dir_exists(&module_dir)?;

--- a/userspace/ksud/src/su.rs
+++ b/userspace/ksud/src/su.rs
@@ -6,10 +6,10 @@ use anyhow::{Context, Ok, Result, bail};
 use getopts::Options;
 use libc::c_int;
 use log::error;
-use std::env;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
+use std::{cmp::Ordering, env};
 use std::{
     ffi::{CStr, CString},
     process::Command,
@@ -88,18 +88,42 @@ pub fn root_shell() -> Result<()> {
     use anyhow::anyhow;
     let env_args: Vec<String> = env::args().collect();
     let program = env_args[0].clone();
-    let args = env_args.iter().position(|arg| arg == "-c").map_or_else(
-        || env_args.clone(),
-        |i| {
-            let rest = env_args[i + 1..].to_vec();
-            let mut new_args = env_args[..i].to_vec();
+    let mut executable: Option<String> = None;
+    let mut exec_args: Option<Vec<String>> = None;
+    let first_option_c = env_args
+        .iter()
+        .position(|arg| arg == "-c")
+        .unwrap_or(usize::MAX);
+    let first_non_option = env_args
+        .windows(3)
+        .position(|arg| {
+            !arg[1].starts_with('-')
+                && !arg[2].starts_with('-')
+                && !(arg[0].starts_with("-g")
+                    || arg[0].starts_with("-G")
+                    || arg[0].starts_with("-s")
+                    || arg[0] == "--group"
+                    || arg[0] == "--supp-group="
+                    || arg[0] == "--shell=")
+        })
+        .map_or(usize::MAX, |idx| idx + 1);
+    let args = match first_non_option.cmp(&first_option_c) {
+        Ordering::Equal => env_args,
+        Ordering::Less => {
+            executable = Some(env_args[first_non_option + 1].clone());
+            exec_args = Some(env_args[first_non_option + 2..].to_vec());
+            env_args[..=first_non_option].to_vec()
+        }
+        Ordering::Greater => {
+            let rest = env_args[first_option_c + 1..].to_vec();
+            let mut new_args = env_args[..first_option_c].to_vec();
             new_args.push("-c".to_string());
             if !rest.is_empty() {
                 new_args.push(rest.join(" "));
             }
             new_args
-        },
-    );
+        }
+    };
 
     let mut opts = Options::new();
     opts.optopt(
@@ -201,10 +225,12 @@ pub fn root_shell() -> Result<()> {
     }
 
     // we've make sure that -c is the last option and it already contains the whole command, no need to construct it again
-    let args = matches
-        .opt_str("c")
-        .map(|cmd| vec!["-c".to_string(), cmd])
-        .unwrap_or_default();
+    let args = exec_args.unwrap_or_else(|| {
+        matches
+            .opt_str("c")
+            .map(|cmd| vec!["-c".to_string(), cmd])
+            .unwrap_or_default()
+    });
 
     let mut free_idx = 0;
     if !matches.free.is_empty() && matches.free[free_idx] == "-" {
@@ -227,10 +253,11 @@ pub fn root_shell() -> Result<()> {
 
     // if there is no gid provided, use uid.
     let gid = gid.unwrap_or(uid);
+    let executable = executable.as_ref().unwrap_or(&shell);
     // https://github.com/topjohnwu/Magisk/blob/master/native/src/su/su_daemon.cpp#L408
-    let arg0 = if is_login { "-" } else { &shell };
+    let arg0 = if is_login { "-" } else { executable };
 
-    let mut command = &mut Command::new(&shell);
+    let mut command = Command::new(executable);
 
     if !preserve_env {
         // This is actually incorrect, i don't know why.
@@ -245,7 +272,7 @@ pub fn root_shell() -> Result<()> {
             let home = home.to_string_lossy();
             let pw_name = pw_name.to_string_lossy();
 
-            command = command
+            command
                 .env("HOME", home.as_ref())
                 .env("USER", pw_name.as_ref())
                 .env("LOGNAME", pw_name.as_ref())
@@ -258,13 +285,13 @@ pub fn root_shell() -> Result<()> {
 
     // when KSURC_PATH exists and ENV is not set, set ENV to KSURC_PATH
     if PathBuf::from(defs::KSURC_PATH).exists() && env::var("ENV").is_err() {
-        command = command.env("ENV", defs::KSURC_PATH);
+        command.env("ENV", defs::KSURC_PATH);
     }
 
     // escape from the current cgroup and become session leader
     // WARNING!!! This cause some root shell hang forever!
     // command = command.process_group(0);
-    command = unsafe {
+    unsafe {
         command.pre_exec(move || {
             umask(0o22);
             utils::switch_cgroups();
@@ -286,7 +313,7 @@ pub fn root_shell() -> Result<()> {
         })
     };
 
-    command = command.args(args).arg0(arg0);
+    command.args(args).arg0(arg0);
     Err(command.exec().into())
 }
 


### PR DESCRIPTION
```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Thu May 14 22:38:28 2026 +0800
```
```
ksud: su: support parsing arguments after user (https://github.com/tiann/KernelSU/pull/3464)
```
```
Author: AlexLiuDev233 <wzylin11@outlook.com>
Date:   Wed May 20 14:09:51 2026 +0000
```
```
 ksud: fix some module scripts won't add KSU_MODULE environment var (https://github.com/tiann/KernelSU/pull/3445)

KSU_MODULE environment var will only pass in exec_script, that's cause
only stage-scripts, action.sh and uninstall scripts have this
environment var

So, it cause customize.sh, and meta*.sh won't have this envionment var
And module developers will see them can't use ksud module config set
command,
because ksud throw
`This command must be run in the context of a module or passed
--internal <name>`

Taking the magic_mount_rs module as an example:
 before:
 ```
KSU='true'
KSU_KERNEL_VER_CODE='32481'
KSU_VER='3.2.4-24-gcc83433b'
KSU_VER_CODE='32481'
```
after:
```
KSU='true'
KSU_KERNEL_VER_CODE='32481'
KSU_MODULE='magic_mount_rs'
KSU_VER='3.2.4-24-gcc83433b'
KSU_VER_CODE='32481'
```

Signed-off-by: AlexLiuDev233 <wzylin11@outlook.com>
```