### PR TITLE
fix(legacy): selinux_hide build error on kprobe

### DIFF
--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -1,3 +1,6 @@
+#ifdef KSU_KPROBES_HOOK
+#include <linux/completion.h>
+#endif
 #include <linux/fs.h>
 #include <linux/jump_label.h>
 #include <linux/mm.h>
@@ -28,10 +31,14 @@ extern struct kprobe *slow_avc_audit_kp;
 static struct page *fake_status = NULL;
 static DEFINE_MUTEX(fake_status_init_mutex);
 
+#ifndef KSU_KPROBES_HOOK
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
 extern bool ksu_input_hook __read_mostly __attribute__((weak));
 #else
 extern bool ksu_input_hook __read_mostly;
+#endif
+#else
+extern struct completion stop_input_hook_work_complete;
 #endif
 extern struct selinux_state selinux_state;
 
@@ -268,8 +275,12 @@ static int ksu_hide_init_thread(void *data)
 {
 	set_user_nice(current, 19);
 
+#ifndef KSU_KPROBES_HOOK
 	while (READ_ONCE(ksu_input_hook))
 		msleep(5000);
+#else
+	wait_for_completion(&stop_input_hook_work_complete);
+#endif
 
 	if (ksu_selinux_hide_is_enabled)
 		ksu_selinux_hide_enable();

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -3,6 +3,9 @@
 #include <linux/task_work.h>
 #include <asm/current.h>
 #include <linux/compat.h>
+#ifdef KSU_KPROBES_HOOK
+#include <linux/completion.h>
+#endif
 #include <linux/cred.h>
 #include <linux/dcache.h>
 #include <linux/err.h>
@@ -71,6 +74,7 @@ void stop_input_hook();
 static struct work_struct __maybe_unused stop_init_rc_hook_work;
 static struct work_struct __maybe_unused stop_execve_hook_work;
 static struct work_struct __maybe_unused stop_input_hook_work;
+DECLARE_COMPLETION(stop_input_hook_work_complete);
 #else
 bool ksu_init_rc_hook __read_mostly = true;
 bool __maybe_unused ksu_vfs_read_hook = true;
@@ -694,6 +698,7 @@ static void do_stop_execve_hook(struct work_struct *work)
 static void do_stop_input_hook(struct work_struct *work)
 {
 	unregister_kprobe(&input_event_kp);
+	complete(&stop_input_hook_work_complete);
 }
 #else
 static int ksu_execve_ksud_common(const char __user *filename_user,


### PR DESCRIPTION
#1420 
kernel/feature/selinux_hide.c uses `ksu_input_hook` to wait for `stop_input_hook` in kernel/runtime/ksud_integration.c. However this does not exist in kprobe hook mode.