### PR TITLE
kernel: fix CAP_DAC_READ_SEARCH capability bitmask in escape_with_root_profile

### DIFF
--- a/kernel/policy/app_profile.c
+++ b/kernel/policy/app_profile.c
@@ -200,7 +200,10 @@ int escape_with_root_profile(void)
     // setup capabilities
     // we need CAP_DAC_READ_SEARCH becuase `/data/adb/ksud` is not accessible for non root process
     // we add it here but don't add it to cap_inhertiable, it would be dropped automaticly after exec!
-    u64 cap_for_ksud = profile.capabilities.effective | CAP_DAC_READ_SEARCH;
+    // NOTE: CAP_DAC_READ_SEARCH is a capability index (2), not a bitmask.
+    // We must use BIT_ULL() to convert it to the correct bit position (0x4).
+    // Using the raw index value would set CAP_DAC_OVERRIDE (bit 1) instead.
+    u64 cap_for_ksud = profile.capabilities.effective | BIT_ULL(CAP_DAC_READ_SEARCH);
     memcpy(&cred->cap_effective, &cap_for_ksud, sizeof(cred->cap_effective));
     memcpy(&cred->cap_permitted, &profile.capabilities.effective,
            sizeof(cred->cap_permitted));


### PR DESCRIPTION
## Bug

`CAP_DAC_READ_SEARCH` is a capability **index** (value `2`), not a bitmask. Using it directly with bitwise OR:

```c
u64 cap_for_ksud = profile.capabilities.effective | CAP_DAC_READ_SEARCH;
```

sets **bit 1** (`CAP_DAC_OVERRIDE`) instead of **bit 2** (`CAP_DAC_READ_SEARCH`), silently granting the wrong capability.

## Fix

Use `BIT_ULL()` to correctly convert the capability index to its bitmask:

```c
u64 cap_for_ksud = profile.capabilities.effective | BIT_ULL(CAP_DAC_READ_SEARCH);
```

## Impact

On devices where `CAP_DAC_OVERRIDE` alone is insufficient to read `/data/adb/ksud`, the ksud process may fail to start or behave unexpectedly. This affects all legacy branch builds.