### PR TITLE
kernel: Remove strncpy() from the kernel (https://github.com/tiann/KernelSU/pull/3529)

### DIFF
--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -343,7 +343,7 @@ int get_pkg_from_apk_path(char *pkg, const char *path)
 		return -1;
 
 	// Copying the package name
-	strncpy(pkg, second_last_slash + 1, pkg_len);
+	memcpy(pkg, second_last_slash + 1, pkg_len);
 	pkg[pkg_len] = '\0';
 
 	return 0;

--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -306,7 +306,7 @@ void track_throne(bool prune_only)
 			break;
 		}
 		data->uid = res;
-		strncpy(data->package, package, KSU_MAX_PACKAGE_NAME);
+		strscpy(data->package, package, sizeof(data->package));
 		list_add_tail(&data->list, &uid_list);
 		// reset line start
 		line_start = pos;


### PR DESCRIPTION
```
Author: Wang Han <416810799@qq.com>
Date:   Sun Jun 21 10:02:59 2026 +0800
```
kernel: Remove strncpy() from the kernel (https://github.com/tiann/KernelSU/pull/3529)

https://github.com/torvalds/linux/commit/079a028d6327e68cfa5d38b36123637b321c19a7