### PR TITLE
docs: explain KernelSU module install gate

### DIFF
--- a/website/docs/guide/metamodule.md
+++ b/website/docs/guide/metamodule.md
@@ -424,6 +424,12 @@ Modules will no longer be mounted. Your device will boot normally, but module mo
 
 No. It provides standard overlayfs mounting compatible with most modules. You can create your own metamodule if you need different behavior.
 
+### Why does a Zygisk-related module say "KernelSU version abnormal" during installation?
+
+Some third-party Zygisk-related modules still ship installer checks that abort when the KernelSU version code reaches a fixed limit, for example `KSU_KERNEL_VER_CODE >= 20000`. On recent KernelSU Next releases, that message may mean the module has not been updated for newer KernelSU interface expectations. It does not necessarily mean that the module ZIP is corrupt, your device root is broken, or KernelSU Next itself was integrated incorrectly.
+
+Do not bypass that check blindly. If the module needs KernelSU-specific communication at runtime, it may also need support for newer KernelSU interfaces, not only a higher installer version limit. Prefer an updated module release, check the module maintainer's compatibility notes, or report the exact installer log to that module. If an older installed version of the module already works on your device, keeping it can be safer than forcing an incompatible update.
+
 ## Late-load mode {#late-load-mode}
 
 In addition to the standard boot flow described above, KernelSU supports a **late-load mode** for LKM (Loadable Kernel Module) scenarios. In this mode, the KernelSU kernel module is loaded **after the system has fully booted**, rather than during the init process.

--- a/website/docs/zh_CN/guide/metamodule.md
+++ b/website/docs/zh_CN/guide/metamodule.md
@@ -421,6 +421,12 @@ fsconfig_set_string(fs， "source"， "KSU")?;  // 必需!
 
 不是。它提供与大多数模块兼容的标准 overlayfs 挂载。如果您需要不同的行为，可以创建自己的元模块。
 
+### 为什么安装 Zygisk 相关模块时提示 "KernelSU version abnormal"?
+
+一些第三方 Zygisk 相关模块仍然带有旧的安装脚本检查，会在 KernelSU 版本号达到固定阈值时中止安装，例如 `KSU_KERNEL_VER_CODE >= 20000`。在较新的 KernelSU Next 版本中，这类提示可能只是说明该模块尚未适配新的 KernelSU 接口预期。它不一定表示模块 ZIP 损坏、设备 Root 状态异常，或 KernelSU Next 本身集成错误。
+
+不要盲目绕过这个检查。如果模块在运行时需要和 KernelSU 通信，它可能还需要适配新的 KernelSU 接口，而不只是提高安装脚本里的版本上限。建议优先使用模块的新版本、查看模块维护者的兼容性说明，或把完整安装日志反馈给对应模块。如果旧版本模块已经能在设备上正常工作，保留旧版本通常比强行安装不兼容的新版本更稳妥。
+
 ## Late-load 模式 {#late-load-mode}
 
 除了上述标准启动流程外，KernelSU 还支持 **late-load 模式**，用于 LKM（可加载内核模块）场景。在该模式下，KernelSU 内核模块在**系统完全启动后**加载，而非在 init 过程中加载。


### PR DESCRIPTION
## Summary

- Add a FAQ entry for Zygisk-related module installers that report `KernelSU version abnormal` on newer KernelSU Next releases.
- Explain that a fixed installer version gate such as `KSU_KERNEL_VER_CODE >= 20000` may indicate module compatibility work is still needed, not a corrupt ZIP or broken root state.
- Add the same guidance to the Simplified Chinese metamodule FAQ.

## Validation

- `git diff --check`
