### PR TITLE
fix: sucompat, __init/__exit macros (legacy)

### DIFF
--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -35,48 +35,6 @@ static int ksu_selinux_get_sids(void)
 	return (!ksu_sid || !priv_app_sid) ? -1 : 0;
 }
 
-#if defined(CONFIG_KPROBES)
-#include <linux/kprobes.h>
-static struct kprobe *slow_avc_audit_kp;
-
-static int slow_avc_audit_pre_handler(struct kprobe *p, struct pt_regs *regs)
-{
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0) && defined(KSU_COMPAT_USE_SELINUX_STATE)
-	u32 *tsid = (u32 *)&PT_REGS_PARM3(regs);
-#else
-	u32 *tsid = (u32 *)&PT_REGS_PARM2(regs);
-#endif
-	if (ksu_selinux_hide_is_enabled && *tsid == ksu_sid) {
-		*tsid = priv_app_sid;
-	}
-	return 0;
-}
-
-static struct kprobe *init_kprobe(const char *name, kprobe_pre_handler_t handler)
-{
-	struct kprobe *kp = kzalloc(sizeof(*kp), GFP_KERNEL);
-	if (!kp)
-		return NULL;
-	kp->symbol_name = name;
-	kp->pre_handler = handler;
-	if (register_kprobe(kp)) {
-		kfree(kp);
-		return NULL;
-	}
-	return kp;
-}
-
-static void destroy_kprobe(struct kprobe **kp_ptr)
-{
-	if (!*kp_ptr)
-		return;
-	unregister_kprobe(*kp_ptr);
-	synchronize_rcu();
-	kfree(*kp_ptr);
-	*kp_ptr = NULL;
-}
-#endif
-
 static void ksu_selinux_hide_enable(void)
 {
 	if (ksu_selinux_get_sids())

--- a/kernel/feature/selinux_hide.h
+++ b/kernel/feature/selinux_hide.h
@@ -3,7 +3,7 @@
 
 #include <linux/types.h>
 
-void __init ksu_selinux_hide_init();
-void __exit ksu_selinux_hide_exit();
+void ksu_selinux_hide_init();
+void ksu_selinux_hide_exit();
 
 #endif

--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -92,6 +92,10 @@ int ksu_handle_faccessat(int *dfd, const char __user **filename_user,
 {
 	const char su[] = SU_PATH;
 
+	if (!ksu_su_compat_enabled) {
+		return 0;
+	}
+
 	if (!ksu_is_allow_uid_for_current(current_uid().val)) {
 		return 0;
 	}
@@ -113,6 +117,10 @@ int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags)
 {
 	// const char sh[] = SH_PATH;
 	const char su[] = SU_PATH;
+
+	if (!ksu_su_compat_enabled){
+		return 0;
+	}
 
 	if (!ksu_is_allow_uid_for_current(current_uid().val)) {
 		return 0;
@@ -146,6 +154,9 @@ long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, 
 	unsigned long addr;
 
 	if (unlikely(!filename_user))
+		goto do_orig_execve;
+
+	if (!ksu_su_compat_enabled)
 		goto do_orig_execve;
 
 	if (!ksu_is_allow_uid_for_current(current_uid().val))
@@ -210,6 +221,9 @@ int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
 	if (unlikely(!filename_ptr))
 		return 0;
 
+	if (!ksu_su_compat_enabled)
+		return 0;
+
 	if (!ksu_is_allow_uid_for_current(current_uid().val))
 		return 0;
 
@@ -226,39 +240,6 @@ int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
 	escape_with_root_profile();
 
 	return 0;
-}
-
-int __ksu_handle_devpts(struct inode *inode)
-{
-#ifndef KSU_KPROBES_HOOK
-	if (!ksu_su_compat_enabled)
-		return 0;
-#endif
-
-	if (!current->mm) {
-		return 0;
-	}
-
-	uid_t uid = current_uid().val;
-	if (uid % 100000 < 10000) {
-		// not untrusted_app, ignore it
-		return 0;
-	}
-
-	if (likely(!ksu_is_allow_uid(uid)))
-		return 0;
-
-	struct inode_security_struct *sec = selinux_inode(inode);
-
-	if (ksu_file_sid && sec)
-		sec->sid = ksu_file_sid;
-	return 0;
-}
-
-// dead code: devpts handling
-int __maybe_unused ksu_handle_devpts(struct inode *inode)
-{
-	return __ksu_handle_devpts(inode);
 }
 
 // sucompat: permitted process can execute 'su' to gain root access.

--- a/kernel/feature/sulog.h
+++ b/kernel/feature/sulog.h
@@ -2,9 +2,10 @@
 #define __KSU_H_SULOG
 
 #include <linux/types.h>
+#include <linux/init.h>
 
 bool ksu_sulog_is_enabled(void);
 void __init ksu_sulog_init(void);
-void __exit ksu_sulog_exit(void);
+void ksu_sulog_exit(void);
 
 #endif

--- a/kernel/hook/lsm_hooks.c
+++ b/kernel/hook/lsm_hooks.c
@@ -113,8 +113,6 @@ static int ksu_task_fix_setuid(struct cred *new, const struct cred *old,
 #define DEVPTS_SUPER_MAGIC	0x1cd1
 #endif
 
-extern int __ksu_handle_devpts(struct inode *inode); // sucompat.c
-
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 int ksu_inode_permission(struct mnt_idmap *idmap, struct inode *inode, int mask)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
@@ -124,7 +122,7 @@ int ksu_inode_permission(struct inode *inode, int mask)
 #endif
 {
 	if (unlikely(inode && inode->i_sb && inode->i_sb->s_magic == DEVPTS_SUPER_MAGIC)) {
-		__ksu_handle_devpts(inode);
+		// __ksu_handle_devpts(inode);
 	}
 	return 0;
 }

--- a/kernel/sulog/event.h
+++ b/kernel/sulog/event.h
@@ -3,6 +3,7 @@
 
 #include <linux/compiler_types.h>
 #include <linux/gfp.h>
+#include <linux/init.h>
 #include <linux/types.h>
 #include "uapi/sulog.h" // IWYU pragma: keep
 
@@ -10,7 +11,7 @@ struct ksu_event_queue;
 struct ksu_sulog_pending_event;
 
 int __init ksu_sulog_events_init(void);
-void __exit ksu_sulog_events_exit(void);
+void ksu_sulog_events_exit(void);
 
 struct ksu_sulog_pending_event *ksu_sulog_capture_root_execve(const char __user *filename_user,
                                                               const char __user *const __user *argv_user, gfp_t gfp);

--- a/kernel/sulog/fd.h
+++ b/kernel/sulog/fd.h
@@ -1,8 +1,10 @@
 #ifndef __KSU_H_SULOG_FD
 #define __KSU_H_SULOG_FD
 
+#include <linux/init.h>
+
 int ksu_install_sulog_fd(void);
 void __init ksu_sulog_fd_init(void);
-void __exit ksu_sulog_fd_exit(void);
+void ksu_sulog_fd_exit(void);
 
 #endif


### PR DESCRIPTION
1. __init/__exit, these macros are included automatically on some trees but mostly it
    needs the linux/init.h header for safety 

2. removed Kprobes-specific hooks in selinux_hide.c as the avc denial spoof
    is already handled

3. sucompat: functions providing sucompat run it unconditionally bypassing the manager toggle at all. is_enabled is defined in this case but not ever checked or used.