### PR TITLE
kernel: return an error when set_cred_ucounts fails in escape_with_root_profile

### DIFF
--- a/kernel/policy/app_profile.c
+++ b/kernel/policy/app_profile.c
@@ -168,6 +168,7 @@ int escape_with_root_profile(void)
     // on older kernels, per-UID process accounting lives in user_struct.
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
     if (set_cred_ucounts(cred)) {
+        ret = -ENOMEM;
         goto out_abort_creds;
     }
 #endif


### PR DESCRIPTION
While reading through `escape_with_root_profile()` I noticed the `set_cred_ucounts()` failure path never sets an error code.

When `set_cred_ucounts()` fails it does `goto out_abort_creds`, but `ret` is still `0` at that point — it only gets set to `-ENOMEM` on the `alloc_uid()` failure right above. So the creds are torn down with `abort_creds()` and root is never granted, yet the function returns `0`. `do_grant_root()` forwards that `0` to userspace, so ksud treats the grant as successful while the process actually keeps its original uid.

It only triggers under memory pressure (`set_cred_ucounts()` allocates), so it is rare, but when it happens the caller has no way to tell the grant silently failed.

The fix just sets `ret = -ENOMEM` before the `goto`, matching the `alloc_uid()` path a few lines up. The normal/success path is unchanged.