### PR TITLE
manager: fix banner cache key collision when modules share same banner filename

### DIFF
--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
@@ -989,7 +989,7 @@ fun ModuleItem(
                             alpha = 0.18f
                         )
                     } else {
-                        val bannerData = remember(module.banner) {
+                        val bannerData = remember(module.id, module.banner) {
                             try {
                                 val file = SuFile("/data/adb/modules/${module.id}/${module.banner}")
                                 return@remember file.newInputStream().use { it.readBytes() }


### PR DESCRIPTION
Adding `module.id` to the key is enough to scope the cache per-module.