### PR TITLE
kernel: prevent /system/bin/stub_zygote from being unmarked (https://github.com/tiann/KernelSU/pull/3601)

### DIFF
--- a/kernel/hook/syscall_event_bridge.c
+++ b/kernel/hook/syscall_event_bridge.c
@@ -39,7 +39,8 @@ static int ksu_handle_init_mark_tracker(const char __user **filename_user)
     if (unlikely(strcmp(path, KSUD_PATH) == 0)) {
         pr_info("hook_manager: escape to root for init executing ksud: %d\n", current->pid);
         escape_to_root_for_init();
-    } else if (likely(strstr(path, "/app_process") == NULL && strstr(path, "/adbd") == NULL)) {
+    } else if (likely(strstr(path, "/app_process") == NULL && strstr(path, "/adbd") == NULL &&
+                      strstr(path, "/stub_zygote") == NULL)) {
         pr_info("hook_manager: unmark %d exec %s\n", current->pid, path);
         ksu_clear_task_tracepoint_flag_if_needed(current);
     }


### PR DESCRIPTION
```
Author: f19 <58457605+F-19-F@users.noreply.github.com>
Date:   Wed Jul 29 09:56:10 2026 +0800
```

If the `stub_zygote` process is unexpectedly unmarked, the zygote spawned by it will also be unmarked. On certain Android-based operating systems like Meta Quest Horizon OS, this causes the manager to fail after a soft reboot.