### PR TITLE
kernel/ksud/manager: reg. TP handler min. prio./allocation paths NULL chk; spawn_sulogd no ret. child; saved app profile stray quote

### DIFF
--- a/kernel/hook/syscall_hook_manager.c
+++ b/kernel/hook/syscall_hook_manager.c
@@ -138,7 +138,7 @@ void __init ksu_syscall_hook_manager_init(void)
     ksu_register_syscall_hook(__NR_faccessat, ksu_hook_faccessat);
 
 #ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
-    ret = register_trace_sys_enter(ksu_sys_enter_handler, NULL);
+    ret = register_trace_prio_sys_enter(ksu_sys_enter_handler, NULL, INT_MIN);
 #ifndef CONFIG_KRETPROBES
     ksu_mark_running_process_locked();
 #endif

--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -150,6 +150,10 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name,
 				}
 			} else {
 				struct apk_path_hash *apk_data = kzalloc(sizeof(struct apk_path_hash), GFP_KERNEL);
+				if (!apk_data) {
+					pr_err("Failed to allocate apk_path_hash for %s\n", dirpath);
+					return FILLDIR_ACTOR_CONTINUE;
+				}
 				apk_data->hash = hash;
 				apk_data->exists = true;
 				list_add_tail(&apk_data->list, &apk_path_hash_list);

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -566,6 +566,8 @@ static bool add_filename_trans(struct policydb *db, const char *s,
 {
     struct type_datum *src, *tgt, *def;
     struct class_datum *cls;
+    struct filename_trans_key *new_key = NULL;
+    int rc;
 
     src = symtab_search(&db->p_types, s);
     if (src == NULL) {
@@ -611,18 +613,41 @@ static bool add_filename_trans(struct policydb *db, const char *s,
     if (trans == NULL) {
         trans = (struct filename_trans_datum *)kcalloc(1, sizeof(*trans),
                                                        GFP_KERNEL);
-        struct filename_trans_key *new_key =
-            (struct filename_trans_key *)kzalloc(sizeof(*new_key), GFP_KERNEL);
+        if (!trans) {
+            pr_err("add_filename_trans: alloc filename_trans_datum failed\n");
+            goto out;
+        }
+        new_key = (struct filename_trans_key *)kzalloc(sizeof(*new_key), GFP_KERNEL);
+        if (!new_key) {
+            pr_err("add_filename_trans: alloc filename_trans_key failed\n");
+            goto free_trans;
+        }
         *new_key = key;
         new_key->name = kstrdup(key.name, GFP_KERNEL);
+        if (!new_key->name) {
+            pr_err("add_filename_trans: kstrdup name failed\n");
+            goto free_key;
+        }
         trans->next = last;
         trans->otype = def->value;
-        hashtab_insert(&db->filename_trans, new_key, trans,
-                       filenametr_key_params);
+        rc = hashtab_insert(&db->filename_trans, new_key, trans, filenametr_key_params);
+        if (rc) {
+            pr_err("add_filename_trans: hashtab_insert failed: %d\n", rc);
+            goto free_name;
+        }
     }
 
     db->compat_filename_trans_count++;
     return ebitmap_set_bit(&trans->stypes, src->value - 1, 1) == 0;
+
+free_name:
+    kfree(new_key->name);
+free_key:
+    kfree(new_key);
+free_trans:
+    kfree(trans);
+out:
+    return false;
 }
 
 static bool add_genfscon(struct policydb *db, const char *fs_name,

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/KsuCli.kt
@@ -88,9 +88,9 @@ fun createRootShell(globalMnt: Boolean = false): Shell {
     }
 }
 
-fun execKsud(args: String, newShell: Boolean = false): Boolean {
+fun execKsud(args: String, newShell: Boolean = false, globalMnt: Boolean = false): Boolean {
     return if (newShell) {
-        withNewRootShell {
+        withNewRootShell(globalMnt = globalMnt) {
             ShellUtils.fastCmdResult(this, "${getKsuDaemonPath()} $args")
         }
     } else {
@@ -400,7 +400,7 @@ fun installBoot(
 fun reboot(reason: String = "") {
     if (reason == "soft-reboot") {
         // ksud (userspace)
-        com.rifsxd.ksunext.ui.util.execKsud("soft-reboot")
+        com.rifsxd.ksunext.ui.util.execKsud("soft-reboot", true, true)
         return
     }
 

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/KsuCli.kt
@@ -640,8 +640,8 @@ fun getMetaModule(): String {
 }
 
 fun setAppProfileTemplate(id: String, template: String): Boolean {
-    val escapedTemplate = template.replace("\"", "\\\"")
-    val cmd = """${getKsuDaemonPath()} profile set-template "$id" "$escapedTemplate'""""
+    val escapedTemplate = template.replace("'", "'\\''")
+    val cmd = """${getKsuDaemonPath()} profile set-template "$id" '$escapedTemplate'"""
     return Shell.cmd(cmd)
         .to(ArrayList(), null).exec().isSuccess
 }

--- a/userspace/ksud/src/sulog.rs
+++ b/userspace/ksud/src/sulog.rs
@@ -779,8 +779,7 @@ pub fn run_sulogd() -> Result<()> {
 
 pub fn spawn_sulogd() -> Result<()> {
     if utils::create_daemon(true)? {
-        let current_exe = std::env::current_exe().context("failed to resolve current ksud path")?;
-        let mut command = Command::new(current_exe);
+        let mut command = Command::new("/proc/self/exe");
         command
             .arg("sulogd")
             .stdin(Stdio::null())
@@ -788,10 +787,13 @@ pub fn spawn_sulogd() -> Result<()> {
             .stderr(Stdio::null())
             .current_dir("/");
 
-        Err(command.exec()).context("failed to exec sulogd")
-    } else {
-        Ok(())
+        let err = command.exec();
+        log::error!("failed to exec sulogd: {err:#}");
+        unsafe {
+            libc::_exit(1);
+        }
     }
+    Ok(())
 }
 
 pub fn ensure_sulogd_running() -> Result<()> {


### PR DESCRIPTION
```
Author: palaziks <gochmyradov0@gmail.com>
Date:   Sun Jul 19 12:07:31 2026 +0500

    kernel: add missing NULL checks on allocation paths (https://github.com/tiann/KernelSU/pull/3572)

    Co-authored-by: Wang Han <416810799@qq.com>

Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Sun Jul 19 00:27:25 2026 +0800

    ksud: ensure spawn_sulogd don't return in child; execute /proc/self/exe instead of resolving executable path (https://github.com/tiann/KernelSU/pull/3583)

    -Omit: getRootShell(globalMnt) from execKsud `else`
           (libsu's cached shell is used)

Author: palaziks <gochmyradov0@gmail.com>
Date:   Fri Jul 17 06:09:17 2026 +0500

    manager: fix stray quote corrupting saved app profile templates (https://github.com/tiann/KernelSU/pull/3571)

    ---

    Co-authored-by: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>

Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Fri Jul 17 08:47:37 2026 +0800

    kernel: register tracepoint handler with minimum priority (https://github.com/tiann/KernelSU/pull/3582)

    This allows other tracepoint handler like perf/bpf to run before we
    corrupt the context
```