### PR TITLE
feature: adb_root; manager: re-order features placement

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -44,6 +44,8 @@ kernelsu-objs += supercall/dispatch.o
 kernelsu-objs += supercall/perm.o
 kernelsu-objs += supercall/supercall.o
 
+kernelsu-objs += feature/adb_root.o
+
 kernelsu-objs += feature/selinux_hide.o
 
 ifdef KBUILD_EXTMOD

--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -21,6 +21,7 @@
 #include "infra/file_wrapper.h"
 #include "selinux/selinux.h"
 #include "hook/syscall_hook.h"
+#include "feature/adb_root.h"
 #include "feature/selinux_hide.h"
 #include "infra/symbol_resolver.h"
 
@@ -126,6 +127,8 @@ int __init kernelsu_init(void)
 
 	ksu_feature_init();
 
+	ksu_adb_root_init();
+
 	ksu_lsm_hook_init();
 
 	ksu_selinux_hide_init();
@@ -204,6 +207,8 @@ void __exit kernelsu_exit(void)
 	ksu_selinux_hide_exit();
 
 	ksu_lsm_hook_exit();
+
+	ksu_adb_root_exit();
 
 	ksu_feature_exit();
 

--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -1,0 +1,224 @@
+
+#include <asm/memory.h>
+#include <asm/ptrace.h>
+#include <linux/namei.h>
+#include <linux/path.h>
+#include <linux/printk.h>
+#include <linux/types.h>
+#include <linux/string.h>
+#include <linux/uaccess.h>
+#include <linux/ptrace.h>
+#include <linux/static_key.h>
+#include <linux/slab.h>
+
+#include "adb_root.h"
+#include "arch.h"
+#include "policy/feature.h"
+#include "selinux/selinux.h"
+
+#include "klog.h" // IWYU pragma: keep
+
+DEFINE_STATIC_KEY_FALSE(ksu_adb_root);
+
+static long is_exec_adbd(struct pt_regs *regs)
+{
+    static const char kAdbd[] = "/adbd";
+    static const size_t kAdbdLen = sizeof(kAdbd) - 1;
+    char __user *filename_user = (char __user *)PT_REGS_PARM1(regs);
+    // should be bigger than `/apex/com.android.adbd/bin/adbd`
+    char buf[40];
+    char __user *fn;
+    long ret;
+    fn = (char __user *)untagged_addr((unsigned long)filename_user);
+    memset(buf, 0, sizeof(buf));
+
+    ret = strncpy_from_user(buf, fn, sizeof(buf));
+    if (ret < 0) {
+        pr_warn("Access filename when adb_root_handle_execve failed: %ld\n", ret);
+        return ret;
+    }
+
+    if (ret < kAdbdLen || memcmp(buf + ret - kAdbdLen, kAdbd, kAdbdLen + 1) != 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static long is_libadbroot_ok()
+{
+    static const char kLibAdbRoot[] = "/data/adb/ksu/lib/libadbroot.so";
+    struct path path;
+    long ret = kern_path(kLibAdbRoot, 0, &path);
+    if (ret < 0) {
+        if (ret == -ENOENT) {
+            pr_err("libadbroot.so not exists, skip adb root. Please run `ksud install`\n");
+            ret = 0;
+        } else {
+            pr_err("access libadbroot.so failed: %ld, skip adb root\n", ret);
+        }
+    } else {
+        ret = 1;
+    }
+    path_put(&path);
+    return ret;
+}
+
+static long setup_ld_preload(struct pt_regs *regs)
+{
+    static const char kLdPreload[] = "LD_PRELOAD=/data/adb/ksu/lib/libadbroot.so";
+    static const char kLdLibraryPath[] = "LD_LIBRARY_PATH=/data/adb/ksu/lib";
+    static const size_t kReadEnvBatch = 16;
+    static const size_t kPtrSize = sizeof(unsigned long);
+    unsigned long stackp = user_stack_pointer(regs);
+    unsigned long envp, ld_preload_p, ld_library_path_p;
+    unsigned long *envp_p = (unsigned long *)&PT_REGS_PARM3(regs);
+    unsigned long *tmp_env_p = NULL, *tmp_env_p2 = NULL;
+    size_t env_count = 0, total_size;
+    long ret;
+
+    envp = (char __user **)untagged_addr((unsigned long)*envp_p);
+
+    ld_preload_p = stackp = ALIGN_DOWN(stackp - sizeof(kLdPreload), 8);
+    ret = copy_to_user(ld_preload_p, kLdPreload, sizeof(kLdPreload));
+    if (ret != 0) {
+        pr_warn("write ld_preload when adb_root_handle_execve failed: %ld\n", ret);
+        return -EFAULT;
+    }
+
+    ld_library_path_p = stackp = ALIGN_DOWN(stackp - sizeof(kLdLibraryPath), 8);
+    ret = copy_to_user(ld_library_path_p, kLdLibraryPath, sizeof(kLdLibraryPath));
+    if (ret != 0) {
+        pr_warn("write ld_library_path when adb_root_handle_execve failed: %ld\n", ret);
+        return -EFAULT;
+    }
+
+    for (;;) {
+        tmp_env_p2 = krealloc(tmp_env_p, (env_count + kReadEnvBatch + 2) * kPtrSize, GFP_KERNEL);
+        if (tmp_env_p2 == NULL) {
+            pr_err("alloc tmp env failed\n");
+            ret = -ENOMEM;
+            goto out_release_env_p;
+        }
+        tmp_env_p = tmp_env_p2;
+        ret = copy_from_user(&tmp_env_p[env_count], envp + env_count * kPtrSize, kReadEnvBatch * kPtrSize);
+        if (ret < 0) {
+            pr_warn("Access envp when adb_root_handle_execve failed: %ld\n", ret);
+            ret = -EFAULT;
+            goto out_release_env_p;
+        }
+        size_t read_count = kReadEnvBatch * kPtrSize - ret;
+        size_t max_new_env_count = read_count / kPtrSize, new_env_count = 0;
+        bool meet_zero = false;
+        for (; new_env_count < max_new_env_count; new_env_count++) {
+            if (!tmp_env_p[new_env_count + env_count]) {
+                meet_zero = true;
+                break;
+            }
+        }
+        if (!meet_zero) {
+            if (read_count % kPtrSize != 0) {
+                pr_err("unaligned envp array!\n");
+                ret = -EFAULT;
+                goto out_release_env_p;
+            } else if (ret != 0) {
+                pr_err("truncated envp array!\n");
+                ret = -EFAULT;
+                goto out_release_env_p;
+            }
+        }
+        env_count += new_env_count;
+        if (meet_zero)
+            break;
+    }
+
+    // We should have allocated enough memory
+    // TODO: handle existing LD_PRELOAD
+    tmp_env_p[env_count++] = ld_preload_p;
+    tmp_env_p[env_count++] = ld_library_path_p;
+    tmp_env_p[env_count++] = 0;
+    total_size = env_count * kPtrSize;
+
+    stackp -= total_size;
+    ret = copy_to_user(stackp, tmp_env_p, total_size);
+    if (ret != 0) {
+        pr_err("copy new env failed: %ld\n", ret);
+        ret = -EFAULT;
+        goto out_release_env_p;
+    }
+
+    *envp_p = stackp;
+    ret = 0;
+
+out_release_env_p:
+    if (tmp_env_p) {
+        kfree(tmp_env_p);
+    }
+
+    return ret;
+}
+
+static long do_ksu_adb_root_handle_execve(struct pt_regs *regs)
+{
+    if (likely(is_exec_adbd(regs) != 1)) {
+        return 0;
+    }
+
+    if (unlikely(is_libadbroot_ok() != 1)) {
+        return 0;
+    }
+
+    long ret = setup_ld_preload(regs);
+    if (ret) {
+        return ret;
+    }
+
+    pr_info("escape to root for adb\n");
+    escape_to_root_for_adb_root();
+    return 0;
+}
+
+long ksu_adb_root_handle_execve(struct pt_regs *regs)
+{
+    if (static_branch_unlikely(&ksu_adb_root)) {
+        return do_ksu_adb_root_handle_execve(regs);
+    }
+    return 0;
+}
+
+static int kernel_adb_root_feature_get(u64 *value)
+{
+    *value = static_key_enabled(&ksu_adb_root) ? 1 : 0;
+    return 0;
+}
+
+static int kernel_adb_root_feature_set(u64 value)
+{
+    bool enable = value != 0;
+    if (enable) {
+        static_key_enable(&ksu_adb_root.key);
+    } else {
+        static_key_disable(&ksu_adb_root.key);
+    }
+    pr_info("adb_root: set to %d\n", enable);
+    return 0;
+}
+
+static const struct ksu_feature_handler ksu_adb_root_handler = {
+    .feature_id = KSU_FEATURE_ADB_ROOT,
+    .name = "adb_root",
+    .get_handler = kernel_adb_root_feature_get,
+    .set_handler = kernel_adb_root_feature_set,
+};
+
+void __init ksu_adb_root_init(void)
+{
+    if (ksu_register_feature_handler(&ksu_adb_root_handler)) {
+        pr_err("Failed to register adb_root feature handler\n");
+    }
+}
+
+void __exit ksu_adb_root_exit(void)
+{
+    ksu_unregister_feature_handler(KSU_FEATURE_ADB_ROOT);
+}

--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -38,7 +38,8 @@ static long is_exec_adbd(struct pt_regs *regs)
         return ret;
     }
 
-    if (ret < kAdbdLen || memcmp(buf + ret - kAdbdLen, kAdbd, kAdbdLen + 1) != 0) {
+    // strncpy_from_user may copy `sizeof(buf)` bytes
+    if (ret < kAdbdLen || ret >= sizeof(buf) || memcmp(buf + ret - kAdbdLen, kAdbd, kAdbdLen + 1) != 0) {
         return 0;
     }
 

--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -1,5 +1,4 @@
 
-#include <asm/memory.h>
 #include <asm/ptrace.h>
 #include <linux/namei.h>
 #include <linux/path.h>

--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -58,6 +58,7 @@ static long is_libadbroot_ok()
         } else {
             pr_err("access libadbroot.so failed: %ld, skip adb root\n", ret);
         }
+        return ret;
     } else {
         ret = 1;
     }

--- a/kernel/feature/adb_root.h
+++ b/kernel/feature/adb_root.h
@@ -1,0 +1,11 @@
+#ifndef __KSU_H_ADB_ROOT
+#define __KSU_H_ADB_ROOT
+#include <asm/ptrace.h>
+
+long ksu_adb_root_handle_execve(struct pt_regs *regs);
+
+void ksu_adb_root_init(void);
+
+void ksu_adb_root_exit(void);
+
+#endif

--- a/kernel/hook/syscall_event_bridge.c
+++ b/kernel/hook/syscall_event_bridge.c
@@ -16,6 +16,7 @@
 #include "runtime/ksud.h"
 #include "hook/syscall_hook.h"
 #include "hook/syscall_event_bridge.h"
+#include "feature/adb_root.h"
 
 static int ksu_handle_init_mark_tracker(const char __user **filename_user)
 {
@@ -90,12 +91,17 @@ long __nocfi ksu_hook_execve(int orig_nr, const struct pt_regs *regs)
 {
     const char __user **filename_user = (const char __user **)&PT_REGS_PARM1(regs);
     bool current_is_init = is_init(current_cred());
+    long ret;
 
     if (static_branch_unlikely(&ksud_execve_key))
         ksu_execve_hook_ksud(regs);
 
     if (current->pid != 1 && current_is_init) {
         ksu_handle_init_mark_tracker(filename_user);
+        ret = ksu_adb_root_handle_execve((struct pt_regs *)regs);
+        if (ret) {
+            pr_err("adb root failed: %ld\n", ret);
+        }
     } else if (ksu_su_compat_enabled) {
         return ksu_handle_execve_sucompat(filename_user, orig_nr, regs);
     }

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -130,6 +130,11 @@ void apply_kernelsu_rules()
     ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fifo_file", "read");
     ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fifo_file", "open");
     ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fifo_file", "getattr");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "read");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "write");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "connectto");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "getopt");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "getattr");
 
     // bootctl
     ksu_allow(db, "hwservicemanager", KERNEL_SU_DOMAIN, "dir", "search");

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -23,7 +23,7 @@ static u32 cached_zygote_sid __read_mostly = 0;
 static u32 cached_init_sid __read_mostly = 0;
 u32 ksu_file_sid __read_mostly = 0;
 
-static int transive_to_domain(const char *domain, struct cred *cred)
+static int transive_to_domain(const char *domain, struct cred *cred, bool clear_exec_sid)
 {
     u32 sid;
     int error;
@@ -47,13 +47,16 @@ static int transive_to_domain(const char *domain, struct cred *cred)
         tsec->create_sid = 0;
         tsec->keycreate_sid = 0;
         tsec->sockcreate_sid = 0;
+        if (clear_exec_sid) {
+            tsec->exec_sid = 0;
+        }
     }
     return error;
 }
 
 void setup_selinux(const char *domain, struct cred *cred)
 {
-    if (transive_to_domain(domain, cred)) {
+    if (transive_to_domain(domain, cred, false)) {
         pr_err("transive domain failed.\n");
         return;
     }
@@ -61,7 +64,7 @@ void setup_selinux(const char *domain, struct cred *cred)
 
 void setup_ksu_cred(void)
 {
-    if (ksu_cred && transive_to_domain(KERNEL_SU_CONTEXT, ksu_cred)) {
+    if (ksu_cred && transive_to_domain(KERNEL_SU_CONTEXT, ksu_cred, false)) {
         pr_err("setup ksu cred failed.\n");
     }
 }
@@ -206,4 +209,20 @@ bool is_zygote(const struct cred *cred)
 bool is_init(const struct cred *cred)
 {
     return is_sid_match(cred, cached_init_sid, INIT_CONTEXT);
+}
+
+void escape_to_root_for_adb_root(void)
+{
+    struct cred *cred = prepare_creds();
+    if (!cred) {
+        pr_err("Failed to prepare adbd's creds!\n");
+        return;
+    }
+
+    if (transive_to_domain(KERNEL_SU_CONTEXT, cred, true)) {
+        pr_err("transive domain failed.\n");
+        abort_creds(cred);
+        return;
+    }
+    commit_creds(cred);
 }

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -35,6 +35,8 @@ int handle_sepolicy(void __user *user_data, u64 data_len);
 
 void setup_ksu_cred();
 
+void escape_to_root_for_adb_root();
+
 extern u32 ksu_file_sid;
 
 #endif

--- a/manager/app/src/main/cpp/CMakeLists.txt
+++ b/manager/app/src/main/cpp/CMakeLists.txt
@@ -21,3 +21,6 @@ target_include_directories(kernelsu PRIVATE .)
 find_library(log-lib log)
 
 target_link_libraries(kernelsu ${log-lib})
+
+add_library(adbroot SHARED adbroot.cc)
+target_link_libraries(adbroot ${log-lib})

--- a/manager/app/src/main/cpp/adbroot.cc
+++ b/manager/app/src/main/cpp/adbroot.cc
@@ -1,6 +1,8 @@
 #include <string>
 #include <dlfcn.h>
 #include <cstdlib>
+#include <unistd.h>
+#include <vector>
 
 // Skip drop privileges
 // https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/adb/daemon/main.cpp;l=123;drc=3b74954ec50836e0c8faeed1877fefb1dc2de006
@@ -32,6 +34,55 @@ std::string GetProperty(const std::string &key, const std::string &default_value
     }
 
     return orig_fn(key, default_value);
+}
+
+// If the user creates ksurc, use ksurc instead of mkshrc
+// https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/adb/daemon/shell_service.cpp;l=389-394
+extern "C" [[gnu::visibility("default"), gnu::used]]
+int execle(const char *pathname, const char *arg, ...) {
+    std::vector<const char *> argv_list;
+    va_list va;
+    va_start(va, arg);
+
+    // start dump argv
+    if (arg != nullptr) {
+        argv_list.push_back(arg);
+        const char *next;
+        while ((next = va_arg(va, const char*)) != nullptr) {
+            argv_list.push_back(next);
+        }
+    }
+    argv_list.push_back(nullptr);
+
+    char *const *old_envp = va_arg(va, char* const*);
+    va_end(va);
+
+    // start dump envp
+    std::vector<const char *> env_list;
+    bool ksurc_exists = (access("/data/adb/ksu/.ksurc", F_OK) == 0);
+    const char *ksu_env_str = "ENV=/data/adb/ksu/.ksurc";
+
+    if (old_envp != nullptr) {
+        for (size_t i = 0; old_envp[i] != nullptr; ++i) {
+            // skip original ENV in envp
+            // even there shouldn't exists in normal android, but let's still check it, avoid newer android/custom rom modify there
+            if (ksurc_exists && strncmp(old_envp[i], "ENV=", 4) == 0) {
+                continue;
+            }
+            env_list.push_back(old_envp[i]);
+        }
+    }
+
+    if (ksurc_exists) {
+        // push our ENV in here!!!
+        env_list.push_back(ksu_env_str);
+    }
+    env_list.push_back(nullptr);
+
+    // skip origin execle, because we already completed everything of execle
+    return execve(pathname,
+                  const_cast<char *const *>(argv_list.data()),
+                  const_cast<char *const *>(env_list.data()));
 }
 
 // skip setcon

--- a/manager/app/src/main/cpp/adbroot.cc
+++ b/manager/app/src/main/cpp/adbroot.cc
@@ -1,0 +1,55 @@
+#include <string>
+#include <dlfcn.h>
+#include <cstdlib>
+
+// Skip drop privileges
+// https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/adb/daemon/main.cpp;l=123;drc=3b74954ec50836e0c8faeed1877fefb1dc2de006
+extern "C"
+[[gnu::visibility("default"), gnu::used]]
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
+int __android_log_is_debuggable() {
+    return 1;
+}
+
+// This function has a C++ return type, so we can't use extern "C".
+// We can't define simply it in android::base namespace, otherwise we will get wrong mangled name (string is in ndk namespace)
+// Therefore, we use asm to define its mangled name instead.
+// https://stackoverflow.com/a/33321513
+[[gnu::visibility("default"), gnu::used]]
+std::string GetProperty(const std::string &key, const std::string &default_value)
+asm ("_ZN7android4base11GetPropertyERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEES9_");
+
+// Enable adb root by default, without run `adb root` command explicitly or setprop
+// https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/adb/daemon/main.cpp;l=84;drc=3b74954ec50836e0c8faeed1877fefb1dc2de006
+[[gnu::visibility("default"), gnu::used]]
+std::string GetProperty(const std::string &key, const std::string &default_value) {
+    static constexpr const auto kSymbolName = "_ZN7android4base11GetPropertyERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEES9_";
+    static auto orig_fn = (decltype(GetProperty) *) dlsym(RTLD_NEXT, kSymbolName);
+
+    if (key == "service.adb.root") {
+        // allow drop privilege by prop, but don't drop by default
+        return orig_fn(key, "1");
+    }
+
+    return orig_fn(key, default_value);
+}
+
+// skip setcon
+extern "C"
+[[gnu::visibility("default"), gnu::used]]
+int selinux_android_setcon(const char *con) {
+    return 0;
+}
+
+[[gnu::used, gnu::constructor(0)]]
+void Init() {
+    unsetenv("LD_PRELOAD");
+    unsetenv("LD_LIBRARY_PATH");
+    std::string path = getenv("PATH") ?: "";
+    if (!path.empty()) {
+        path += ":/data/adb/ksu/bin";
+    } else {
+        path += "/data/adb/ksu/bin";
+    }
+    setenv("PATH", path.c_str(), 1);
+}

--- a/manager/app/src/main/cpp/adbroot.cc
+++ b/manager/app/src/main/cpp/adbroot.cc
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <unistd.h>
 #include <vector>
+#include <sys/system_properties.h>
 
 // Skip drop privileges
 // https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/adb/daemon/main.cpp;l=123;drc=3b74954ec50836e0c8faeed1877fefb1dc2de006
@@ -13,27 +14,43 @@ int __android_log_is_debuggable() {
     return 1;
 }
 
-// This function has a C++ return type, so we can't use extern "C".
-// We can't define simply it in android::base namespace, otherwise we will get wrong mangled name (string is in ndk namespace)
-// Therefore, we use asm to define its mangled name instead.
-// https://stackoverflow.com/a/33321513
-[[gnu::visibility("default"), gnu::used]]
-std::string GetProperty(const std::string &key, const std::string &default_value)
-asm ("_ZN7android4base11GetPropertyERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEES9_");
+struct prop_info {};
+
+static struct prop_info g_adb_root_prop;
 
 // Enable adb root by default, without run `adb root` command explicitly or setprop
 // https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/adb/daemon/main.cpp;l=84;drc=3b74954ec50836e0c8faeed1877fefb1dc2de006
-[[gnu::visibility("default"), gnu::used]]
-std::string GetProperty(const std::string &key, const std::string &default_value) {
-    static constexpr const auto kSymbolName = "_ZN7android4base11GetPropertyERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEES9_";
-    static auto orig_fn = (decltype(GetProperty) *) dlsym(RTLD_NEXT, kSymbolName);
+// https://cs.android.com/android/platform/superproject/+/android-latest-release:system/libbase/properties.cpp;l=159-175;drc=6d19b5c690fa4220c10e42c2326150bbd4d4b7bb
+// android::base::GetProperty is from libbase.so, but some adbd are statically-linked to it, 
+// so we replace these two underlying functions.
 
-    if (key == "service.adb.root") {
-        // allow drop privilege by prop, but don't drop by default
-        return orig_fn(key, "1");
+extern "C" [[gnu::visibility("default"), gnu::used]]
+const prop_info* __system_property_find(const char* name) {
+    static decltype(__system_property_find) *system_property_find_fn = nullptr;
+    if (strcmp(name, "service.adb.root") == 0) {
+        return &g_adb_root_prop;
     }
+    if (!system_property_find_fn) {
+        system_property_find_fn = (decltype(system_property_find_fn)) dlsym(RTLD_NEXT, "__system_property_find");
+    }
+    return system_property_find_fn(name);
+}
 
-    return orig_fn(key, default_value);
+extern "C" [[gnu::visibility("default"), gnu::used]]
+void __system_property_read_callback(const prop_info* pi,
+    void (*callback)(void* cookie, const char* name, const char* value, uint32_t serial),
+    void* cookie) {
+    static decltype(__system_property_read_callback) *orig_fn = nullptr;
+    if (pi == &g_adb_root_prop) {
+        if (callback) {
+            callback(cookie, "service.adb.root", "1", 0);
+        }
+        return;
+    }
+    if (!orig_fn) {
+        orig_fn = (decltype(orig_fn)) dlsym(RTLD_NEXT, "__system_property_read_callback");
+    }
+    orig_fn(pi, callback, cookie);
 }
 
 // If the user creates ksurc, use ksurc instead of mkshrc

--- a/manager/app/src/main/cpp/jni.cc
+++ b/manager/app/src/main/cpp/jni.cc
@@ -383,17 +383,6 @@ Java_com_rifsxd_ksunext_Natives_setAdbRootEnabled(JNIEnv *env, jobject thiz, jbo
 
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_rifsxd_ksunext_Natives_isAvcSpoofEnabled(JNIEnv *env, jobject thiz) {
-    return is_avc_spoof_enabled();
-}
-extern "C"
-JNIEXPORT jboolean JNICALL
-Java_com_rifsxd_ksunext_Natives_setAvcSpoofEnabled(JNIEnv *env, jobject thiz, jboolean enabled) {
-    return set_avc_spoof_enabled(enabled);
-}
-
-extern "C"
-JNIEXPORT jboolean JNICALL
 Java_com_rifsxd_ksunext_Natives_isSelinuxHideEnabled(JNIEnv *env, jobject thiz) {
     return is_selinux_hide_enabled();
 }
@@ -402,6 +391,17 @@ extern "C"
 JNIEXPORT jint JNICALL
 Java_com_rifsxd_ksunext_Natives_setSelinuxHideEnabled(JNIEnv *env, jobject thiz, jboolean enabled) {
     return set_selinux_hide_enabled(enabled);
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_rifsxd_ksunext_Natives_isAvcSpoofEnabled(JNIEnv *env, jobject thiz) {
+    return is_avc_spoof_enabled();
+}
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_rifsxd_ksunext_Natives_setAvcSpoofEnabled(JNIEnv *env, jobject thiz, jboolean enabled) {
+    return set_avc_spoof_enabled(enabled);
 }
 
 extern "C"

--- a/manager/app/src/main/cpp/jni.cc
+++ b/manager/app/src/main/cpp/jni.cc
@@ -371,6 +371,18 @@ Java_com_rifsxd_ksunext_Natives_setKernelUmountEnabled(JNIEnv *env, jobject thiz
 
 extern "C"
 JNIEXPORT jboolean JNICALL
+Java_com_rifsxd_ksunext_Natives_isAdbRootEnabled(JNIEnv *env, jobject thiz) {
+    return is_adb_root_enabled();
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_rifsxd_ksunext_Natives_setAdbRootEnabled(JNIEnv *env, jobject thiz, jboolean enabled) {
+    return set_adb_root_enabled(enabled);
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
 Java_com_rifsxd_ksunext_Natives_isAvcSpoofEnabled(JNIEnv *env, jobject thiz) {
     return is_avc_spoof_enabled();
 }

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -162,25 +162,6 @@ bool is_su_enabled() {
     return cmd.value != 0;
 }
 
-bool set_avc_spoof_enabled(bool enabled) {
-    struct ksu_set_feature_cmd cmd = {};
-    cmd.feature_id = KSU_FEATURE_AVC_SPOOF;
-    cmd.value = enabled ? 1 : 0;
-    return ksuctl(KSU_IOCTL_SET_FEATURE, &cmd) == 0;
-}
-
-bool is_avc_spoof_enabled() {
-    struct ksu_get_feature_cmd cmd = {};
-    cmd.feature_id = KSU_FEATURE_AVC_SPOOF;
-    if (ksuctl(KSU_IOCTL_GET_FEATURE, &cmd) != 0) {
-        return false;
-    }
-    if (!cmd.supported) {
-        return false;
-    }
-    return cmd.value != 0;
-}
-
 static inline bool get_feature(uint32_t feature_id, uint64_t *out_value, bool *out_supported) {
     struct ksu_get_feature_cmd cmd = {};
     cmd.feature_id = feature_id;
@@ -248,6 +229,25 @@ bool is_selinux_hide_enabled() {
         return false;
     }
     return value != 0;
+}
+
+bool set_avc_spoof_enabled(bool enabled) {
+    struct ksu_set_feature_cmd cmd = {};
+    cmd.feature_id = KSU_FEATURE_AVC_SPOOF;
+    cmd.value = enabled ? 1 : 0;
+    return ksuctl(KSU_IOCTL_SET_FEATURE, &cmd) == 0;
+}
+
+bool is_avc_spoof_enabled() {
+    struct ksu_get_feature_cmd cmd = {};
+    cmd.feature_id = KSU_FEATURE_AVC_SPOOF;
+    if (ksuctl(KSU_IOCTL_GET_FEATURE, &cmd) != 0) {
+        return false;
+    }
+    if (!cmd.supported) {
+        return false;
+    }
+    return cmd.value != 0;
 }
 
 const char* get_hook_mode(void)

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -215,6 +215,22 @@ bool is_kernel_umount_enabled() {
     return value != 0;
 }
 
+bool set_adb_root_enabled(bool enabled) {
+    return set_feature(KSU_FEATURE_ADB_ROOT, enabled ? 1 : 0);
+}
+
+bool is_adb_root_enabled() {
+    uint64_t value = 0;
+    bool supported = false;
+    if (!get_feature(KSU_FEATURE_ADB_ROOT, &value, &supported)) {
+        return false;
+    }
+    if (!supported) {
+        return false;
+    }
+    return value != 0;
+}
+
 int set_selinux_hide_enabled(bool enabled) {
     if (!set_feature(KSU_FEATURE_SELINUX_HIDE, enabled ? 1 : 0)) {
         return -errno;

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -56,15 +56,15 @@ bool set_adb_root_enabled(bool enabled);
 
 bool is_adb_root_enabled();
 
-// Avc spoof
-bool set_avc_spoof_enabled(bool enabled);
-
-bool is_avc_spoof_enabled();
-
 // SELinux hide
 int set_selinux_hide_enabled(bool enabled);
 
 bool is_selinux_hide_enabled();
+
+// Avc spoof
+bool set_avc_spoof_enabled(bool enabled);
+
+bool is_avc_spoof_enabled();
 
 bool get_allow_list(struct ksu_new_get_allow_list_cmd *);
 

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -51,6 +51,11 @@ bool set_kernel_umount_enabled(bool enabled);
 
 bool is_kernel_umount_enabled();
 
+// ADB root
+bool set_adb_root_enabled(bool enabled);
+
+bool is_adb_root_enabled();
+
 // Avc spoof
 bool set_avc_spoof_enabled(bool enabled);
 

--- a/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
@@ -108,6 +108,15 @@ object Natives {
     external fun setKernelUmountEnabled(enabled: Boolean): Boolean
 
     /**
+     * ADB root can be enabled/disabled.
+     *  0: disabled
+     *  1: enabled
+     *  negative : error
+     */
+    external fun isAdbRootEnabled(): Boolean
+    external fun setAdbRootEnabled(enabled: Boolean): Boolean
+
+    /**
      * SELinux hide can be disabled temporarily.
      *  0: disabled
      *  1: enabled

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
@@ -113,18 +113,18 @@ fun SettingScreen(navigator: DestinationsNavigator) {
         }
     }
 
-    var avcSpoofStatus by rememberSaveable { mutableStateOf("") }
     var suCompatStatus by rememberSaveable { mutableStateOf("") }
     var kernelUmountStatus by rememberSaveable { mutableStateOf("") }
     var adbRootStatus by rememberSaveable { mutableStateOf("") }
     var selinuxHideStatus by rememberSaveable { mutableStateOf("") }
+    var avcSpoofStatus by rememberSaveable { mutableStateOf("") }
 
     LaunchedEffect(Unit) {
-        avcSpoofStatus = getFeatureStatus("avc_spoof")
         suCompatStatus = getFeatureStatus("su_compat")
         kernelUmountStatus = getFeatureStatus("kernel_umount")
         adbRootStatus = getFeatureStatus("adb_root")
         selinuxHideStatus = getFeatureStatus("selinux_hide")
+        avcSpoofStatus = getFeatureStatus("avc_spoof")
     }
 
     Scaffold(
@@ -157,8 +157,8 @@ fun SettingScreen(navigator: DestinationsNavigator) {
                     suCompatStatus = suCompatStatus,
                     kernelUmountStatus = kernelUmountStatus,
                     adbRootStatus = adbRootStatus,
-                    avcSpoofStatus = avcSpoofStatus,
                     selinuxHideStatus = selinuxHideStatus,
+                    avcSpoofStatus = avcSpoofStatus,
                     scope = scope
                 )
                 SecurityCard(
@@ -187,8 +187,8 @@ private fun KernelFeaturesCard(
     suCompatStatus: String,
     kernelUmountStatus: String,
     adbRootStatus: String,
-    avcSpoofStatus: String,
     selinuxHideStatus: String,
+    avcSpoofStatus: String,
     scope: kotlinx.coroutines.CoroutineScope
 ) {
     val context = LocalContext.current

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
@@ -116,12 +116,14 @@ fun SettingScreen(navigator: DestinationsNavigator) {
     var avcSpoofStatus by rememberSaveable { mutableStateOf("") }
     var suCompatStatus by rememberSaveable { mutableStateOf("") }
     var kernelUmountStatus by rememberSaveable { mutableStateOf("") }
+    var adbRootStatus by rememberSaveable { mutableStateOf("") }
     var selinuxHideStatus by rememberSaveable { mutableStateOf("") }
 
     LaunchedEffect(Unit) {
         avcSpoofStatus = getFeatureStatus("avc_spoof")
         suCompatStatus = getFeatureStatus("su_compat")
         kernelUmountStatus = getFeatureStatus("kernel_umount")
+        adbRootStatus = getFeatureStatus("adb_root")
         selinuxHideStatus = getFeatureStatus("selinux_hide")
     }
 
@@ -154,6 +156,7 @@ fun SettingScreen(navigator: DestinationsNavigator) {
                 KernelFeaturesCard(
                     suCompatStatus = suCompatStatus,
                     kernelUmountStatus = kernelUmountStatus,
+                    adbRootStatus = adbRootStatus,
                     avcSpoofStatus = avcSpoofStatus,
                     selinuxHideStatus = selinuxHideStatus,
                     scope = scope
@@ -183,6 +186,7 @@ fun SettingScreen(navigator: DestinationsNavigator) {
 private fun KernelFeaturesCard(
     suCompatStatus: String,
     kernelUmountStatus: String,
+    adbRootStatus: String,
     avcSpoofStatus: String,
     selinuxHideStatus: String,
     scope: kotlinx.coroutines.CoroutineScope
@@ -249,6 +253,28 @@ private fun KernelFeaturesCard(
                         execKsud("feature save", true)
                         prefsLocal.edit { putInt("kernel_umount_mode", if (checked) 0 else 2) }
                         isKernelUmountEnabled = checked
+                    }
+                }
+            }
+
+            if (adbRootStatus == "supported") {
+                var isAdbRootEnabled by rememberSaveable {
+                    mutableStateOf(Natives.isAdbRootEnabled())
+                }
+                SwitchItem(
+                    icon = Icons.Filled.Usb,
+                    title = stringResource(id = R.string.settings_adb_root),
+                    summary = stringResource(id = R.string.settings_adb_root_summary),
+                    checked = isAdbRootEnabled,
+                    modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp)),
+                    colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+                ) { checked ->
+                    val prefsLocal = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
+                    if (Natives.setAdbRootEnabled(checked)) {
+                        execKsud("feature save", true)
+                        prefsLocal.edit { putInt("adb_root_mode", if (checked) 0 else 2) }
+                        com.topjohnwu.superuser.ShellUtils.fastCmd("setprop ctl.restart adbd")
+                        isAdbRootEnabled = checked
                     }
                 }
             }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/KsuCli.kt
@@ -117,7 +117,8 @@ suspend fun getFeaturePersistValue(feature: String): Long? = withContext(Dispatc
 fun install() {
     val start = SystemClock.elapsedRealtime()
     val magiskboot = File(ksuApp.applicationInfo.nativeLibraryDir, "libmagiskboot.so").absolutePath
-    val result = execKsud("install --magiskboot $magiskboot", true)
+    val libadbroot = File(ksuApp.applicationInfo.nativeLibraryDir, "libadbroot.so").absolutePath
+    val result = execKsud("install --magiskboot $magiskboot --libadbroot $libadbroot", true)
     Log.w(TAG, "install result: $result, cost: ${SystemClock.elapsedRealtime() - start}ms")
 }
 

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -235,6 +235,10 @@
   <string name="settings_enable_kernel_umount">内核处理卸载模块</string>
   <string name="settings_enable_kernel_umount_summary">在内核层面卸载模块。</string>
   <string name="settings_adb_root_summary">以 root 权限运行 adbd 守护进程</string>
+  <string name="settings_selinux_hide">隐藏 SELinux 修改</string>
+  <string name="settings_selinux_hide_summary">阻止应用检测 SELinux 修改</string>
+  <string name="settings_selinux_hide_reboot_required">重启生效</string>
+  <string name="settings_selinux_hide_failed">错误： %d</string>
   <string name="settings_enable_avc_spoof">AVC 日志伪装</string>
   <string name="settings_enable_avc_spoof_summary">修复日志中 avc denial 导致的 SELinux 上下文泄漏。</string>
   <string name="manage_repositories">管理仓库</string>
@@ -254,8 +258,4 @@
   <string name="enable_adb_summary">强制允许 USB 调试并取消 adb 认证，非必要请勿开启。</string>
   <string name="advanced_options">高级选项</string>
   <string name="expand">展开</string>
-  <string name="settings_selinux_hide">隐藏 SELinux 修改</string>
-  <string name="settings_selinux_hide_summary">阻止应用检测 SELinux 修改</string>
-  <string name="settings_selinux_hide_reboot_required">重启生效</string>
-  <string name="settings_selinux_hide_failed">错误： %d</string>
 </resources>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -234,6 +234,7 @@
   <string name="settings_enable_su_summary">允许任何应用通过 su 命令获取 root 权限（已有的 root 进程不受影响）。</string>
   <string name="settings_enable_kernel_umount">内核处理卸载模块</string>
   <string name="settings_enable_kernel_umount_summary">在内核层面卸载模块。</string>
+  <string name="settings_adb_root_summary">以 root 权限运行 adbd 守护进程</string>
   <string name="settings_enable_avc_spoof">AVC 日志伪装</string>
   <string name="settings_enable_avc_spoof_summary">修复日志中 avc denial 导致的 SELinux 上下文泄漏。</string>
   <string name="manage_repositories">管理仓库</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -203,6 +203,8 @@
     <string name="module_sort_webui_first">Sort (WebUI first)</string>
     <string name="settings_enable_kernel_umount">Kernel umount</string>
     <string name="settings_enable_kernel_umount_summary">Umount modules at kernel-level.</string>
+    <string name="settings_adb_root" translatable="false">ADB Root</string>
+    <string name="settings_adb_root_summary">Run adbd daemon with root privileges</string>
     <string name="settings_selinux_hide">Hide SELinux modification</string>
     <string name="settings_selinux_hide_summary">Prevent applications from detecting SELinux modifications</string>
     <string name="settings_selinux_hide_reboot_required">Reboot to take effect</string>

--- a/uapi/feature.h
+++ b/uapi/feature.h
@@ -4,6 +4,7 @@
 enum ksu_feature_id {
     KSU_FEATURE_SU_COMPAT = 0,
     KSU_FEATURE_KERNEL_UMOUNT = 1,
+    KSU_FEATURE_ADB_ROOT = 3,
     KSU_FEATURE_SELINUX_HIDE = 4,
 
     // custom extensions

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -40,6 +40,9 @@ enum Commands {
     Install {
         #[arg(long, default_value = None)]
         magiskboot: Option<PathBuf>,
+
+        #[arg(long, default_value = None)]
+        libadbroot: Option<PathBuf>,
     },
 
     /// Unload KernelSU Next kernel module (LKM Only)
@@ -575,7 +578,10 @@ pub fn run() -> Result<()> {
                 }
             }
         }
-        Commands::Install { magiskboot } => utils::install(magiskboot),
+        Commands::Install {
+            magiskboot,
+            libadbroot,
+        } => utils::install(magiskboot, libadbroot),
         Commands::Unload => crate::unload::unload(),
         Commands::Uninstall { magiskboot } => utils::uninstall(magiskboot),
         Commands::Sepolicy { command } => match command {

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -5,6 +5,7 @@ mod android {
     pub const ADB_DIR: &str = "/data/adb/";
     pub const WORKING_DIR: &str = concatcp!(ADB_DIR, "ksu/");
     pub const BINARY_DIR: &str = concatcp!(WORKING_DIR, "bin/");
+    pub const LIBRARY_DIR: &str = concatcp!(WORKING_DIR, "lib/");
     pub const LOG_DIR: &str = concatcp!(WORKING_DIR, "log/");
 
     pub const PROFILE_DIR: &str = concatcp!(WORKING_DIR, "profile/");
@@ -14,6 +15,7 @@ mod android {
     pub const KSURC_PATH: &str = concatcp!(WORKING_DIR, ".ksurc");
     pub const DAEMON_PATH: &str = concatcp!(ADB_DIR, "ksud");
     pub const MAGISKBOOT_PATH: &str = concatcp!(BINARY_DIR, "magiskboot");
+    pub const LIBADBROOT_PATH: &str = concatcp!(LIBRARY_DIR, "libadbroot.so");
 
     pub const DAEMON_LINK_PATH: &str = concatcp!(BINARY_DIR, "ksud");
 

--- a/userspace/ksud/src/feature.rs
+++ b/userspace/ksud/src/feature.rs
@@ -19,6 +19,7 @@ pub enum FeatureId {
     SuCompat = 0,
     KernelUmount = 1,
     EnhancedSecurity = 2,
+    AdbRoot = 3,
     SelinuxHide = 4,
     AvcSpoof = 10003,
 }
@@ -29,6 +30,7 @@ impl FeatureId {
             0 => Some(Self::SuCompat),
             1 => Some(Self::KernelUmount),
             2 => Some(Self::EnhancedSecurity),
+            3 => Some(Self::AdbRoot),
             4 => Some(Self::SelinuxHide),
             10003 => Some(Self::AvcSpoof),
             _ => None,
@@ -40,6 +42,7 @@ impl FeatureId {
             Self::SuCompat => "su_compat",
             Self::KernelUmount => "kernel_umount",
             Self::EnhancedSecurity => "enhanced_security",
+            Self::AdbRoot => "adb_root",
             Self::SelinuxHide => "selinux_hide",
             Self::AvcSpoof => "avc_spoof",
         }
@@ -56,6 +59,7 @@ impl FeatureId {
             Self::EnhancedSecurity => {
                 "Enhanced Security - disable non‑KSU root elevation and unauthorized UID downgrades"
             }
+            Self::AdbRoot => "ADB Root - Enable adbd root",
             Self::SelinuxHide => {
                 "SELinux Hide - sanitize /sys/fs/selinux access results for app UIDs"
             }
@@ -71,6 +75,7 @@ fn parse_feature_id(name: &str) -> Result<FeatureId> {
         "su_compat" | "0" => Ok(FeatureId::SuCompat),
         "kernel_umount" | "1" => Ok(FeatureId::KernelUmount),
         "enhanced_security" | "2" => Ok(FeatureId::EnhancedSecurity),
+        "adb_root" | "3" => Ok(FeatureId::AdbRoot),
         "selinux_hide" | "4" => Ok(FeatureId::SelinuxHide),
         "avc_spoof" | "10003" => Ok(FeatureId::AvcSpoof),
         _ => bail!("Unknown feature: {name}"),
@@ -297,6 +302,7 @@ pub fn list_features() {
         FeatureId::SuCompat,
         FeatureId::KernelUmount,
         FeatureId::EnhancedSecurity,
+        FeatureId::AdbRoot,
         FeatureId::SelinuxHide,
         FeatureId::AvcSpoof,
     ];
@@ -360,6 +366,7 @@ pub fn save_config() -> Result<()> {
         FeatureId::SuCompat,
         FeatureId::KernelUmount,
         FeatureId::EnhancedSecurity,
+        FeatureId::AdbRoot,
         FeatureId::SelinuxHide,
         FeatureId::AvcSpoof,
     ];

--- a/userspace/ksud/src/late_load.rs
+++ b/userspace/ksud/src/late_load.rs
@@ -70,7 +70,7 @@ pub fn run() -> Result<()> {
         warn!("clear temp configs failed: {e}");
     }
 
-    utils::install(None).context("Failed to install ksud")?;
+    utils::install(None, None).context("Failed to install ksud")?;
 
     // 5. Handle module updates
     if let Err(e) = handle_updated_modules() {

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -189,7 +189,7 @@ fn link_ksud_to_bin() -> Result<()> {
     Ok(())
 }
 
-pub fn install(magiskboot: Option<PathBuf>) -> Result<()> {
+pub fn install(magiskboot: Option<PathBuf>, libadbroot: Option<PathBuf>) -> Result<()> {
     ensure_dir_exists(defs::ADB_DIR)?;
     std::fs::copy(
         std::env::current_exe().with_context(|| "Failed to get self exe path")?,
@@ -203,7 +203,14 @@ pub fn install(magiskboot: Option<PathBuf>) -> Result<()> {
 
     if let Some(magiskboot) = magiskboot {
         ensure_dir_exists(defs::BINARY_DIR)?;
+        let _ = std::fs::remove_file(defs::MAGISKBOOT_PATH);
         let _ = std::fs::copy(magiskboot, defs::MAGISKBOOT_PATH);
+    }
+
+    if let Some(libadbroot) = libadbroot {
+        ensure_dir_exists(defs::LIBRARY_DIR)?;
+        let _ = std::fs::remove_file(defs::LIBADBROOT_PATH);
+        let _ = std::fs::copy(libadbroot, defs::LIBADBROOT_PATH);
     }
 
     Ok(())


### PR DESCRIPTION
feature: adb_root; manager: re-order features placement

```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Wed Apr 1 23:49:07 2026 +0800

    feature: adb root (https://github.com/tiann/KernelSU/pull/3382)
```
```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Thu Apr 2 15:34:15 2026 +0800

    kernel: fix path check in adb root (https://github.com/tiann/KernelSU/pull/3391)
```
```
Author: AlexLiuDev233 <wzylin11@outlook.com>
Date:   Sun Apr 12 05:02:42 2026 +0000

    manager: adb_root: load our ksurc if possible (https://github.com/tiann/KernelSU/pull/3412)
```
```
Author: AlexLiuDev233 <wzylin11@outlook.com>
Date:   Sat Apr 11 11:04:42 2026 +0000

    kernel: don't call path_put when kern_path failed (https://github.com/tiann/KernelSU/pull/3410)
```
```
Author: u9521 <63995396+u9521@users.noreply.github.com>
Date:   Fri Apr 3 12:15:29 2026 +0800

    [PARTIAL] kernel: Fix absolute src handling in Kbuild (https://github.com/tiann/KernelSU/pull/3390)
````
```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Sun May 17 17:41:42 2026 +0800

    adbroot: support statically-linked GetProperty (https://github.com/tiann/KernelSU/pull/3470)
````
```
Author: pershoot <190600+pershoot@users.noreply.github.com>
Date:   Sun May 24 12:15:21 2026 -0400

    manager: Re-order AVC Spoof feature placement
```
```
Author: pershoot <190600+pershoot@users.noreply.github.com>
Date:   Sun May 24 13:22:46 2026 -0400

    manager: strings: zh-rCN: Re-order SELinux Hide feature placement
```