### PR TITLE
[PARTIAL] ksud: expose module env vars (https://github.com/tiann/KernelSU/pull/3522)

### DIFF
--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -11,7 +11,7 @@ use crate::{apk_sign, assets, debug, defs, ksu_uapi, init_event, ksucalls, modul
 
 /// KernelSU Next userspace cli
 #[derive(Parser, Debug)]
-#[command(author, version = defs::VERSION_NAME, about, long_about = None)]
+#[command(author, version = defs::FULL_VERSION, about, long_about = None)]
 struct Args {
     #[command(subcommand)]
     command: Commands,
@@ -697,14 +697,9 @@ pub fn run() -> Result<()> {
                 println!("flags: 0x{:x}", info.flags);
                 println!("uapi_version: {}", info.uapi_version);
                 println!("features: 0x{:x}", info.features);
-                println!(
-                    "lkm: {}",
-                    (info.flags & ksu_uapi::KSU_GET_INFO_FLAG_LKM) != 0
-                );
-                println!(
-                    "late_load: {}",
-                    (info.flags & ksu_uapi::KSU_GET_INFO_FLAG_LATE_LOAD) != 0
-                );
+                println!("lkm: {}", ksucalls::is_lkm());
+                println!("late_load: {}", ksucalls::is_late_load());
+                println!("runtime_mode: {}", ksucalls::runtime_mode());
                 println!(
                     "pr_build: {}",
                     (info.flags & ksu_uapi::KSU_GET_INFO_FLAG_PR_BUILD) != 0

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -54,6 +54,12 @@ mod android {
 #[allow(unused)]
 pub const VERSION_CODE: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_CODE"));
 pub const VERSION_NAME: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_NAME"));
+#[cfg(target_os = "android")]
+pub const FULL_VERSION: &str = const_format::formatcp!(
+    "{} (uapi: {})",
+    VERSION_NAME,
+    crate::ksu_uapi::KERNEL_SU_UAPI_VERSION
+);
 
 #[cfg(target_os = "android")]
 pub use android::*;

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -14,8 +14,8 @@ use std::path::Path;
 use std::process::Command;
 
 pub fn on_post_data_fs() -> Result<()> {
-    if ksucalls::is_uapi_version_mismatch() {
-        error!("Kernel and userspace uapi version mismatch! skip on_post_fs_data");
+    if let Err(e) = ksucalls::ensure_uapi_version_matched() {
+        error!("{e:#}, skip on_post_fs_data");
         return Ok(());
     }
 
@@ -156,8 +156,8 @@ pub fn run_stage(stage: &str, block: bool) {
 }
 
 pub fn on_services() {
-    if ksucalls::is_uapi_version_mismatch() {
-        error!("Kernel and userspace uapi version mismatch! skip on_services");
+    if let Err(e) = ksucalls::ensure_uapi_version_matched() {
+        error!("{e:#}, skip on_services");
         return;
     }
 
@@ -166,8 +166,8 @@ pub fn on_services() {
 }
 
 pub fn on_boot_completed() {
-    if ksucalls::is_uapi_version_mismatch() {
-        error!("Kernel and userspace uapi version mismatch! skip on_boot_completed");
+    if let Err(e) = ksucalls::ensure_uapi_version_matched() {
+        error!("{e:#}, skip on_boot_completed");
         return;
     }
 
@@ -247,8 +247,8 @@ fn catch_bootlog(logname: &str, command: &[&str]) -> Result<()> {
 
 pub fn soft_reboot() -> Result<()> {
     // check it avoid user click "soft_reboot" in manager when version mismatch
-    if ksucalls::is_uapi_version_mismatch() {
-        error!("Kernel and userspace uapi version mismatch! skip soft_reboot");
+    if let Err(e) = ksucalls::ensure_uapi_version_matched() {
+        error!("{e:#}, skip soft_reboot");
         return Ok(());
     }
 

--- a/userspace/ksud/src/ksucalls.rs
+++ b/userspace/ksud/src/ksucalls.rs
@@ -87,8 +87,33 @@ pub fn is_late_load() -> bool {
     get_info().flags & ksu_uapi::KSU_GET_INFO_FLAG_LATE_LOAD != 0
 }
 
-pub fn is_uapi_version_mismatch() -> bool {
-    get_info().uapi_version != ksu_uapi::KERNEL_SU_UAPI_VERSION
+pub fn is_lkm() -> bool {
+    get_info().flags & ksu_uapi::KSU_GET_INFO_FLAG_LKM != 0
+}
+
+pub const fn uapi_version() -> u32 {
+    ksu_uapi::KERNEL_SU_UAPI_VERSION
+}
+
+pub fn runtime_mode() -> &'static str {
+    if is_late_load() {
+        "late-load"
+    } else if is_lkm() {
+        "lkm"
+    } else {
+        "built-in"
+    }
+}
+
+pub fn ensure_uapi_version_matched() -> anyhow::Result<()> {
+    let kernel_uapi = get_info().uapi_version;
+    let userspace_uapi = uapi_version();
+    if kernel_uapi != userspace_uapi {
+        bail!(
+            "UAPI version mismatch: kernel={kernel_uapi}, ksud={userspace_uapi}. Please update KernelSU!"
+        );
+    }
+    Ok(())
 }
 
 pub fn grant_root() -> std::io::Result<()> {

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -67,6 +67,8 @@ pub fn get_common_script_envs(module_id: Option<&str>) -> Vec<(&'static str, Str
         ("KSU_KERNEL_VER_CODE", ksucalls::get_version().to_string()),
         ("KSU_VER_CODE", defs::VERSION_CODE.to_string()),
         ("KSU_VER", defs::VERSION_NAME.to_string()),
+        ("KSU_UAPI_VER", ksucalls::uapi_version().to_string()),
+        ("KSU_RUNTIME_MODE", ksucalls::runtime_mode().to_string()),
         (
             "PATH",
             format!(
@@ -662,6 +664,8 @@ fn install_module_to_system(zip: &str) -> Result<()> {
 }
 
 pub fn install_module(zip: &str) -> Result<()> {
+    ksucalls::ensure_uapi_version_matched()?;
+
     let result = install_module_to_system(zip);
     if let Err(ref e) = result {
         println!("- Error: {e}");
@@ -713,6 +717,7 @@ pub fn uninstall_module(id: &str) -> Result<()> {
 
 pub fn run_action(id: &str) -> Result<()> {
     validate_module_id(id)?;
+    ksucalls::ensure_uapi_version_matched()?;
 
     let action_script_path = format!("/data/adb/modules/{id}/action.sh");
     exec_script(&action_script_path, true)

--- a/website/docs/guide/metamodule.md
+++ b/website/docs/guide/metamodule.md
@@ -218,7 +218,7 @@ done
 
 This script inherits all variables and functions from the built-in `install.sh`:
 
-- **Variables**: `MODPATH`, `TMPDIR`, `ZIPFILE`, `ARCH`, `API`, `IS64BIT`, `KSU`, `KSU_VER`, `KSU_VER_CODE`, `BOOTMODE`, etc.
+- **Variables**: `MODPATH`, `TMPDIR`, `ZIPFILE`, `ARCH`, `API`, `IS64BIT`, `KSU`, `KSU_VER`, `KSU_VER_CODE`, `KSU_UAPI_VER`, `KSU_RUNTIME_MODE`, `KSU_LATE_LOAD`, `BOOTMODE`, etc.
 - **Functions**:
   - `ui_print <msg>` - Print message to console
   - `abort <msg>` - Print error and terminate installation

--- a/website/docs/id_ID/guide/metamodule.md
+++ b/website/docs/id_ID/guide/metamodule.md
@@ -216,7 +216,7 @@ done
 
 Skrip ini mewarisi semua variabel dan fungsi dari `install.sh` bawaan:
 
-- **Variabel**: `MODPATH`, `TMPDIR`, `ZIPFILE`, `ARCH`, `API`, `IS64BIT`, `KSU`, `KSU_VER`, `KSU_VER_CODE`, `BOOTMODE`, dll.
+- **Variabel**: `MODPATH`, `TMPDIR`, `ZIPFILE`, `ARCH`, `API`, `IS64BIT`, `KSU`, `KSU_VER`, `KSU_VER_CODE`, `KSU_UAPI_VER`, `KSU_RUNTIME_MODE`, `KSU_LATE_LOAD`, `BOOTMODE`, dll.
 - **Fungsi**:
   - `ui_print <msg>` - Cetak pesan ke konsol
   - `abort <msg>` - Cetak error dan hentikan instalasi

--- a/website/docs/ja_JP/guide/metamodule.md
+++ b/website/docs/ja_JP/guide/metamodule.md
@@ -216,7 +216,7 @@ done
 
 このスクリプトは、組み込みの `install.sh` からすべての変数と関数を継承します:
 
-- **変数**: `MODPATH`、`TMPDIR`、`ZIPFILE`、`ARCH`、`API`、`IS64BIT`、`KSU`、`KSU_VER`、`KSU_VER_CODE`、`BOOTMODE` など
+- **変数**: `MODPATH`、`TMPDIR`、`ZIPFILE`、`ARCH`、`API`、`IS64BIT`、`KSU`、`KSU_VER`、`KSU_VER_CODE`、`KSU_UAPI_VER`、`KSU_RUNTIME_MODE`、`KSU_LATE_LOAD`、`BOOTMODE` など
 - **関数**:
   - `ui_print <msg>` - コンソールにメッセージを出力
   - `abort <msg>` - エラーを出力してインストールを終了

--- a/website/docs/pt_BR/guide/metamodule.md
+++ b/website/docs/pt_BR/guide/metamodule.md
@@ -216,7 +216,7 @@ done
 
 Este script herda todas as variáveis e funções do `install.sh` embutido:
 
-- **Variáveis**: `MODPATH`, `TMPDIR`, `ZIPFILE`, `ARCH`, `API`, `IS64BIT`, `KSU`, `KSU_VER`, `KSU_VER_CODE`, `BOOTMODE`, etc.
+- **Variáveis**: `MODPATH`, `TMPDIR`, `ZIPFILE`, `ARCH`, `API`, `IS64BIT`, `KSU`, `KSU_VER`, `KSU_VER_CODE`, `KSU_UAPI_VER`, `KSU_RUNTIME_MODE`, `KSU_LATE_LOAD`, `BOOTMODE`, etc.
 - **Funções**:
   - `ui_print <msg>` - Imprime mensagem no console
   - `abort <msg>` - Imprime erro e encerra a instalação

--- a/website/docs/ru_RU/guide/metamodule.md
+++ b/website/docs/ru_RU/guide/metamodule.md
@@ -216,7 +216,7 @@ done
 
 Этот скрипт наследует все переменные и функции из встроенного `install.sh`:
 
-- **Переменные**: `MODPATH`, `TMPDIR`, `ZIPFILE`, `ARCH`, `API`, `IS64BIT`, `KSU`, `KSU_VER`, `KSU_VER_CODE`, `BOOTMODE` и т. д.
+- **Переменные**: `MODPATH`, `TMPDIR`, `ZIPFILE`, `ARCH`, `API`, `IS64BIT`, `KSU`, `KSU_VER`, `KSU_VER_CODE`, `KSU_UAPI_VER`, `KSU_RUNTIME_MODE`, `KSU_LATE_LOAD`, `BOOTMODE` и т. д.
 - **Функции**:
   - `ui_print <msg>` - Вывести сообщение в консоль
   - `abort <msg>` - Вывести ошибку и завершить установку

--- a/website/docs/vi_VN/guide/metamodule.md
+++ b/website/docs/vi_VN/guide/metamodule.md
@@ -216,7 +216,7 @@ done
 
 Script này kế thừa tất cả các biến và hàm từ `install.sh` tích hợp:
 
-- **Biến**: `MODPATH`, `TMPDIR`, `ZIPFILE`, `ARCH`, `API`, `IS64BIT`, `KSU`, `KSU_VER`, `KSU_VER_CODE`, `BOOTMODE`, v.v.
+- **Biến**: `MODPATH`, `TMPDIR`, `ZIPFILE`, `ARCH`, `API`, `IS64BIT`, `KSU`, `KSU_VER`, `KSU_VER_CODE`, `KSU_UAPI_VER`, `KSU_RUNTIME_MODE`, `KSU_LATE_LOAD`, `BOOTMODE`, v.v.
 - **Hàm**:
   - `ui_print <msg>` - In thông báo ra console
   - `abort <msg>` - In lỗi và kết thúc cài đặt

--- a/website/docs/zh_CN/guide/metamodule.md
+++ b/website/docs/zh_CN/guide/metamodule.md
@@ -215,7 +215,7 @@ done
 
 此脚本继承内置 `install.sh` 的所有变量和函数:
 
-- **变量**: `MODPATH`、`TMPDIR`、`ZIPFILE`、`ARCH`、`API`、`IS64BIT`、`KSU`、`KSU_VER`、`KSU_VER_CODE`、`BOOTMODE` 等
+- **变量**: `MODPATH`、`TMPDIR`、`ZIPFILE`、`ARCH`、`API`、`IS64BIT`、`KSU`、`KSU_VER`、`KSU_VER_CODE`、`KSU_UAPI_VER`、`KSU_RUNTIME_MODE`、`KSU_LATE_LOAD`、`BOOTMODE` 等
 - **函数**:
   - `ui_print <msg>` - 向控制台打印消息
   - `abort <msg>` - 打印错误并终止安装

--- a/website/docs/zh_TW/guide/metamodule.md
+++ b/website/docs/zh_TW/guide/metamodule.md
@@ -216,7 +216,7 @@ done
 
 此腳本繼承內建 `install.sh` 的所有變數和函式:
 
-- **變數**: `MODPATH`、`TMPDIR`、`ZIPFILE`、`ARCH`、`API`、`IS64BIT`、`KSU`、`KSU_VER`、`KSU_VER_CODE`、`BOOTMODE` 等
+- **變數**: `MODPATH`、`TMPDIR`、`ZIPFILE`、`ARCH`、`API`、`IS64BIT`、`KSU`、`KSU_VER`、`KSU_VER_CODE`、`KSU_UAPI_VER`、`KSU_RUNTIME_MODE`、`KSU_LATE_LOAD`、`BOOTMODE` 等
 - **函式**:
   - `ui_print <msg>` - 向主控台列印訊息
   - `abort <msg>` - 列印錯誤並終止安裝


### PR DESCRIPTION
```
Author: u9521 <63995396+u9521@users.noreply.github.com>
Date:   Mon Jun 29 23:21:58 2026 +0800
```

[PARTIAL] ksud: expose module env vars (https://github.com/tiann/KernelSU/pull/3522)

ksud:
- Refactor `is_uapi_version_mismatch()` into `ensure_uapi_version_matched()` with descriptive error messages showing both kernel and ksud UAPI versions.
- expose `KSU_UAPI_VER` and `KSU_RUNTIME_MODE` to module scripts.
- Block module installation on UAPI version mismatch.
- Show UAPI version in `ksud --version` output.

docs:

- Document `KSU_UAPI_VER`, `KSU_RUNTIME_MODE`, `KSU_LATE_LOAD` env vars.

---------

Signed-off-by: u9521 <63995396+u9521@users.noreply.github.com>
Co-authored-by: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>

-Omit:
 -'docs: initrc injection and rescue guide'
  guide/module.md, guide/rescue-from-bootloop.md
  - Add initrc injection guide with examples and limitations.
  - Rewrite rescue guide with practical manual recovery methods.