### PR TITLE
kernel: fix observer init error propagation, NULL guard in faccessat,…

### DIFF
--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -80,6 +80,9 @@ int ksu_handle_faccessat(int *dfd, const char __user **filename_user,
 		return 0;
 	}
 
+	if (unlikely(!filename_user))
+		return 0;
+
 	char path[sizeof(su) + 1];
 	memset(path, 0, sizeof(path));
 	strncpy_from_user_nofault(path, *filename_user, sizeof(path));
@@ -146,8 +149,6 @@ long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, 
 	if (likely(memcmp(path, su, sizeof(su))))
 		goto do_orig_execve;
 
-	write_sulog('x');
-
 	pr_info("sys_execve su found\n");
 	*filename_user = ksud_user_path();
 
@@ -161,7 +162,9 @@ long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, 
 	if (ret < 0) {
 		pr_err("failed to execve ksud as su: %ld, fallback to sh\n", ret);
 		*filename_user = sh_user_path();
+		write_sulog('x');
 	} else {
+		write_sulog('x');
 		return ret;
 	}
 

--- a/kernel/manager/pkg_observer.c
+++ b/kernel/manager/pkg_observer.c
@@ -115,11 +115,13 @@ int ksu_observer_init(void)
 		return PTR_ERR(g);
 
 	ret = watch_one_dir(&g_watch);
+	if (ret)
+		pr_warn("observer: failed to watch /data/system: %d\n", ret);
 	pr_info("observer init done\n");
-	return 0;
+	return ret;
 }
 
-void __exit ksu_observer_exit(void)
+void ksu_observer_exit(void)
 {
 	unwatch_one_dir(&g_watch);
 	fsnotify_put_group(g);


### PR DESCRIPTION
… write_sulog ordering

- pkg_observer: ksu_observer_init() always returned 0 even when watch_one_dir() failed, silently hiding initialization errors. Return the actual error code and emit a warning on failure. Remove __exit annotation from ksu_observer_exit() to avoid undefined behavior in built-in (non-LKM) configurations where the __exit section may be discarded by the linker.

- sucompat: ksu_handle_faccessat() was missing a NULL check on filename_user before dereferencing it. ksu_handle_stat() already has this guard; adds parity to prevent a potential NULL dereference.

- sucompat: write_sulog('x') was called before escape_with_root_profile() and execve completed. A failed su attempt would still be recorded as successful in the audit log. Move write_sulog to after the outcome is known.