### PR TITLE
fix(ksud): Fix buffer overflow caused by android-properties library

### DIFF
--- a/userspace/ksud/Cargo.lock
+++ b/userspace/ksud/Cargo.lock
@@ -47,12 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-properties"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
-
-[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,7 +991,6 @@ name = "ksud"
 version = "0.1.0"
 dependencies = [
  "android-bootimg",
- "android-properties",
  "android_logger",
  "anyhow",
  "base16ct",

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -29,7 +29,6 @@ android-bootimg = { git = "https://github.com/5ec1cff/android_bootimg", rev = "1
 rustix = { version = "1", features = [
     "all-apis",
 ] }
-android-properties = { version = "0.2", features = ["bionic-deprecated"] }
 android_logger = { version = "0.15", default-features = false }
 zip = { version = "8",  features = [
     "deflate",

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -3,6 +3,7 @@ use rustix::fs::{Mode, OFlags, open};
 use rustix::process::setpgid;
 use rustix::stdio::{dup2_stderr, dup2_stdin, dup2_stdout};
 use std::{
+    ffi::{CStr, CString, c_char, c_void},
     fs::{File, OpenOptions, create_dir_all, remove_file, write},
     io::{
         ErrorKind::{AlreadyExists, NotFound},
@@ -26,6 +27,17 @@ use rustix::{
     process,
     thread::{LinkNameSpaceType, move_into_link_name_space},
 };
+
+type PropertyReadCallback = unsafe extern "C" fn(*mut c_void, *const c_char, *const c_char, u32);
+
+unsafe extern "C" {
+    fn __system_property_find(name: *const c_char) -> *const c_void;
+    fn __system_property_read_callback(
+        property_info: *const c_void,
+        callback: PropertyReadCallback,
+        cookie: *mut c_void,
+    );
+}
 
 #[macro_export]
 macro_rules! debug_select {
@@ -103,8 +115,37 @@ pub fn ensure_binary<T: AsRef<Path>>(
     Ok(())
 }
 
-pub fn getprop(prop: &str) -> Option<String> {
-    android_properties::getprop(prop).value()
+unsafe extern "C" fn property_read_callback(
+    cookie: *mut c_void,
+    _name: *const c_char,
+    value: *const c_char,
+    _serial: u32,
+) {
+    if cookie.is_null() || value.is_null() {
+        return;
+    }
+
+    let result = unsafe { &mut *cookie.cast::<Option<String>>() };
+    let value = unsafe { CStr::from_ptr(value) };
+    *result = Some(value.to_string_lossy().into_owned());
+}
+
+pub fn getprop(name: &str) -> Option<String> {
+    let name = CString::new(name).ok()?;
+    let property_info = unsafe { __system_property_find(name.as_ptr()) };
+    if property_info.is_null() {
+        return None;
+    }
+
+    let mut value = None;
+    unsafe {
+        __system_property_read_callback(
+            property_info,
+            property_read_callback,
+            std::ptr::addr_of_mut!(value).cast(),
+        );
+    }
+    value
 }
 
 pub fn is_safe_mode() -> bool {


### PR DESCRIPTION
https://github.com/tiann/KernelSU/pull/3624
```
Author: Weiguangtwk <41853928+WeiguangTWK@users.noreply.github.com>
Date:   Sun Aug 9 12:30:43 2026 +0800
```
The deprecated android-properties bionic backend constructs an empty CString and passes its one-byte allocation to __system_property_get(), which expects a writable PROPERTY_VALUE_MAX-sized buffer.

Reading even a short property such as sys.boot_completed can therefore write past the allocation. Scudo usually hides the issue through size-class slack, while mimalloc secure padding detects the overwrite when the CString is freed and aborts ksud. This causes KernelSU module installation to fail with error 135.

Replace android-properties with the modern bionic property callback API. Use __system_property_find() and __system_property_read_callback() to copy the property value into an owned Rust String without relying on a caller-provided fixed-size buffer.

Remove the now-unused android-properties dependency.