### PR TITLE
kernel: symbol_resolver: resolve symbol suffix starts with '$'

### DIFF
--- a/kernel/infra/symbol_resolver.c
+++ b/kernel/infra/symbol_resolver.c
@@ -97,7 +97,7 @@ static int lookup_symbol_variant_cb(void *data, const char *name, struct module 
 
     if (strcmp(name, ctx->symbol_name) != 0) {
         if (name_len <= ctx->symbol_len || strncmp(name, ctx->symbol_name, ctx->symbol_len) != 0 ||
-            name[ctx->symbol_len] != '.')
+            (name[ctx->symbol_len] != '.' && name[ctx->symbol_len] != '$'))
             return 0;
     }
 


### PR DESCRIPTION
```
Author: 5ec1cff <ewtqyqyewtqyqy@gmail.com>
Date:   Sat May 23 14:57:13 2026 +0800
```
```
kernel: symbol_resolver: resolve symbol suffix starts with '$'
```
https://github.com/tiann/KernelSU/commit/96a72dd0107d660adcb273ab1911e1e77d87e562