### PR TITLE
[Port] port selinux_hide from dev branch

### DIFF
--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -107,6 +107,7 @@ int __init kernelsu_init(void)
 
 		apply_kernelsu_rules();
 		cache_sid();
+		ksu_selinux_hide_status_init();
 		setup_ksu_cred();
 
 		// Grant current process (ksud late-load) root
@@ -135,6 +136,8 @@ int __init kernelsu_init(void)
 		ksu_syscall_hook_manager_init();
 		
 		ksu_lsm_hook_init();
+
+		ksu_selinux_hide_status_init();
 
 		ksu_allowlist_init();
 

--- a/kernel/hook/hook_manager.c
+++ b/kernel/hook/hook_manager.c
@@ -385,6 +385,7 @@ void __init ksu_syscall_hook_manager_init(void)
 	ksu_setuid_hook_init();
 	ksu_sucompat_init();
 	ksu_avc_spoof_init();
+	ksu_selinux_hide_status_init();
 }
 
 void __exit ksu_syscall_hook_manager_exit(void)
@@ -404,6 +405,7 @@ void __exit ksu_syscall_hook_manager_exit(void)
 	ksu_sucompat_exit();
 	ksu_setuid_hook_exit();
 	ksu_avc_spoof_exit();
+    ksu_selinux_hide_status_exit();
 }
 #else
 #include "klog.h" // IWYU pragma: keep
@@ -417,6 +419,7 @@ void __init ksu_syscall_hook_manager_init(void)
 	ksu_setuid_hook_init();
 	ksu_sucompat_init();
 	ksu_avc_spoof_init();
+	ksu_selinux_hide_status_init();
 }
 
 void __exit ksu_syscall_hook_manager_exit(void)
@@ -425,5 +428,6 @@ void __exit ksu_syscall_hook_manager_exit(void)
 	ksu_sucompat_exit();
 	ksu_setuid_hook_exit();
 	ksu_avc_spoof_exit();
+    ksu_selinux_hide_status_exit();
 }
 #endif

--- a/kernel/hook/hook_manager.h
+++ b/kernel/hook/hook_manager.h
@@ -12,6 +12,8 @@ void ksu_syscall_hook_manager_exit(void);
 // extras.c
 void ksu_avc_spoof_init(void);
 void ksu_avc_spoof_exit(void);
+void ksu_selinux_hide_status_init(void);
+void ksu_selinux_hide_status_exit(void);
 
 #ifdef KSU_KPROBES_HOOK
 // Process marking for tracepoint

--- a/kernel/runtime/boot_event.c
+++ b/kernel/runtime/boot_event.c
@@ -9,6 +9,7 @@
 #include "runtime/ksud.h"
 #include "manager/manager_observer.h"
 #include "manager/throne_tracker.h"
+#include "selinux/selinux.h"
 
 bool ksu_module_mounted __read_mostly = false;
 bool ksu_boot_completed __read_mostly = false;
@@ -28,6 +29,7 @@ void on_post_fs_data(void)
 
 	ksu_load_allow_list();
 	ksu_observer_init();
+	ksu_selinux_hide_status_handle_post_fs_data();
 	// sanity check, this may influence the performance
 	stop_input_hook();
 }

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -9,6 +9,7 @@
 #include <linux/file.h>
 #include <linux/fs.h>
 #include <linux/version.h>
+#include "selinux/selinux.h"
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
 #include <linux/input-event-codes.h>
 #else
@@ -178,6 +179,7 @@ static void ksu_initialize_selinux_tw_func(struct callback_head *cb)
 {
 	apply_kernelsu_rules();
 	cache_sid();
+	ksu_selinux_hide_status_handle_second_stage();
 	setup_ksu_cred();
 	kfree(cb);
 }

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -244,3 +244,192 @@ bool is_init(const struct cred *cred)
 {
     return is_sid_match(cred, cached_init_sid, INIT_CONTEXT);
 }
+
+/* --------------- fake SELinux status page --------------- */
+
+#include <linux/fs.h>
+#include <linux/jump_label.h>
+#include <linux/kallsyms.h>
+#include <linux/mm.h>
+#include <linux/mutex.h>
+#include <linux/slab.h>
+#include "policy/feature.h"
+#include "include/ksu.h"
+
+static DEFINE_STATIC_KEY_FALSE(fake_status_initialize_key);
+static struct page *fake_status = NULL;
+static DEFINE_MUTEX(fake_status_init_mutex);
+static bool ksu_selinux_hide_status_enabled = true;
+
+static void initialize_fake_status(void)
+{
+	if (READ_ONCE(fake_status))
+		return;
+
+	mutex_lock(&fake_status_init_mutex);
+	if (fake_status) /* double-check after lock */
+		goto out;
+
+	struct page *real_page = selinux_kernel_status_page(&selinux_state);
+	if (!real_page) {
+		pr_warn("ksu_selinux_hide: status_page not exist\n");
+		goto out;
+	}
+
+	struct selinux_kernel_status *status = page_address(real_page);
+	if (!status->enforcing && !ksu_late_loaded) {
+		pr_warn("ksu_selinux_hide: skip not enforcing\n");
+		goto out;
+	}
+
+	struct page *new_page = alloc_page(GFP_KERNEL | __GFP_ZERO);
+	if (!new_page) {
+		pr_err("ksu_selinux_hide: failed to allocate fake status page\n");
+		goto out;
+	}
+
+	struct selinux_kernel_status *new_status = page_address(new_page);
+	memcpy(new_status, status, sizeof(*status));
+	if (ksu_late_loaded && !new_status->enforcing) {
+		/*
+		 * In late_load mode we may be loaded after setenforce 0.
+		 * Adjust sequence to look like a normal enforcing boot.
+		 * Assumes setenforce 0 was called exactly once.
+		 */
+		new_status->enforcing = 1;
+		new_status->sequence = 4;
+	}
+
+	WRITE_ONCE(fake_status, new_page);
+	pr_info("ksu_selinux_hide: fake status ready: sequence=%d policyload=%d enforcing=%d\n",
+		new_status->sequence, new_status->policyload,
+		new_status->enforcing);
+out:
+	mutex_unlock(&fake_status_init_mutex);
+}
+
+typedef int (*sel_open_handle_status_fn)(struct inode *inode,
+					 struct file *filp);
+static sel_open_handle_status_fn orig_sel_open_handle_status = NULL;
+
+static int my_sel_open_handle_status(struct inode *inode, struct file *filp)
+{
+	if (likely(current_uid().val >= 10000 &&
+		   ksu_selinux_hide_status_enabled)) {
+		struct page *data = READ_ONCE(fake_status);
+		if (data) {
+			filp->private_data = page_address(data);
+			return 0;
+		}
+	}
+
+	int ret = orig_sel_open_handle_status(inode, filp);
+	if (static_branch_unlikely(&fake_status_initialize_key) && !ret &&
+	    !fake_status) {
+		initialize_fake_status();
+	}
+	return ret;
+}
+
+static void hook_selinux_status_open(void)
+{
+	if (orig_sel_open_handle_status)
+		return;
+
+	struct file_operations *ops =
+		(struct file_operations *)kallsyms_lookup_name(
+			"sel_handle_status_ops");
+	if (!ops) {
+		pr_err("ksu_selinux_hide: sel_handle_status_ops not found, fake status disabled\n");
+		return;
+	}
+
+	orig_sel_open_handle_status = ops->open;
+	ops->open = my_sel_open_handle_status;
+	pr_info("ksu_selinux_hide: hooked sel_handle_status_ops->open\n");
+}
+
+static void unhook_selinux_status_open(void)
+{
+	if (!orig_sel_open_handle_status)
+		return;
+
+	struct file_operations *ops =
+		(struct file_operations *)kallsyms_lookup_name(
+			"sel_handle_status_ops");
+	if (!ops) {
+		pr_err("ksu_selinux_hide: sel_handle_status_ops not found on unhook\n");
+		return;
+	}
+
+	ops->open = orig_sel_open_handle_status;
+	orig_sel_open_handle_status = NULL;
+	pr_info("ksu_selinux_hide: unhooked sel_handle_status_ops->open\n");
+}
+
+static int selinux_hide_status_feature_get(u64 *value)
+{
+	*value = ksu_selinux_hide_status_enabled ? 1 : 0;
+	return 0;
+}
+
+static int selinux_hide_status_feature_set(u64 value)
+{
+	bool enable = !!value;
+	if (enable == ksu_selinux_hide_status_enabled) {
+		pr_info("ksu_selinux_hide: no need to change\n");
+		return 0;
+	}
+	ksu_selinux_hide_status_enabled = enable;
+	pr_info("ksu_selinux_hide: set to %d\n", enable);
+	return 0;
+}
+
+static const struct ksu_feature_handler selinux_hide_status_handler = {
+	.feature_id = KSU_FEATURE_SELINUX_HIDE_STATUS,
+	.name = "selinux_hide_status",
+	.get_handler = selinux_hide_status_feature_get,
+	.set_handler = selinux_hide_status_feature_set,
+};
+
+void ksu_selinux_hide_status_handle_second_stage(void)
+{
+	initialize_fake_status();
+	if (READ_ONCE(fake_status)) {
+		static_key_disable(&fake_status_initialize_key.key);
+	} else {
+		pr_warn("ksu_selinux_hide: fake status needs late initialization\n");
+	}
+}
+
+void ksu_selinux_hide_status_handle_post_fs_data(void)
+{
+	static_key_disable(&fake_status_initialize_key.key);
+	if (!READ_ONCE(fake_status))
+		pr_err("ksu_selinux_hide: fake status not initialized after post-fs-data!\n");
+}
+
+void __init ksu_selinux_hide_status_init(void)
+{
+	if (ksu_register_feature_handler(&selinux_hide_status_handler))
+		pr_err("ksu_selinux_hide: failed to register feature handler\n");
+
+	if (ksu_late_loaded) {
+		initialize_fake_status();
+	} else {
+		static_key_enable(&fake_status_initialize_key.key);
+	}
+	hook_selinux_status_open();
+}
+
+void __exit ksu_selinux_hide_status_exit(void)
+{
+	ksu_unregister_feature_handler(KSU_FEATURE_SELINUX_HIDE_STATUS);
+	unhook_selinux_status_open();
+	mutex_lock(&fake_status_init_mutex);
+	if (fake_status) {
+		__free_page(fake_status);
+		fake_status = NULL;
+	}
+	mutex_unlock(&fake_status_init_mutex);
+}

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -47,6 +47,11 @@ bool getenforce();
 
 void cache_sid(void);
 
+void ksu_selinux_hide_status_init(void);
+void ksu_selinux_hide_status_exit(void);
+void ksu_selinux_hide_status_handle_second_stage(void);
+void ksu_selinux_hide_status_handle_post_fs_data(void);
+
 bool is_task_ksu_domain(const struct cred* cred);
 
 bool is_ksu_domain();

--- a/uapi/feature.h
+++ b/uapi/feature.h
@@ -4,6 +4,7 @@
 enum ksu_feature_id {
     KSU_FEATURE_SU_COMPAT = 0,
     KSU_FEATURE_KERNEL_UMOUNT = 1,
+    KSU_FEATURE_SELINUX_HIDE_STATUS = 4,
 
     // custom extensions
     KSU_FEATURE_AVC_SPOOF = 10003,


### PR DESCRIPTION
1. ported selinux_hide from dev
2. added registeration to the manager UI

The feature uses selinux_kernel_status_page() API universally so it works on older kernels, it should work seamlessly
tested on 4.19 and 4.14 only

add mutex init to avoid race issues in initialize_fake_status
