### PR TITLE
legacy: throne_tracker: fix ABBA deadlock between fsnotify hook and worker (unrecoverable freeze)

### DIFF
--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -406,11 +406,17 @@ void track_throne(bool prune_only)
 		return;
 	}
 
-	// For asynchronous runs, if a work is already pending, canceling it
-	// ensures we don't clobber the prune_only state while it's waiting.
-	cancel_delayed_work_sync(&throne_data.dwork);
+	// Never flush/wait here: this is reachable from the pkg_observer
+	// fsnotify hook, which runs inside vfs_rename with the parent dir
+	// i_rwsem held, while the worker may be blocked in
+	// filp_open(packages.list) -> lookup_slow -> down_read on that same
+	// i_rwsem -- a sync cancel then deadlocks both sides in D state.
+	// Async cancel is sufficient: a mid-run worker finishes with the old
+	// prune_only, and the run queued below applies the new state (the
+	// worker's own retry reschedule is a no-op against pending work).
+	cancel_delayed_work(&throne_data.dwork);
 
-	// Update state safely and queue the new work
+	// Update state and queue the new work
 	throne_data.prune_only = prune_only;
 	throne_data.retries = 0;
 	schedule_delayed_work(&throne_data.dwork, 0);


### PR DESCRIPTION
Fixes #1408

`track_throne()` is reachable from the `pkg_observer` fsnotify hook, which runs inside `vfs_rename` with the parent directory `i_rwsem` held. Its `cancel_delayed_work_sync()` then waits for `ksu_throne_work_fn`, which can itself be blocked in `filp_open(packages.list)` → `lookup_slow` → `down_read` on that same `i_rwsem` — an ABBA deadlock with both sides in uninterruptible D state. Full captured stacks and the freeze mechanism (watchdog SIGKILL can't kill the D-state thread → zombie system_server → zygote never restarts the framework → device frozen, `adb reboot` wedges) are in #1408.

This PR makes the cancel asynchronous. That preserves the intent of the original sync cancel (not clobbering `prune_only` under a waiting work): a mid-run worker completes with the old `prune_only`, and the run queued immediately after applies the new state; the worker's own retry `schedule_delayed_work()` against already-pending work is a no-op. The `cancel_delayed_work_sync()` in `ksu_throne_tracker_exit()` is deliberately untouched (never called under VFS locks).

On "in operation for months with no issues": the window is narrow — it needs a `packages.list` rename to land while the worker is between queue and open, and the open must take the slow-lookup path — but the 100 ms × 10 retry loop keeps re-arming the worker around every commit, and when it does hit, it presents as a full device freeze that users typically blame on the ROM/kernel rather than on this driver, so reports wouldn't naturally converge here. It hit the same device twice within two days (both traced to this cycle); with the async cancel it has not recurred, and superuser/manager behavior is unaffected.

Only the `legacy` delayed-work tracker is affected; the `dev` rewrite doesn't have this code path.
