### PR TITLE
Fix compilation compatibility for Linux Kernel 4.9

### DIFF
--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -3,7 +3,12 @@
 #include <linux/mm.h>
 #include <linux/mutex.h>
 #include <linux/slab.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
 #include <asm/set_memory.h>
+#else
+#include <asm/cacheflush.h>
+#endif
 #include <linux/namei.h>
 #include <linux/kthread.h>
 #include <linux/delay.h>

--- a/kernel/feature/sulog.c
+++ b/kernel/feature/sulog.c
@@ -1,5 +1,10 @@
 #include <linux/cache.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
 #include <linux/compiler_types.h>
+#else
+#include <linux/compiler.h>
+#endif
 
 #include "feature/sulog.h"
 #include "klog.h" // IWYU pragma: keep

--- a/kernel/infra/event_queue.c
+++ b/kernel/infra/event_queue.c
@@ -11,6 +11,20 @@
 
 #include "infra/event_queue.h"
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+#ifndef EPOLLIN
+#define EPOLLIN POLLIN
+#endif
+#ifndef EPOLLRDNORM
+#define EPOLLRDNORM POLLRDNORM
+#endif
+#ifndef EPOLLHUP
+#define EPOLLHUP POLLHUP
+#endif
+#endif
+
+
 struct ksu_event_queue_node {
     struct list_head list;
     struct ksu_event_record_hdr hdr;

--- a/kernel/infra/event_queue.h
+++ b/kernel/infra/event_queue.h
@@ -10,6 +10,11 @@
 #include <linux/types.h>
 #include <linux/wait.h>
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+typedef unsigned int __poll_t;
+#endif
+
 #define KSU_EVENT_RECORD_FLAG_INTERNAL (1U << 0)
 #define KSU_EVENT_QUEUE_TYPE_DROPPED ((__u16)0xFFFF)
 

--- a/kernel/sulog/event.c
+++ b/kernel/sulog/event.c
@@ -4,7 +4,11 @@
 #include <linux/gfp.h>
 #include <linux/kernel.h>
 #include <linux/overflow.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include <linux/sched/signal.h>
+#endif
+
 #include <linux/slab.h>
 #include <linux/string.h>
 #include <linux/uaccess.h>

--- a/kernel/sulog/event.h
+++ b/kernel/sulog/event.h
@@ -1,7 +1,12 @@
 #ifndef __KSU_H_SULOG_EVENT
 #define __KSU_H_SULOG_EVENT
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
 #include <linux/compiler_types.h>
+#else
+#include <linux/compiler.h>
+#endif
 #include <linux/gfp.h>
 #include <linux/init.h>
 #include <linux/types.h>


### PR DESCRIPTION
- Add conditional checks for compiler_types.h (introduced in 4.14)
- Handle missing __poll_t and EPOLL* flags on older polling systems
- Fix asm/set_memory.h and sched/signal.h include paths for legacy kernels