### PR TITLE
ksud: boot-patch: only use kmi from boot if ota (https://github.com/tiann/KernelSU/pull/3557)

### DIFF
--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -519,6 +519,14 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
         let kmi = kmi.map_or_else(
             || -> Result<_> {
                 #[cfg(target_os = "android")]
+                if ota {
+                    let slot_suffix = get_slot_suffix(true);
+                    println!("- Trying to auto detect KMI version from boot");
+                    return parse_kmi_from_boot(Path::new(&format!(
+                        "/dev/block/by-name/boot{slot_suffix}"
+                    )));
+                }
+                #[cfg(target_os = "android")]
                 match get_current_kmi() {
                     Ok(value) => {
                         return Ok(value);


### PR DESCRIPTION
```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Mon Jul 6 00:36:15 2026 +0800
```