### PR TITLE
ksuinit: compat for version magic mismatch kernel (https://github.com/tiann/KernelSU/pull/3584)

### DIFF
--- a/userspace/ksuinit/src/lib.rs
+++ b/userspace/ksuinit/src/lib.rs
@@ -1,11 +1,12 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use goblin::elf::{Elf, section_header, sym::Sym};
 use rustix::system::init_module;
 use scroll::{Pwrite, ctx::SizeWith};
 use std::collections::HashMap;
 use std::ffi::CStr;
-use std::fs::{self, File};
-use std::io::{BufRead, BufReader};
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, ErrorKind, Read, Seek, SeekFrom};
+use std::os::unix::fs::OpenOptionsExt;
 
 struct Kptr {
     value: String,
@@ -82,6 +83,235 @@ pub fn for_each_kernel_symbols<F: FnMut(&(String, u64)) -> Result<bool>>(mut f: 
     Ok(())
 }
 
+const O_NONBLOCK: i32 = 0x800;
+
+fn open_kmsg_at_end() -> Result<File> {
+    let mut last_error = None;
+
+    for path in ["/dev/kmsg", "/kmsg"] {
+        match OpenOptions::new()
+            .read(true)
+            .custom_flags(O_NONBLOCK)
+            .open(path)
+        {
+            Ok(mut file) => {
+                file.seek(SeekFrom::End(0))
+                    .with_context(|| format!("Cannot seek {path} to end"))?;
+
+                log::info!("Reading kernel log from {path}");
+                return Ok(file);
+            }
+            Err(error) => {
+                last_error = Some((path, error));
+            }
+        }
+    }
+
+    match last_error {
+        Some((path, error)) => {
+            Err(error).with_context(|| format!("Cannot open kernel log device, last tried {path}"))
+        }
+        None => bail!("No kernel log device candidate"),
+    }
+}
+
+fn read_new_kmsg(file: &mut File) -> Result<String> {
+    let mut output = Vec::new();
+    let mut record = [0u8; 8192];
+
+    loop {
+        match file.read(&mut record) {
+            Ok(0) => break,
+            Ok(length) => {
+                output.extend_from_slice(&record[..length]);
+                output.push(b'\n');
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+            Err(error) => return Err(error).context("Cannot read /dev/kmsg"),
+        }
+    }
+
+    Ok(String::from_utf8_lossy(&output).into_owned())
+}
+
+fn extract_required_vermagic(kmsg: &str) -> Option<String> {
+    const PREFIX: &str = "version magic '";
+    const SEPARATOR: &str = "' should be '";
+
+    for record in kmsg.lines().rev() {
+        let message = record
+            .split_once(';')
+            .map(|(_, message)| message)
+            .unwrap_or(record);
+
+        let Some(prefix_position) = message.find(PREFIX) else {
+            continue;
+        };
+        let after_prefix = &message[prefix_position + PREFIX.len()..];
+
+        let Some(separator_position) = after_prefix.find(SEPARATOR) else {
+            continue;
+        };
+        let required = &after_prefix[separator_position + SEPARATOR.len()..];
+
+        let Some(end_quote) = required.find('\'') else {
+            continue;
+        };
+        let required = &required[..end_quote];
+
+        if !required.is_empty() {
+            return Some(required.to_owned());
+        }
+    }
+
+    None
+}
+
+fn align_up(value: usize, alignment: usize) -> Result<usize> {
+    let alignment = alignment.max(1);
+
+    if !alignment.is_power_of_two() {
+        bail!("Invalid ELF alignment: {alignment}");
+    }
+
+    value
+        .checked_add(alignment - 1)
+        .map(|value| value & !(alignment - 1))
+        .context("ELF alignment overflow")
+}
+
+fn write_elf64_word(
+    buffer: &mut [u8],
+    offset: usize,
+    value: u64,
+    little_endian: bool,
+) -> Result<()> {
+    let end = offset.checked_add(8).context("ELF write overflow")?;
+    let destination = buffer
+        .get_mut(offset..end)
+        .context("ELF write outside module buffer")?;
+
+    let bytes = if little_endian {
+        value.to_le_bytes()
+    } else {
+        value.to_be_bytes()
+    };
+    destination.copy_from_slice(&bytes);
+    Ok(())
+}
+
+fn replace_module_vermagic(buffer: &mut Vec<u8>, required_vermagic: &str) -> Result<()> {
+    struct ModinfoLocation {
+        offset: usize,
+        size: usize,
+        section_header_offset: usize,
+        alignment: usize,
+        little_endian: bool,
+    }
+
+    let location = {
+        let elf = Elf::parse(buffer)?;
+
+        if !elf.is_64 {
+            bail!("Only ELF64 modules are supported");
+        }
+
+        let section_table_offset =
+            usize::try_from(elf.header.e_shoff).context("Section table offset overflow")?;
+        let section_entry_size = usize::from(elf.header.e_shentsize);
+        let mut location = None;
+
+        for (index, section) in elf.section_headers.iter().enumerate() {
+            let Some(name) = elf.shdr_strtab.get_at(section.sh_name) else {
+                continue;
+            };
+            if name != ".modinfo" {
+                continue;
+            }
+
+            let offset = usize::try_from(section.sh_offset).context(".modinfo offset overflow")?;
+            let size = usize::try_from(section.sh_size).context(".modinfo size overflow")?;
+            let end = offset
+                .checked_add(size)
+                .context(".modinfo range overflow")?;
+
+            if end > buffer.len() {
+                bail!(".modinfo is outside module buffer");
+            }
+
+            let section_header_offset = section_table_offset
+                .checked_add(
+                    index
+                        .checked_mul(section_entry_size)
+                        .context("Section index overflow")?,
+                )
+                .context("Section header offset overflow")?;
+
+            location = Some(ModinfoLocation {
+                offset,
+                size,
+                section_header_offset,
+                alignment: usize::try_from(section.sh_addralign).unwrap_or(1).max(1),
+                little_endian: elf.little_endian,
+            });
+            break;
+        }
+
+        location.context("Module has no .modinfo section")?
+    };
+
+    let old_modinfo = &buffer[location.offset..location.offset + location.size];
+    let replacement = format!("vermagic={required_vermagic}");
+    let mut new_modinfo = Vec::with_capacity(old_modinfo.len().max(replacement.len() + 1));
+    let mut replaced = false;
+
+    for entry in old_modinfo.split(|byte| *byte == 0) {
+        if entry.is_empty() {
+            continue;
+        }
+
+        if entry.starts_with(b"vermagic=") {
+            if !replaced {
+                new_modinfo.extend_from_slice(replacement.as_bytes());
+                new_modinfo.push(0);
+                replaced = true;
+            }
+        } else {
+            new_modinfo.extend_from_slice(entry);
+            new_modinfo.push(0);
+        }
+    }
+
+    if !replaced {
+        new_modinfo.extend_from_slice(replacement.as_bytes());
+        new_modinfo.push(0);
+    }
+
+    let new_offset = align_up(buffer.len(), location.alignment)?;
+    buffer.resize(new_offset, 0);
+    buffer.extend_from_slice(&new_modinfo);
+
+    // Elf64_Shdr: sh_offset at +0x18, sh_size at +0x20.
+    write_elf64_word(
+        buffer,
+        location.section_header_offset + 0x18,
+        new_offset as u64,
+        location.little_endian,
+    )?;
+    write_elf64_word(
+        buffer,
+        location.section_header_offset + 0x20,
+        new_modinfo.len() as u64,
+        location.little_endian,
+    )?;
+
+    log::warn!(
+        "Replaced module vermagic with kernel-required value: {:?}",
+        required_vermagic
+    );
+    Ok(())
+}
+
 /// Relocate undefined symbols in an ELF kernel module buffer using /proc/kallsyms,
 /// then load it via init_module syscall.
 pub fn load_module(data: &[u8], params: &CStr) -> Result<()> {
@@ -124,8 +354,39 @@ pub fn load_module(data: &[u8], params: &CStr) -> Result<()> {
         log::warn!("Cannot find symbol: {}", name);
     }
 
-    init_module(&buffer, params).context("init_module failed.")?;
-    Ok(())
+    let mut kmsg = match open_kmsg_at_end() {
+        Ok(file) => Some(file),
+        Err(error) => {
+            log::warn!("Cannot prepare kmsg fallback: {error:#}");
+            None
+        }
+    };
+
+    match init_module(&buffer, params) {
+        Ok(()) => Ok(()),
+        Err(first_error) => {
+            let logs = match kmsg.as_mut() {
+                Some(file) => read_new_kmsg(file).unwrap_or_default(),
+                None => String::new(),
+            };
+
+            let Some(required_vermagic) = extract_required_vermagic(&logs) else {
+                log::error!("Kernel module loading log:\n{}", logs);
+                return Err(first_error).context("init_module failed without vermagic mismatch");
+            };
+
+            log::warn!(
+                "Kernel requires vermagic {:?}; replacing and retrying",
+                required_vermagic
+            );
+
+            replace_module_vermagic(&mut buffer, &required_vermagic)
+                .context("Cannot replace module vermagic")?;
+
+            init_module(&buffer, params).context("init_module failed after replacing vermagic")?;
+            Ok(())
+        }
+    }
 }
 
 fn has_kernelsu_legacy() -> bool {


### PR DESCRIPTION
```
Author: AlexLiuDev233 <wzylin11@outlook.com>
Date:   Fri Aug 7 16:12:01 2026 +0800
```

Some device, e.g. iQOO Neo9 Pro
Their kernel added "vivo" to thier modversions

Let's read kmsg to get current version magic, replace ourselves, and attempt load again

This solved some VIVO devices can't load lkm.

Tested-by: glboxed-max <glboxed@gmail.com>