### PR TITLE
kernel: Support out-of-tree builds against generic Linux

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -74,14 +74,13 @@ ifneq ($(KBUILD_EXTMOD),)
 # 6.18 exports the external module source as srcroot when M/MO are used.
 ifneq ($(srcroot),)
 KSU_KERNEL_DIR := $(srcroot)
+else
+KSU_KERNEL_DIR := $(KBUILD_EXTMOD)
 endif
-endif
-ifndef KSU_KERNEL_DIR
-ifeq ($(filter /%,$(src)),)
+else ifeq ($(filter /%,$(src)),)
 KSU_KERNEL_DIR := $(srctree)/$(src)
 else
 KSU_KERNEL_DIR := $(src)
-endif
 endif
 
 ccflags-y += -I$(KSU_KERNEL_DIR) -I$(KSU_KERNEL_DIR)/include
@@ -155,7 +154,7 @@ ccflags-y += -DEXPECTED_MANAGER_HASH=\"$(KSU_NEXT_MANAGER_HASH)\"
 
 ccflags-y += -DKSU_NEW_DCACHE_FLUSH=$(KSU_NEW_DCACHE_FLUSH)
 
-ccflags-y += -Wno-strict-prototypes -Wno-int-conversion -Wno-gcc-compat -Wno-missing-prototypes
+ccflags-y += -Wno-strict-prototypes -Wno-int-conversion -Wno-gcc-compat -Wno-missing-prototypes -Wno-missing-declarations
 ccflags-y += -Wno-declaration-after-statement -Wno-unused-function -Wno-unused-variable
 
 # Keep a new line here!! Because someone may append config

--- a/kernel/extras.c
+++ b/kernel/extras.c
@@ -5,6 +5,7 @@
 #include "policy/feature.h"
 #include "uapi/feature.h"
 #include "klog.h"
+#include "ksu.h"
 #include "runtime/ksud.h"
 #include "infra/seccomp_cache.h"
 
@@ -65,14 +66,14 @@ static const struct ksu_feature_handler avc_spoof_handler = {
 static int get_sid()
 {
 	// dont load at all if we cant get sids
-	int err = security_secctx_to_secid("u:r:su:s0", strlen("u:r:su:s0"), &su_sid);
+	int err = ksu_security_secctx_to_secid("u:r:su:s0", strlen("u:r:su:s0"), &su_sid);
 	if (err) {
 		pr_info("avc_spoof/get_sid: su_sid not found!\n");
 		return -1;
 	}
 	pr_info("avc_spoof/get_sid: su_sid: %u\n", su_sid);
 
-	err = security_secctx_to_secid("u:r:priv_app:s0:c512,c768", strlen("u:r:priv_app:s0:c512,c768"), &priv_app_sid);
+	err = ksu_security_secctx_to_secid("u:r:priv_app:s0:c512,c768", strlen("u:r:priv_app:s0:c512,c768"), &priv_app_sid);
 	if (err) {
 		pr_info("avc_spoof/get_sid: priv_app_sid not found!\n");
 		return -1;

--- a/kernel/hook/lsm_hook.c
+++ b/kernel/hook/lsm_hook.c
@@ -343,7 +343,12 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
                     hook->list.head = head;
                     hook->list.list.next = NULL;
                     hook->list.list.pprev = &head->first;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+                    static const struct lsm_id ksu_lsm_id = { .name = "ksu", .id = 0 };
+                    hook->list.lsmid = &ksu_lsm_id;
+#else
                     hook->list.lsm = "ksu";
+#endif
                     *(void **)((char *)selected_entry + hook->hook_offset) = hook->replacement;
                     selected_slot = (void **)&head->first;
                     selected_origin = NULL;

--- a/kernel/include/ksu.h
+++ b/kernel/include/ksu.h
@@ -14,6 +14,8 @@ extern bool allow_shell;
 extern struct selinux_policy *backup_sepolicy;
 extern bool ksu_no_custom_rc;
 
+int ksu_security_secctx_to_secid(const char *secdata, u32 seclen, u32 *secid);
+
 static inline int startswith(char *s, char *prefix)
 {
 	return strncmp(s, prefix, strlen(prefix));

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -52,6 +52,12 @@ void apply_kernelsu_rules()
     }
 
     mutex_lock(&selinux_state.policy_mutex);
+    if (!old_pol) {
+        pr_warn("SELinux policy is NULL. Skipping SELinux rules application.\n");
+        mutex_unlock(&selinux_state.policy_mutex);
+        return;
+    }
+
     backup_sepolicy =
         ksu_dup_sepolicy(rcu_dereference_protected(old_pol, lockdep_is_held(&selinux_state.policy_mutex)));
     if (IS_ERR(backup_sepolicy)) {
@@ -472,6 +478,12 @@ int handle_sepolicy(void __user *user_data, u64 data_len)
     mutex_lock(&selinux_state.policy_mutex);
 
     old_pol = selinux_state.policy;
+    if (!old_pol) {
+        pr_warn("SELinux policy is NULL. Skipping ksu_handle_sepolicy.\n");
+        ret = -EINVAL;
+        goto out_unlock;
+    }
+
     pol = ksu_dup_sepolicy(rcu_dereference_protected(
         old_pol, lockdep_is_held(&selinux_state.policy_mutex)));
     if (IS_ERR(pol)) {

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -5,6 +5,72 @@
 #include "linux/version.h"
 #include "klog.h" // IWYU pragma: keep
 #include "ksu.h"
+#include "infra/symbol_resolver.h"
+
+int ksu_security_secctx_to_secid(const char *secdata, u32 seclen, u32 *secid)
+{
+    static int (*real_func)(const char *, u32, u32 *) = NULL;
+    if (!real_func) {
+        real_func = (void *)find_kernel_symbol_exact("security_secctx_to_secid");
+        if (!real_func) pr_warn_once("KernelSU: failed to resolve security_secctx_to_secid\n");
+    }
+    if (real_func) {
+        return real_func(secdata, seclen, secid);
+    }
+    return -1;
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+static int ksu_security_secid_to_secctx(u32 secid, struct lsm_context *cp)
+{
+    static int (*real_func)(u32, struct lsm_context *) = NULL;
+    if (!real_func) {
+        real_func = (void *)find_kernel_symbol_exact("security_secid_to_secctx");
+        if (!real_func) pr_warn_once("KernelSU: failed to resolve security_secid_to_secctx\n");
+    }
+    if (real_func) {
+        return real_func(secid, cp);
+    }
+    return -1;
+}
+
+static void ksu_security_release_secctx(struct lsm_context *cp)
+{
+    static void (*real_func)(struct lsm_context *) = NULL;
+    if (!real_func) {
+        real_func = (void *)find_kernel_symbol_exact("security_release_secctx");
+        if (!real_func) pr_warn_once("KernelSU: failed to resolve security_release_secctx\n");
+    }
+    if (real_func) {
+        real_func(cp);
+    }
+}
+#else
+static int ksu_security_secid_to_secctx(u32 secid, char **secdata, u32 *seclen)
+{
+    static int (*real_func)(u32, char **, u32 *) = NULL;
+    if (!real_func) {
+        real_func = (void *)find_kernel_symbol_exact("security_secid_to_secctx");
+        if (!real_func) pr_warn_once("KernelSU: failed to resolve security_secid_to_secctx\n");
+    }
+    if (real_func) {
+        return real_func(secid, secdata, seclen);
+    }
+    return -1;
+}
+
+static void ksu_security_release_secctx(char *secdata, u32 seclen)
+{
+    static void (*real_func)(char *, u32) = NULL;
+    if (!real_func) {
+        real_func = (void *)find_kernel_symbol_exact("security_release_secctx");
+        if (!real_func) pr_warn_once("KernelSU: failed to resolve security_release_secctx\n");
+    }
+    if (real_func) {
+        real_func(secdata, seclen);
+    }
+}
+#endif
 
 /*
  * Cached SID values for frequently checked contexts.
@@ -13,7 +79,7 @@
  *
  * A value of 0 means "no cached SID is available" for that context.
  * This covers both the initial "not yet cached" state and any case
- * where resolving the SID (e.g. via security_secctx_to_secid) failed.
+ * where resolving the SID (e.g. via ksu_security_secctx_to_secid) failed.
  * In all such cases we intentionally fall back to the slower
  * string-based comparison path; this degrades performance only and
  * does not cause a functional failure.
@@ -37,9 +103,9 @@ static int transive_to_domain(const char *domain, struct cred *cred, bool clear_
         pr_err("tsec == NULL!\n");
         return -1;
     }
-    error = security_secctx_to_secid(domain, strlen(domain), &sid);
+    error = ksu_security_secctx_to_secid(domain, strlen(domain), &sid);
     if (error) {
-        pr_info("security_secctx_to_secid %s -> sid: %d, error: %d\n", domain,
+        pr_info("ksu_security_secctx_to_secid %s -> sid: %d, error: %d\n", domain,
                 sid, error);
     }
     if (!error) {
@@ -97,17 +163,17 @@ struct lsm_context {
     u32 len;
 };
 
-static int __security_secid_to_secctx(u32 secid, struct lsm_context *cp)
+static int __ksu_security_secid_to_secctx(u32 secid, struct lsm_context *cp)
 {
-    return security_secid_to_secctx(secid, &cp->context, &cp->len);
+    return ksu_security_secid_to_secctx(secid, &cp->context, &cp->len);
 }
-static void __security_release_secctx(struct lsm_context *cp)
+static void __ksu_security_release_secctx(struct lsm_context *cp)
 {
-    security_release_secctx(cp->context, cp->len);
+    ksu_security_release_secctx(cp->context, cp->len);
 }
 #else
-#define __security_secid_to_secctx security_secid_to_secctx
-#define __security_release_secctx security_release_secctx
+#define __ksu_security_secid_to_secctx ksu_security_secid_to_secctx
+#define __ksu_security_release_secctx ksu_security_release_secctx
 #endif
 
 /*
@@ -119,7 +185,7 @@ void cache_sid(void)
 {
     int err;
 
-    err = security_secctx_to_secid(KERNEL_SU_CONTEXT, strlen(KERNEL_SU_CONTEXT),
+    err = ksu_security_secctx_to_secid(KERNEL_SU_CONTEXT, strlen(KERNEL_SU_CONTEXT),
                                    &cached_su_sid);
     if (err) {
         pr_warn("Failed to cache kernel su domain SID: %d\n", err);
@@ -128,7 +194,7 @@ void cache_sid(void)
         pr_info("Cached su SID: %u\n", cached_su_sid);
     }
 
-    err = security_secctx_to_secid(ZYGOTE_CONTEXT, strlen(ZYGOTE_CONTEXT),
+    err = ksu_security_secctx_to_secid(ZYGOTE_CONTEXT, strlen(ZYGOTE_CONTEXT),
                                    &cached_zygote_sid);
     if (err) {
         pr_warn("Failed to cache zygote SID: %d\n", err);
@@ -137,7 +203,7 @@ void cache_sid(void)
         pr_info("Cached zygote SID: %u\n", cached_zygote_sid);
     }
 
-    err = security_secctx_to_secid(INIT_CONTEXT, strlen(INIT_CONTEXT),
+    err = ksu_security_secctx_to_secid(INIT_CONTEXT, strlen(INIT_CONTEXT),
                                    &cached_init_sid);
     if (err) {
         pr_warn("Failed to cache init SID: %d\n", err);
@@ -146,7 +212,7 @@ void cache_sid(void)
         pr_info("Cached init SID: %u\n", cached_init_sid);
     }
 
-    err = security_secctx_to_secid(KSU_FILE_CONTEXT, strlen(KSU_FILE_CONTEXT),
+    err = ksu_security_secctx_to_secid(KSU_FILE_CONTEXT, strlen(KSU_FILE_CONTEXT),
                                    &ksu_file_sid);
     if (err) {
         pr_warn("Failed to cache ksu_file SID: %d\n", err);
@@ -183,11 +249,11 @@ static bool is_sid_match(const struct cred *cred, u32 cached_sid,
     // Slow path fallback: string comparison (only before cache is initialized)
     struct lsm_context ctx;
     bool result;
-    if (__security_secid_to_secctx(tsec->sid, &ctx)) {
+    if (__ksu_security_secid_to_secctx(tsec->sid, &ctx)) {
         return false;
     }
     result = strncmp(fallback_context, ctx.context, ctx.len) == 0;
-    __security_release_secctx(&ctx);
+    __ksu_security_release_secctx(&ctx);
     return result;
 }
 

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -988,6 +988,7 @@ struct selinux_policy *ksu_dup_sepolicy(struct selinux_policy *old_pol)
     if (len >= kConfigOff + sizeof(u32)) {
         u32 *config_ptr = (u32 *)((unsigned long)data + kConfigOff);
         pr_info("old config: %u\n", *config_ptr);
+#ifdef POLICYDB_CONFIG_ANDROID_NETLINK_ROUTE
         if (old_pol->policydb.android_netlink_route) {
             pr_info("adding POLICYDB_CONFIG_ANDROID_NETLINK_ROUTE\n");
             *config_ptr |= POLICYDB_CONFIG_ANDROID_NETLINK_ROUTE;
@@ -996,6 +997,7 @@ struct selinux_policy *ksu_dup_sepolicy(struct selinux_policy *old_pol)
             pr_info("adding POLICYDB_CONFIG_ANDROID_NETLINK_GETNEIGH\n");
             *config_ptr |= POLICYDB_CONFIG_ANDROID_NETLINK_GETNEIGH;
         }
+#endif
         pr_info("new config: %u\n", *config_ptr);
     }
 #endif


### PR DESCRIPTION
```
-Fixes compilation/modpost failures when building out-of-tree against standard generic (e.g. Ubuntu/Waydroid)
 -Dynamic lookup for SELinux symbols
  -resolves modpost failures on generic kernels (adapt to pre/post 6.14 lsm_context)
 -lsm_hook -> 'struct lsm_id' (>= 6.8)
 -POLICYDB_CONFIG_ANDROID_NETLINK_ROUTE guard
 -Add -Wno-missing-declarations
  -silence out-of-tree warnings
 -Eval KBUILD_EXTMOD (Kbuild)
  -out-of-tree dir resolution (7.x)
 -Fix BUG deref (0x68) on non-SELinux
  -selinux/rules: add NULL checks (selinux_state.policy)
 -Add logging (blinded symbols)
  -pr_warn_once (secid/secctx)

-https://github.com/KernelSU-Next/KernelSU-Next/issues/1447
```