### PR TITLE
kernel: selinux_hide: rework non-functionals in kprobes hook

### DIFF
--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -1,3 +1,6 @@
+#ifdef KSU_KPROBES_HOOK
+#include <linux/completion.h>
+#endif
 #include <linux/fs.h>
 #include <linux/jump_label.h>
 #include <linux/mm.h>
@@ -21,10 +24,14 @@
 static struct page *fake_status = NULL;
 static DEFINE_MUTEX(fake_status_init_mutex);
 
+#ifndef KSU_KPROBES_HOOK
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
 extern bool ksu_input_hook __read_mostly __attribute__((weak));
 #else
 extern bool ksu_input_hook __read_mostly;
+#endif
+#else
+extern void ksu_wait_stop_input_hook(void);
 #endif
 extern struct selinux_state selinux_state;
 
@@ -303,9 +310,11 @@ static int ksu_hide_init_thread(void *data)
 {
 	set_user_nice(current, 19);
 
-#ifndef CONFIG_KSU_KPROBES_HOOK
+#ifndef KSU_KPROBES_HOOK
 	while (READ_ONCE(ksu_input_hook))
 		msleep(5000);
+#else
+	ksu_wait_stop_input_hook();
 #endif
 
 	hook_selinux_transaction_write();

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -122,10 +122,9 @@ static int __nocfi my_sel_open_handle_status(struct inode *inode, struct file *f
 
 #define FORCE_VOLATILE(x) *(volatile typeof(x) *)&(x)
 
-static int patch_fops_open(struct file_operations *ops,
-			    sel_open_handle_status_fn new_open)
+static int patch_fops_open(void *slot_addr, void *new_fn)
 {
-	unsigned long addr = (unsigned long)&ops->open;
+	unsigned long addr = (unsigned long)slot_addr;
 	unsigned long base = addr & PAGE_MASK;
 	unsigned long offset = addr & ~PAGE_MASK;
 	
@@ -141,7 +140,7 @@ void *writable_addr = vmap(&page, 1, VM_MAP, PAGE_KERNEL);
 
 	preempt_disable();
 	local_irq_disable();
-	FORCE_VOLATILE(*target_slot) = (void *)new_open;
+	FORCE_VOLATILE(*target_slot) = new_fn;
 	local_irq_enable();
 	preempt_enable();
 
@@ -170,7 +169,7 @@ static int resolve_fops(const char *path_str, struct file_operations **out_fops)
 	ret = 0;
 out:
 	path_put(&path);
-	return ret;
+		return ret;
 }
 
 static void hook_selinux_status_open(void)
@@ -190,14 +189,14 @@ static void hook_selinux_status_open(void)
 	}
 	
 	orig_sel_open_handle_status = ops->open;
-	patch_fops_open(ops, my_sel_open_handle_status);
+	patch_fops_slot(&ops->open, my_sel_open_handle_status);
 	pr_info("ksu_selinux_hide: hooked sel_handle_status_ops->open\n");
 }
 
 static void unhook_selinux_status_open(void)
 {
 	if (!orig_sel_open_handle_status)
-	return;
+		return;
 
 	struct file_operations *ops = NULL;
 	if (resolve_fops("/sys/fs/selinux/status", &ops)) {
@@ -205,9 +204,73 @@ static void unhook_selinux_status_open(void)
 		return;
 }
 
-	patch_fops_open(ops, orig_sel_open_handle_status);
+	patch_fops_slot(&ops->open, my_sel_open_handle_status);
 	orig_sel_open_handle_status = NULL;
 	pr_info("ksu_selinux_hide: unhooked sel_handle_status_ops->open\n");
+}
+
+typedef ssize_t (*selinux_transaction_write_fn)(struct file *file, const char __user *buf,
+						  size_t size, loff_t *pos);
+static selinux_transaction_write_fn orig_selinux_transaction_write = NULL;
+
+static __nocfi ssize_t my_selinux_transaction_write(struct file *file, const char __user *buf,
+						      size_t size, loff_t *pos)
+{
+	if (unlikely(!ksu_selinux_hide_is_enabled))
+		goto pass_through;
+
+	if (!test_thread_flag(TIF_SECCOMP))
+		goto pass_through;
+
+	if (current_uid().val < 10000)
+		goto pass_through;
+
+	/* Bare minimum gate: block app-uid writes outright. If you later
+	 * want selective matching (only reject contexts naming ksu/priv_app),
+	 * copy_from_user into a small stack buffer here and strstr against
+	 * ksu_sid/priv_app_sid-derived strings before deciding. */
+	pr_info("ksu_selinux_hide: blocked transaction_write from uid=%d\n", current_uid().val);
+	return -EINVAL;
+
+pass_through:
+	return orig_selinux_transaction_write(file, buf, size, pos);
+}
+
+static void hook_selinux_transaction_write(void)
+{
+	if (orig_selinux_transaction_write)
+		return;
+
+	struct file_operations *ops = NULL;
+	if (resolve_fops("/sys/fs/selinux/context", &ops)) {
+		pr_err("ksu_selinux_hide: context ops not found, write hijack disabled\n");
+		return;
+	}
+
+	if (!ops->write) {
+		pr_err("ksu_selinux_hide: context ops->write is NULL\n");
+		return;
+	}
+
+	orig_selinux_transaction_write = ops->write;
+	patch_fops_slot(&ops->write, my_selinux_transaction_write);
+	pr_info("ksu_selinux_hide: hooked context ops->write\n");
+}
+
+static void unhook_selinux_transaction_write(void)
+{
+	if (!orig_selinux_transaction_write)
+		return;
+
+	struct file_operations *ops = NULL;
+	if (resolve_fops("/sys/fs/selinux/context", &ops)) {
+		pr_err("ksu_selinux_hide: context ops not found on unhook\n");
+		return;
+	}
+
+	patch_fops_slot(&ops->write, orig_selinux_transaction_write);
+	orig_selinux_transaction_write = NULL;
+	pr_info("ksu_selinux_hide: unhooked context ops->write\n");
 }
 
 static int selinux_hide_status_feature_get(u64 *value)
@@ -245,6 +308,8 @@ static int ksu_hide_init_thread(void *data)
 		msleep(5000);
 #endif
 
+	hook_selinux_transaction_write();
+
 	int tries = 0;
 try_again:
 	initialize_fake_status();
@@ -275,6 +340,7 @@ void __exit ksu_selinux_hide_exit(void)
 {
 	ksu_unregister_feature_handler(KSU_FEATURE_SELINUX_HIDE_STATUS);
 	unhook_selinux_status_open();
+	unhook_selinux_transaction_write();
 	mutex_lock(&fake_status_init_mutex);
 	if (fake_status) {
 		__free_page(fake_status);

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -18,13 +18,6 @@
 #include "selinux/selinux.h"
 #include "feature/selinux_hide.h"
 
-#if defined(CONFIG_KSU_KPROBES_HOOK)
-extern struct kprobe *init_kprobe(const char *name, int (*pre_handler)(struct kprobe *, struct pt_regs *));
-extern void destroy_kprobe(struct kprobe **kp_ptr);
-extern int slow_avc_audit_pre_handler(struct kprobe *p, struct pt_regs *regs);
-extern struct kprobe *slow_avc_audit_kp;
-#endif
-
 static struct page *fake_status = NULL;
 static DEFINE_MUTEX(fake_status_init_mutex);
 
@@ -55,22 +48,6 @@ static int ksu_selinux_get_sids(void)
 	if (!err1) pr_info("ksu_selinux_hide: ksu_sid=%u\n", ksu_sid);
 	if (!err2) pr_info("ksu_selinux_hide: priv_app_sid=%u\n", priv_app_sid);
 	return (!ksu_sid || !priv_app_sid) ? -1 : 0;
-}
-
-static void ksu_selinux_hide_enable(void)
-{
-	if (ksu_selinux_get_sids())
-		pr_warn("ksu_selinux_hide: sid grab failed\n");
-#if defined(CONFIG_KSU_KPROBES_HOOK)
-	slow_avc_audit_kp = init_kprobe("slow_avc_audit", slow_avc_audit_pre_handler);
-#endif
-}
-
-static void ksu_selinux_hide_disable(void)
-{
-#if defined(CONFIG_KSU_KPROBES_HOOK)
-	destroy_kprobe(&slow_avc_audit_kp);
-#endif
 }
 
 static void initialize_fake_status(void)
@@ -248,11 +225,6 @@ static int selinux_hide_status_feature_set(u64 value)
 	}
 	ksu_selinux_hide_is_enabled = enable;
 
-	if (!ksu_selinux_hide_is_enabled)
-		ksu_selinux_hide_disable();
-	else
-		ksu_selinux_hide_enable();
-
 	pr_info("ksu_selinux_hide: set to %d\n", enable);
 	return 0;
 }
@@ -268,11 +240,10 @@ static int ksu_hide_init_thread(void *data)
 {
 	set_user_nice(current, 19);
 
+#ifndef CONFIG_KSU_KPROBES_HOOK
 	while (READ_ONCE(ksu_input_hook))
 		msleep(5000);
-
-	if (ksu_selinux_hide_is_enabled)
-		ksu_selinux_hide_enable();
+#endif
 
 	int tries = 0;
 try_again:
@@ -304,7 +275,6 @@ void __exit ksu_selinux_hide_exit(void)
 {
 	ksu_unregister_feature_handler(KSU_FEATURE_SELINUX_HIDE_STATUS);
 	unhook_selinux_status_open();
-	ksu_selinux_hide_disable();
 	mutex_lock(&fake_status_init_mutex);
 	if (fake_status) {
 		__free_page(fake_status);

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -129,7 +129,7 @@ static int __nocfi my_sel_open_handle_status(struct inode *inode, struct file *f
 
 #define FORCE_VOLATILE(x) *(volatile typeof(x) *)&(x)
 
-static int patch_fops_open(void *slot_addr, void *new_fn)
+static int patch_fops_slot(void *slot_addr, void *new_fn)
 {
 	unsigned long addr = (unsigned long)slot_addr;
 	unsigned long base = addr & PAGE_MASK;

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -3,6 +3,9 @@
 #include <linux/task_work.h>
 #include <asm/current.h>
 #include <linux/compat.h>
+#ifdef KSU_KPROBES_HOOK
+#include <linux/completion.h>
+#endif
 #include <linux/cred.h>
 #include <linux/dcache.h>
 #include <linux/err.h>
@@ -71,6 +74,7 @@ void stop_input_hook();
 static struct work_struct __maybe_unused stop_init_rc_hook_work;
 static struct work_struct __maybe_unused stop_execve_hook_work;
 static struct work_struct __maybe_unused stop_input_hook_work;
+static DECLARE_COMPLETION(stop_input_hook_work_complete);
 #else
 bool ksu_init_rc_hook __read_mostly = true;
 bool __maybe_unused ksu_vfs_read_hook = true;
@@ -694,6 +698,12 @@ static void do_stop_execve_hook(struct work_struct *work)
 static void do_stop_input_hook(struct work_struct *work)
 {
 	unregister_kprobe(&input_event_kp);
+	complete(&stop_input_hook_work_complete);
+}
+
+void ksu_wait_stop_input_hook(void)
+{
+	wait_for_completion(&stop_input_hook_work_complete);
 }
 #else
 static int ksu_execve_ksud_common(const char __user *filename_user,


### PR DESCRIPTION
- remove non-functional kprobe hooks
- wait on input_hook in kprobes mode instead of relying on ksu_input_hook which doesn't exist using kprobes
- add selinux context write hijack