### PR TITLE
ksud: update resetprop, improve prop area rebuild (https://github.com/tiann/KernelSU/pull/3545)

### DIFF
--- a/userspace/ksud/Cargo.lock
+++ b/userspace/ksud/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "prop-rs"
 version = "0.2.0"
-source = "git+https://github.com/Kernel-SU/ksu_props#699849f3e4db47b622bcb7fae8e76c728b1b65a6"
+source = "git+https://github.com/Kernel-SU/ksu_props?rev=6f5723105d8d4cacad31d83d343defbf032c7b33#6f5723105d8d4cacad31d83d343defbf032c7b33"
 dependencies = [
  "prost",
 ]
@@ -1342,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "prop-rs-android"
 version = "0.2.0"
-source = "git+https://github.com/Kernel-SU/ksu_props#699849f3e4db47b622bcb7fae8e76c728b1b65a6"
+source = "git+https://github.com/Kernel-SU/ksu_props?rev=6f5723105d8d4cacad31d83d343defbf032c7b33#6f5723105d8d4cacad31d83d343defbf032c7b33"
 dependencies = [
  "libc",
  "log",

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -55,7 +55,7 @@ nom = "8"
 derive-new = "0.7"
 getopts = "0.2"
 ksuinit = { path = "../ksuinit" }
-prop-rs-android = { git = "https://github.com/Kernel-SU/ksu_props" }
+prop-rs-android = { git = "https://github.com/Kernel-SU/ksu_props", rev = "6f5723105d8d4cacad31d83d343defbf032c7b33" }
 
 [profile.release]
 strip = true

--- a/userspace/ksud/src/resetprop.rs
+++ b/userspace/ksud/src/resetprop.rs
@@ -66,13 +66,17 @@ struct Args {
     #[arg(short = 'f', long = "file")]
     file: Option<String>,
 
-    /// Rebuild a property area by SELinux context name.
-    #[arg(short = 'c', long = "compact")]
-    compact: bool,
+    /// Rebuild a property area by SELinux context name, or all property areas if name is not given.
+    #[arg(short = 'c', long = "rebuild", alias = "compact")]
+    rebuild: bool,
 
-    /// Show SELinux context when listing properties.
+    /// Show SELinux context when listing properties, or if -c is used, rebuild the property area containing the property NAME.
     #[arg(short = 'Z')]
     show_context: bool,
+
+    /// Force rebuild all property areas, should be used with `-c` . Without this flag set, only abnormal property areas will be rebuilt.
+    #[arg(long = "force")]
+    force: bool,
 
     #[arg(
         allow_hyphen_values = true,
@@ -136,12 +140,13 @@ fn run_from_args(args: &[String]) -> Result<()> {
     };
 
     // Validate: at most one special mode
-    let special_modes = u8::from(cli.wait)
-        + u8::from(cli.delete)
-        + u8::from(cli.compact)
-        + u8::from(cli.file.is_some());
+    let special_modes = u8::from(cli.wait) + u8::from(cli.delete) + u8::from(cli.file.is_some());
     if special_modes > 1 {
         bail!("multiple operation modes detected");
+    }
+
+    if cli.rebuild && !(special_modes == 0 || cli.delete) {
+        bail!("Only -d can be used with -c");
     }
 
     // -w: wait mode
@@ -160,15 +165,6 @@ fn run_from_args(args: &[String]) -> Result<()> {
         return Ok(());
     }
 
-    // -c: rebuild a property area selected by SELinux context name.
-    if cli.compact {
-        let context = cli
-            .name()
-            .context("--compact requires a property area context name")?;
-        rp.rebuild(context).context("rebuild failed")?;
-        return Ok(());
-    }
-
     // -f: load from file
     if let Some(path) = &cli.file {
         let file = File::open(path).with_context(|| format!("Failed to open {path}"))?;
@@ -184,6 +180,23 @@ fn run_from_args(args: &[String]) -> Result<()> {
         let deleted = rp.delete(name).context("delete failed")?;
         if !deleted {
             bail!("{name} not found");
+        }
+        if !cli.rebuild {
+            return Ok(());
+        }
+    }
+
+    if cli.rebuild {
+        if let Some(name) = cli.name() {
+            let ctx = if cli.show_context || cli.delete {
+                sys_prop::get_context(name)?
+            } else {
+                name.to_owned()
+            };
+            rp.rebuild(&ctx)?;
+        } else if !rp.rebuild_all(cli.force)? {
+            eprintln!("Something wrong happened, see log for detail.");
+            std::process::exit(1);
         }
         return Ok(());
     }


### PR DESCRIPTION
```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Mon Jun 29 22:51:31 2026 +0800
```
ksud: update resetprop, improve prop area rebuild (#3545)

- The `-c` option is now short for `--rebuild`, while retaining the alias `--compact`.
- When using the `rebuild` option, if no NAME is provided, all property areas with anomalies will be rebuilt. Using `-f` will rebuild all areas, regardless of whether anomalies exist.
- The `rebuild` option can also be used with `-Z` and `-d`, which resolves the NAME to a property name and rebuilds the property area containing that property (if the `-d` option is specified, the property will be deleted first and then the property area will be rebuilt).