### PR TITLE
fix: Adding an #if to make compatibility between 4.19 and earlier kernels and 4.14 and older kernels

### DIFF
--- a/kernel/sulog/event.c
+++ b/kernel/sulog/event.c
@@ -52,7 +52,11 @@ void ksu_compat_sulog(uint8_t sym)
     unsigned int uid = current_uid().val;
     struct timespec64 ts;
 
-    ktime_get_boottime_ts64(&ts);
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+	ktime_get_boottime_ts64(&ts);
+#else
+	get_monotonic_boottime(&ts);
+#endif
     entry.s_time = (uint32_t)ts.tv_sec;
     entry.data = (uint32_t)uid;
     memcpy((void *)&entry.data + 3, &sym, 1);
@@ -83,7 +87,11 @@ int ksu_sulog_handle_compat_dump(void __user *uptr)
     if (!sbuf.index_ptr || !sbuf.buf_ptr || !sbuf.uptime_ptr)
         return 1;
 
-    ktime_get_boottime_ts64(&ts);
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+	ktime_get_boottime_ts64(&ts);
+#else
+	get_monotonic_boottime(&ts);
+#endif
     uptime = (uint32_t)ts.tv_sec;
     if (copy_to_user((void __user *)(uintptr_t)sbuf.uptime_ptr, &uptime, sizeof(uptime)))
         return 1;

--- a/kernel/sulog/event.c
+++ b/kernel/sulog/event.c
@@ -52,7 +52,7 @@ void ksu_compat_sulog(uint8_t sym)
     unsigned int uid = current_uid().val;
     struct timespec64 ts;
 
-#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(4, 19, 0) <= LINUX_VERSION_CODE
 	ktime_get_boottime_ts64(&ts);
 #else
 	get_monotonic_boottime(&ts);
@@ -87,7 +87,7 @@ int ksu_sulog_handle_compat_dump(void __user *uptr)
     if (!sbuf.index_ptr || !sbuf.buf_ptr || !sbuf.uptime_ptr)
         return 1;
 
-#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(4, 19, 0) <= LINUX_VERSION_CODE
 	ktime_get_boottime_ts64(&ts);
 #else
 	get_monotonic_boottime(&ts);


### PR DESCRIPTION
Fixing compatibility issues with 4.14 and older kernels on legacy branch
the issue is caused by kernelsu next calling ktime_get_boottime_ts64(&ts); which is fine on 4.19 and newer kernels but make compile errors on 4.14 and older kernels, i fixed it by adding a compile time if that checks the kernel version code and adds the right call.