### PR TITLE
legacy: non-GKI update — execveat (new bionic), hardening fixes, syscall table hooking scheme

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -87,17 +87,23 @@ endif
 
 # Calculate version if git version is available
 ifdef KSU_GIT_VERSION_VALID
-# ksu_version: major * 30000 + git version for historical reasons
 $(eval KSU_VERSION=$(shell expr 30000 + $(KSU_GIT_VERSION) + 200))
 $(info -- KernelSU-Next version: $(KSU_VERSION))
-ccflags-y += -DKSU_VERSION=$(KSU_VERSION)
 else
 # If there is no .git directory, use default version
 $(warning "KSU_GIT_VERSION not defined! It is better to make KernelSU-Next a git repository!")
 KSU_VERSION_FALLBACK := 1
 $(info -- KernelSU-Next version fallback: $(KSU_VERSION_FALLBACK))
-ccflags-y += -DKSU_VERSION=$(KSU_VERSION_FALLBACK)
+KSU_VERSION := $(KSU_VERSION_FALLBACK)
 endif
+
+# Allow integrators to pin the reported version (e.g. when backporting
+# onto release branches where the commit count does not match releases)
+ifdef KSU_VERSION_OVERRIDE
+KSU_VERSION := $(KSU_VERSION_OVERRIDE)
+$(info -- KernelSU-Next version override: $(KSU_VERSION))
+endif
+ccflags-y += -DKSU_VERSION=$(KSU_VERSION)
 
 ifdef KSU_GIT_VERSION_VALID
 $(eval KSU_VERSION_TAG=$(KSU_GIT_TAG))

--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -138,6 +138,15 @@ ccflags-y += -DKSU_KPROBES_HOOK
 HAVE_KSU_HOOK := 0
 endif
 
+ifeq ($(CONFIG_KSU_SYSCALL_TABLE_HOOK), y)
+$(info -- KernelSU-Next: Hook mode: Syscall table patching)
+ccflags-y += -DKSU_SYSCALL_TABLE_HOOK
+HAVE_KSU_HOOK := 0
+kernelsu-objs += hook/patch_memory.o
+kernelsu-objs += hook/syscall_table_hook.o
+kernelsu-objs += infra/symbol_resolver.o
+endif
+
 ifeq ($(CONFIG_KSU_MANUAL_HOOK), y)
 HAVE_KSU_HOOK := $(shell grep -q "ksu_handle_sys_reboot" $(srctree)/kernel/reboot.c && echo 0 || echo 1)
 ifeq ($(HAVE_KSU_HOOK),0)

--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -107,14 +107,18 @@ ccflags-y += -DKSU_VERSION=$(KSU_VERSION)
 
 ifdef KSU_GIT_VERSION_VALID
 $(eval KSU_VERSION_TAG=$(KSU_GIT_TAG))
-$(info -- KernelSU-Next tag: $(KSU_VERSION_TAG))
-ccflags-y += -DKSU_VERSION_TAG=\"$(KSU_VERSION_TAG)\"
 else
 $(warning "KSU_VERSION_TAG not defined! It is better to make KernelSU-Next a git submodule!")
 KSU_VERSION_TAG_FALLBACK := v0.0.1
-$(info -- KernelSU-Next tag fallback: $(KSU_VERSION_TAG_FALLBACK))
-ccflags-y += -DKSU_VERSION_TAG=\"$(KSU_VERSION_TAG_FALLBACK)\"
+KSU_VERSION_TAG=$(KSU_VERSION_TAG_FALLBACK)
 endif
+
+ifdef KSU_VERSION_TAG_OVERRIDE
+KSU_VERSION_TAG := $(KSU_VERSION_TAG_OVERRIDE)
+endif
+
+$(info -- KernelSU-Next tag: $(KSU_VERSION_TAG))
+ccflags-y += -DKSU_VERSION_TAG=\"$(KSU_VERSION_TAG)\"
 
 ifndef KSU_NEXT_MANAGER_SIZE
 KSU_NEXT_MANAGER_SIZE := 0x3e6

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -51,12 +51,20 @@ config KSU_MANUAL_HOOK
 
 config KSU_KPROBES_HOOK
 	bool "KernelSU tracepoint+kretprobe hook"
-	depends on KSU && !KSU_MANUAL_HOOK
+	depends on KSU && !KSU_MANUAL_HOOK && !KSU_SYSCALL_TABLE_HOOK
 	depends on KRETPROBES && KPROBES && HAVE_SYSCALL_TRACEPOINTS
 	default y if KPROBES && KRETPROBES && HAVE_SYSCALL_TRACEPOINTS
-	default y if !KSU_MANUAL_HOOK
 	help
 	  Enable KPROBES, KRETPROBES and TRACEPOINT hook for KernelSU core.
 	  This should not be used on kernel below 5.10.
+
+config KSU_SYSCALL_TABLE_HOOK
+	bool "KernelSU syscall table patching hook"
+	depends on KSU && !KSU_MANUAL_HOOK && !KSU_KPROBES_HOOK && (ARM64 || X86_64)
+	help
+	  Patch sys_call_table entries directly to hook syscalls without
+	  kprobes or tracepoints. Intended for non-GKI kernels where kprobes
+	  are unavailable or non-functional.
+	  Requires kernel >= 4.17 (pt_regs-based syscall ABI).
 
 endmenu

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -49,22 +49,27 @@ config KSU_MANUAL_HOOK
 	help
 	  Enable manual hook support.
 
+choice
+	prompt "KernelSU dynamic hook mode"
+	depends on KSU && !KSU_MANUAL_HOOK
+	default KSU_KPROBES_HOOK
+
 config KSU_KPROBES_HOOK
 	bool "KernelSU tracepoint+kretprobe hook"
-	depends on KSU && !KSU_MANUAL_HOOK && !KSU_SYSCALL_TABLE_HOOK
 	depends on KRETPROBES && KPROBES && HAVE_SYSCALL_TRACEPOINTS
-	default y if KPROBES && KRETPROBES && HAVE_SYSCALL_TRACEPOINTS
 	help
 	  Enable KPROBES, KRETPROBES and TRACEPOINT hook for KernelSU core.
 	  This should not be used on kernel below 5.10.
 
 config KSU_SYSCALL_TABLE_HOOK
 	bool "KernelSU syscall table patching hook"
-	depends on KSU && !KSU_MANUAL_HOOK && !KSU_KPROBES_HOOK && (ARM64 || X86_64)
+	depends on ARM64 || X86_64
 	help
 	  Patch sys_call_table entries directly to hook syscalls without
 	  kprobes or tracepoints. Intended for non-GKI kernels where kprobes
 	  are unavailable or non-functional.
 	  Requires kernel >= 4.17 (pt_regs-based syscall ABI).
+
+endchoice
 
 endmenu

--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -18,11 +18,10 @@
 
 DEFINE_STATIC_KEY_FALSE(ksu_adb_root);
 
-static long is_exec_adbd(struct pt_regs *regs)
+static long is_exec_adbd(const char __user *filename_user)
 {
     static const char kAdbd[] = "/adbd";
     static const size_t kAdbdLen = sizeof(kAdbd) - 1;
-    char __user *filename_user = (char __user *)PT_REGS_PARM1(regs);
     // should be bigger than `/apex/com.android.adbd/bin/adbd`
     char buf[40];
     char __user *fn;
@@ -62,7 +61,7 @@ static long is_libadbroot_ok()
     return ret;
 }
 
-static long setup_ld_preload(struct pt_regs *regs)
+static long setup_ld_preload(struct pt_regs *regs, unsigned long *envp_p)
 {
     static const char kLdPreload[] = "LD_PRELOAD=/data/adb/ksu/lib/libadbroot.so";
     static const char kLdLibraryPath[] = "LD_LIBRARY_PATH=/data/adb/ksu/lib";
@@ -70,7 +69,6 @@ static long setup_ld_preload(struct pt_regs *regs)
     static const size_t kPtrSize = sizeof(unsigned long);
     unsigned long stackp = user_stack_pointer(regs);
     unsigned long envp, ld_preload_p, ld_library_path_p;
-    unsigned long *envp_p = (unsigned long *)&PT_REGS_PARM3(regs);
     unsigned long *tmp_env_p = NULL, *tmp_env_p2 = NULL;
     size_t env_count = 0, total_size;
     long ret;
@@ -156,9 +154,11 @@ out_release_env_p:
     return ret;
 }
 
-static long do_ksu_adb_root_handle_execve(struct pt_regs *regs)
+static long do_ksu_adb_root_handle_execve(const char __user *filename_user,
+					  struct pt_regs *regs,
+					  unsigned long *envp_p)
 {
-    if (likely(is_exec_adbd(regs) != 1)) {
+    if (likely(is_exec_adbd(filename_user) != 1)) {
         return 0;
     }
 
@@ -166,7 +166,7 @@ static long do_ksu_adb_root_handle_execve(struct pt_regs *regs)
         return 0;
     }
 
-    long ret = setup_ld_preload(regs);
+    long ret = setup_ld_preload(regs, envp_p);
     if (ret) {
         return ret;
     }
@@ -179,7 +179,19 @@ static long do_ksu_adb_root_handle_execve(struct pt_regs *regs)
 long ksu_adb_root_handle_execve(struct pt_regs *regs)
 {
     if (static_branch_unlikely(&ksu_adb_root)) {
-        return do_ksu_adb_root_handle_execve(regs);
+        return do_ksu_adb_root_handle_execve(
+                (const char __user *)PT_REGS_PARM1(regs), regs,
+                (unsigned long *)&PT_REGS_PARM3(regs));
+    }
+    return 0;
+}
+
+long ksu_adb_root_handle_execveat(struct pt_regs *regs)
+{
+    if (static_branch_unlikely(&ksu_adb_root)) {
+        return do_ksu_adb_root_handle_execve(
+                (const char __user *)PT_REGS_PARM2(regs), regs,
+                (unsigned long *)&PT_REGS_SYSCALL_PARM4(regs));
     }
     return 0;
 }

--- a/kernel/feature/adb_root.h
+++ b/kernel/feature/adb_root.h
@@ -3,6 +3,7 @@
 #include <asm/ptrace.h>
 
 long ksu_adb_root_handle_execve(struct pt_regs *regs);
+long ksu_adb_root_handle_execveat(struct pt_regs *regs);
 
 void ksu_adb_root_init(void);
 

--- a/kernel/feature/kernel_umount.c
+++ b/kernel/feature/kernel_umount.c
@@ -134,16 +134,16 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
 		return 0;
 	}
 
-    // There are 6 scenarios:
-    // 1. Normal app: zygote -> appuid
-    // 2. Isolated process forked from zygote: zygote -> isolated_process
-    // 3. App zygote forked from zygote: zygote -> appuid
-    // 4. Webview zygote forked from zygote: zygote -> WEBVIEW_ZYGOTE_UID (no need to handle, app cannot run custom code)
-    // 5. Isolated process forked from app zygote: appuid -> isolated_process (already handled by 3)
-    // 6. Isolated process forked from webview zygote (no need to handle, app cannot run custom code)
-    if (!is_appuid(new_uid) && !is_isolated_process(new_uid)) {
-        return 0;
-    }
+	// There are 6 scenarios:
+	// 1. Normal app: zygote -> appuid
+	// 2. Isolated process forked from zygote: zygote -> isolated_process
+	// 3. App zygote forked from zygote: zygote -> appuid
+	// 4. Webview zygote forked from zygote: zygote -> WEBVIEW_ZYGOTE_UID (no need to handle, app cannot run custom code)
+	// 5. Isolated process forked from app zygote: appuid -> isolated_process (already handled by 3)
+	// 6. Isolated process forked from webview zygote (no need to handle, app cannot run custom code)
+	if (!is_appuid(new_uid) && !is_isolated_process(new_uid)) {
+		return 0;
+	}
 
 	if (!ksu_uid_should_umount(new_uid) && !is_isolated_process(new_uid)) {
 		return 0;

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -113,7 +113,7 @@ static void initialize_fake_status(void)
 		 * Assumes setenforce 0 was called exactly once.
 		 */
 		new_status->enforcing = 1;
-		new_status->sequence = 4;
+		new_status->sequence = new_status->policyload ? 4 : 0;
 	}
 	
 	WRITE_ONCE(fake_status, new_page);

--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -20,6 +20,7 @@
 #include <linux/sched.h>
 #endif
 #include <linux/ptrace.h>
+#include <linux/fcntl.h>
 
 #include "objsec.h"
 
@@ -143,15 +144,20 @@ int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags)
 	return 0;
 }
 
-long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, const struct pt_regs *regs)
+static long ksu_handle_execve_sucompat_common(const char __user **filename_user,
+		const char __user *const __user *argv_user, bool execveat,
+		const struct pt_regs *regs)
 {
 	const char su[] = SU_PATH;
 	const char __user *fn;
-	const char __user *const __user *argv_user = (const char __user *const __user *)PT_REGS_PARM2(regs);
 	struct ksu_sulog_pending_event *pending_sucompat = NULL;
 	char path[sizeof(su) + 1];
 	long ret;
 	unsigned long addr;
+
+	if (execveat && ((int)PT_REGS_PARM1(regs) != AT_FDCWD ||
+			 (int)PT_REGS_SYSCALL_PARM4(regs) != 0))
+		goto do_orig_execve;
 
 	if (unlikely(!filename_user))
 		goto do_orig_execve;
@@ -208,6 +214,20 @@ long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, 
 	}
 do_orig_execve:
 	return 0;
+}
+
+long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, const struct pt_regs *regs)
+{
+	return ksu_handle_execve_sucompat_common(filename_user,
+			(const char __user *const __user *)PT_REGS_PARM2(regs),
+			false, regs);
+}
+
+long ksu_handle_execveat_sucompat_user(const char __user **filename_user, int orig_nr, const struct pt_regs *regs)
+{
+	return ksu_handle_execve_sucompat_common(filename_user,
+			(const char __user *const __user *)PT_REGS_PARM3(regs),
+			true, regs);
 }
 
 int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,

--- a/kernel/feature/sucompat.h
+++ b/kernel/feature/sucompat.h
@@ -12,5 +12,6 @@ int ksu_handle_faccessat(int *dfd, const char __user **filename_user,
 				int *mode, int *__unused_flags);
 int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags);
 long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, const struct pt_regs *regs);
+long ksu_handle_execveat_sucompat_user(const char __user **filename_user, int orig_nr, const struct pt_regs *regs);
 
 #endif

--- a/kernel/hook/hook_manager.c
+++ b/kernel/hook/hook_manager.c
@@ -1,5 +1,6 @@
 #ifdef KSU_KPROBES_HOOK
 #include "linux/printk.h"
+#include <linux/limits.h>
 #include <linux/spinlock.h>
 #include <linux/kprobes.h>
 #include <linux/tracepoint.h>
@@ -13,6 +14,7 @@
 #include "klog.h" // IWYU pragma: keep
 #include "hook_manager.h"
 #include "feature/sucompat.h"
+#include "feature/adb_root.h"
 #include "setuid_hook.h"
 #include "selinux/selinux.h"
 #include "compat/kernel_compat.h"
@@ -291,7 +293,8 @@ int ksu_handle_init_mark_tracker(const char __user **filename_user)
 	if (unlikely(strcmp(path, KSUD_PATH) == 0)) {
 		pr_info("hook_manager: escape to root for init executing ksud: %d\n", current->pid);
 		escape_to_root_for_init();
-	} else if (likely(strstr(path, "/app_process") == NULL && strstr(path, "/adbd") == NULL)) {
+	} else if (likely(strstr(path, "/app_process") == NULL && strstr(path, "/adbd") == NULL &&
+			  strstr(path, "/stub_zygote") == NULL)) {
 		pr_info("hook_manager: unmark %d exec %s\n", current->pid, path);
 		ksu_clear_task_tracepoint_flag_if_needed(current);
 	}
@@ -329,18 +332,33 @@ static void ksu_sys_enter_handler(void *data, struct pt_regs *regs, long id)
 				return;
 			}
 
-			// Handle execve (y compatibilidad con arquitecturas híbridas)
+			// Handle execve/execveat (y compatibilidad con arquitecturas híbridas)
+			// New bionic (A17 QPR2+) maps execve to
+			// execveat(AT_FDCWD, path, argv, envp, 0), so both
+			// syscalls must be handled with their own register layout.
 #ifdef __NR_execveat
 			if (id == __NR_execve || id == __NR_execveat) {
 #else
 			if (id == __NR_execve) {
 #endif
+				bool is_execveat = (id == __NR_execveat);
 				const char __user **filename_user =
-					(const char __user **)&PT_REGS_PARM1(regs);
+					is_execveat ?
+						(const char __user **)&PT_REGS_PARM2(regs) :
+						(const char __user **)&PT_REGS_PARM1(regs);
+				long adb_ret;
 				if (current->pid != 1 && is_init(current_cred())) {
 					ksu_handle_init_mark_tracker(filename_user);
+					adb_ret = is_execveat ?
+						ksu_adb_root_handle_execveat(regs) :
+						ksu_adb_root_handle_execve(regs);
+					if (adb_ret) {
+						pr_err("adb root failed: %ld\n", adb_ret);
+					}
+				} else if (is_execveat) {
+					ksu_handle_execveat_sucompat_user(filename_user, 0, regs);
 				} else {
-					ksu_handle_execve_sucompat(filename_user, NULL, NULL);
+					ksu_handle_execve_sucompat(filename_user, 0, regs);
 				}
 				return;
 			}
@@ -371,7 +389,13 @@ void __init ksu_syscall_hook_manager_init(void)
 #endif
 
 #ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
+	// Register with minimum priority so perf/bpf handlers run before
+	// we modify the syscall context
+	ret = register_trace_prio_sys_enter(ksu_sys_enter_handler, NULL, INT_MIN);
+#else
 	ret = register_trace_sys_enter(ksu_sys_enter_handler, NULL);
+#endif
 #ifndef CONFIG_KRETPROBES
 	ksu_mark_running_process_locked();
 #endif
@@ -412,10 +436,14 @@ void __exit ksu_syscall_hook_manager_exit(void)
 #include "hook_manager.h"
 #include "feature/sucompat.h"
 #include "setuid_hook.h"
+#include "syscall_table_hook.h"
 
 void __init ksu_syscall_hook_manager_init(void)
 {
 	pr_info("hook_manager: initializing..\n");
+#ifdef KSU_SYSCALL_TABLE_HOOK
+	ksu_syscall_table_hook_init();
+#endif
 	ksu_setuid_hook_init();
 	ksu_sucompat_init();
 	ksu_avc_spoof_init();
@@ -425,6 +453,9 @@ void __init ksu_syscall_hook_manager_init(void)
 void __exit ksu_syscall_hook_manager_exit(void)
 {
 	pr_info("hook_manager: exiting..\n");
+#ifdef KSU_SYSCALL_TABLE_HOOK
+	ksu_syscall_table_hook_exit();
+#endif
 	ksu_sucompat_exit();
 	ksu_setuid_hook_exit();
 	ksu_avc_spoof_exit();

--- a/kernel/hook/hook_manager.c
+++ b/kernel/hook/hook_manager.c
@@ -341,7 +341,11 @@ static void ksu_sys_enter_handler(void *data, struct pt_regs *regs, long id)
 #else
 			if (id == __NR_execve) {
 #endif
+#ifdef __NR_execveat
 				bool is_execveat = (id == __NR_execveat);
+#else
+				bool is_execveat = false;
+#endif
 				const char __user **filename_user =
 					is_execveat ?
 						(const char __user **)&PT_REGS_PARM2(regs) :

--- a/kernel/hook/patch_memory.c
+++ b/kernel/hook/patch_memory.c
@@ -104,7 +104,8 @@ unsigned long phys_from_virt(unsigned long addr, int *err)
     if (!pte_present(*pte))
         goto fail;
 
-    return __pte_to_phys(*pte) + ((addr & ~PAGE_MASK));
+    return ((unsigned long)pte_pfn(*pte) << PAGE_SHIFT) +
+           ((addr & ~PAGE_MASK));
 
 fail:
     *err = -ENOENT;
@@ -135,7 +136,12 @@ fail:
 #define ksu_flush_icache(start, end) caches_clean_inval_pou
 #else
 #define ksu_flush_dcache(start, sz) __flush_dcache_area((void *)start, sz)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
 #define ksu_flush_icache(start, end) __flush_icache_range
+#else
+// older/vendor kernels may only provide flush_icache_range()
+#define ksu_flush_icache(start, end) flush_icache_range
+#endif
 #endif
 
 struct patch_text_info {

--- a/kernel/hook/patch_memory.c
+++ b/kernel/hook/patch_memory.c
@@ -1,0 +1,490 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (C) 2023 bmax121. All Rights Reserved.
+ *
+ * Merged arm64 + x86_64 implementations for KernelSU-Next legacy.
+ */
+
+#include "patch_memory.h"
+#include <linux/version.h>
+
+// copy_to_kernel_nofault() was introduced in 5.8; before that it was
+// named probe_kernel_write()
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
+#define copy_to_kernel_nofault(dst, src, size)                                 \
+	probe_kernel_write((dst), (src), (size))
+#endif
+
+#if defined(__aarch64__)
+
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (C) 2023 bmax121. All Rights Reserved.
+ */
+
+
+#include "patch_memory.h"
+#include "klog.h" // IWYU pragma: keep
+#include "linux/cpumask.h"
+#include "linux/gfp.h" // IWYU pragma: keep
+#include "linux/uaccess.h"
+#include "linux/stop_machine.h"
+#include "asm/cacheflush.h"
+#include "asm-generic/fixmap.h"
+
+// https://github.com/fuqiuluo/ovo/blob/f7da411458e87d32438dc14fce5a3313ed0c967e/ovo/mmuhack.c#L21
+
+// Translate a kernel virtual address to a physical address by walking the
+// init_mm page tables. Returns the physical address on success, or writes
+// a non-zero error to *err. Callers must check *err before using the result,
+// since physical address 0 is a valid address.
+unsigned long phys_from_virt(unsigned long addr, int *err)
+{
+    struct mm_struct *mm = &init_mm;
+    pgd_t *pgd;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+    p4d_t *p4d;
+#endif
+    pud_t *pud;
+    pmd_t *pmd;
+    pte_t *pte;
+
+    *err = 0;
+
+    pgd = pgd_offset(mm, addr);
+    if (pgd_none(*pgd) || pgd_bad(*pgd))
+        goto fail;
+    pr_debug("pgd of 0x%lx p=0x%lx v=0x%lx", addr, (uintptr_t)pgd,
+             (uintptr_t)pgd_val(*pgd));
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+    p4d = p4d_offset(pgd, addr);
+    if (p4d_none(*p4d) || p4d_bad(*p4d))
+        goto fail;
+    pr_debug("p4d of 0x%lx p=0x%lx v=0x%lx", addr, (uintptr_t)p4d,
+             (uintptr_t)p4d_val(*p4d));
+#if defined(p4d_leaf)
+    if (p4d_leaf(*p4d)) {
+        pr_debug("Address 0x%lx maps to a P4D-level huge page\n", addr);
+        return __p4d_to_phys(*p4d) + ((addr & ~P4D_MASK));
+    }
+#endif
+
+    pud = pud_offset(p4d, addr);
+#else
+    pud = pud_offset(pgd, addr);
+#endif
+    if (pud_none(*pud) || pud_bad(*pud))
+        goto fail;
+    pr_debug("pud of 0x%lx p=0x%lx v=0x%lx", addr, (uintptr_t)pud,
+             (uintptr_t)pud_val(*pud));
+#if defined(pud_leaf)
+    if (pud_leaf(*pud)) {
+        pr_debug("Address 0x%lx maps to a PUD-level huge page\n", addr);
+        return __pud_to_phys(*pud) + ((addr & ~PUD_MASK));
+    }
+#endif
+
+    pmd = pmd_offset(pud, addr);
+    pr_debug("pmd of 0x%lx p=0x%lx v=0x%lx", addr, (uintptr_t)pmd,
+             (uintptr_t)pmd_val(*pmd));
+#if defined(pmd_leaf)
+    if (pmd_leaf(*pmd)) {
+        pr_debug("Address 0x%lx maps to a PMD-level huge page\n", addr);
+        return __pmd_to_phys(*pmd) + ((addr & ~PMD_MASK));
+    }
+#endif
+
+    if (pmd_none(*pmd) || pmd_bad(*pmd))
+        goto fail;
+
+    pte = pte_offset_kernel(pmd, addr);
+    if (!pte)
+        goto fail;
+    if (!pte_present(*pte))
+        goto fail;
+
+    return __pte_to_phys(*pte) + ((addr & ~PAGE_MASK));
+
+fail:
+    *err = -ENOENT;
+    return 0;
+}
+
+// This function appears in 5.14:
+// https://github.com/torvalds/linux/commit/fade9c2c6ee2baea7df8e6059b3f143c681e5ce4#diff-fc9ef24572e183c6c049b5ae8029762159787f8669d909452bdf40db748f94a7L52
+// https://github.com/torvalds/linux/commit/814b186079cd54d3fe3b6b8ab539cbd44705ef9d#diff-fc9ef24572e183c6c049b5ae8029762159787f8669d909452bdf40db748f94a7R53
+// However, it's backport to android13-5.10 but not to android12-5.10.
+// https://cs.android.com/android/_/android/kernel/common/+/6d9f07d8f1ffc310a6877153fe882f35ae380799
+// So we need to grep kernel source code to detect which one to use.
+#if defined(KSU_NEW_DCACHE_FLUSH)
+#define KSU_USE_NEW_DCACHE_FLUSH 1
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+#define KSU_USE_NEW_DCACHE_FLUSH 1
+#else
+#define KSU_USE_NEW_DCACHE_FLUSH 0
+#endif
+
+#if KSU_USE_NEW_DCACHE_FLUSH
+#define ksu_flush_dcache(start, sz)                                            \
+    ({                                                                         \
+        unsigned long __start = (start);                                       \
+        unsigned long __end = __start + (sz);                                  \
+        dcache_clean_inval_poc(__start, __end);                                \
+    })
+#define ksu_flush_icache(start, end) caches_clean_inval_pou
+#else
+#define ksu_flush_dcache(start, sz) __flush_dcache_area((void *)start, sz)
+#define ksu_flush_icache(start, end) __flush_icache_range
+#endif
+
+struct patch_text_info {
+    void *dst;
+    void *src;
+    size_t len;
+    atomic_t cpu_count;
+    int flags;
+};
+
+// Implementation of arbitrary kernel address modification.
+// We could certainly modify the PTE of the target address to make it writable,
+// but this would violate the protection mechanisms of some vendor components
+// (such as MTK's MKP, see ^1) at higher EL levels. Fortunately, the kernel's
+// `aarch64_insn_write` function works fine, which I believe is achieved by
+// modifying memory using fixmaps (MKP's kernel module reports the fixmap address
+// to its hypervisor, which might be used to determine whether such memory
+// modification is "normal" kernel behavior, see ^1). However, we cannot use the
+// `aarch64_insn_write` function directly. First, it can only write 4 bytes
+// at a time. Secondly, there's a bug in modifying the kernel's rodata (in our
+// case, syscall table). The `patch_map` function uses `vmalloc_to_page` to
+// obtain the target's physical address, but `vmalloc_to_page` doesn't handle
+// huge page mapping correctly (before version 5.13, see ^2).
+// Therefore, we need to obtain the target's physical address and use `fixmap` to
+// map and poke it manually. Currently, no patch_lock is held, since I think it's
+// not a big problem because we are in stop_machine.
+// ^1: https://github.com/NothingOSS/android_kernel_device_modules_6.1_nothing_mt6878/blob/957dac185efe46cbf6336b0fff9516d84c8cd78f/drivers/misc/mediatek/mkp/mkp_main.c#L29
+// ^2: https://github.com/torvalds/linux/commit/c0eb315ad9719e41ce44708455cc69df7ac9f3f8
+static int ksu_patch_text_nosync(void *dst, void *src, size_t len, int flags)
+{
+    pr_debug("patch dst=0x%lx src=0x%lx len=%ld\n", (unsigned long)dst,
+             (unsigned long)src, len);
+
+    unsigned long p = (unsigned long)dst;
+    int ret;
+
+    int phy_err;
+    unsigned long phy = phys_from_virt(p, &phy_err);
+    if (phy_err) {
+        ret = phy_err;
+        pr_err("failed to find phy addr for patch dst addr 0x%lx\n", p);
+        goto err;
+    }
+    pr_debug("phy addr for patch 0x%lx: 0x%lx\n", p, phy);
+
+    void *map = set_fixmap_offset(FIX_TEXT_POKE0, phy);
+    pr_debug("fixmap addr for patch 0x%lx: 0x%lx\n", p, (unsigned long)map);
+
+    ret = (int)copy_to_kernel_nofault(map, src, len);
+
+    clear_fixmap(FIX_TEXT_POKE0);
+
+    if (!ret) {
+        if (flags & KSU_PATCH_TEXT_FLUSH_ICACHE)
+            ksu_flush_icache((uintptr_t)dst, (uintptr_t)dst + len);
+        if (flags & KSU_PATCH_TEXT_FLUSH_DCACHE)
+            ksu_flush_dcache(dst, len);
+    }
+
+err:
+    pr_debug("patch result=%d\n", ret);
+    return ret;
+}
+
+static int ksu_patch_text_cb(void *arg)
+{
+    struct patch_text_info *pp = arg;
+    void *dst = pp->dst, *src = pp->src;
+    size_t len = pp->len;
+    int flags = pp->flags;
+
+    int ret = 0;
+
+    /* The last CPU becomes master */
+    if (atomic_inc_return(&pp->cpu_count) == num_online_cpus()) {
+        ret = ksu_patch_text_nosync(dst, src, len, flags);
+        /* Notify other processors with an additional increment. */
+        atomic_inc(&pp->cpu_count);
+    } else {
+        while (atomic_read(&pp->cpu_count) <= num_online_cpus())
+            cpu_relax();
+        isb();
+    }
+
+    return ret;
+}
+
+int ksu_patch_text(void *dst, void *src, size_t len, int flags)
+{
+    struct patch_text_info info = {
+        .dst = dst,
+        .src = src,
+        .len = len,
+        .cpu_count = ATOMIC_INIT(0),
+        .flags = flags,
+    };
+
+    return stop_machine(ksu_patch_text_cb, &info, cpu_online_mask);
+}
+
+/*
+ * Scan the memory region [start, start+size) for a BL instruction whose
+ * branch target equals `target`.  Returns the address of the first matching
+ * instruction, or NULL if none is found.
+ *
+ * AArch64 BL encoding: bits[31:26] = 0b100101, bits[25:0] = imm26.
+ * Branch target = PC + SignExtend(imm26, 26) * 4.
+ */
+void *scan_call_to(void *start, size_t size, void *target)
+{
+    const uint32_t *insn = (const uint32_t *)start;
+    size_t count = size / sizeof(uint32_t);
+    size_t i;
+
+    for (i = 0; i < count; i++) {
+        int32_t imm26;
+        void *branch_target;
+
+        /* Check BL opcode: bits[31:26] == 0b100101 */
+        if ((insn[i] & 0xFC000000U) != 0x94000000U)
+            continue;
+
+        /* Sign-extend the 26-bit immediate to 32 bits */
+        imm26 = (int32_t)((insn[i] & 0x03FFFFFFU) << 6) >> 6;
+
+        /* Branch target = PC + imm26 * 4 */
+        branch_target = (void *)((uintptr_t)(&insn[i]) + ((int64_t)imm26 << 2));
+
+        if (branch_target == target)
+            return (void *)&insn[i];
+    }
+
+    return NULL;
+}
+
+
+
+#elif defined(__x86_64__)
+
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (C) 2023 bmax121. All Rights Reserved.
+ */
+
+
+
+#include <linux/cache.h> 
+#include "patch_memory.h"
+#include "klog.h" // IWYU pragma: keep
+#include <linux/cpumask.h>
+#include <linux/gfp.h> // IWYU pragma: keep
+#include <linux/uaccess.h>
+#include <linux/stop_machine.h>
+#include <asm/cacheflush.h>
+#include <asm-generic/fixmap.h>
+
+#include <asm/pgtable.h>
+#include <asm/page.h>
+#include <asm/fixmap.h>
+
+// --- Architecture-specific Page Table to Physical Address translation ---
+#define KSU_P4D_TO_PHYS(p4d) ((unsigned long)p4d_pfn(p4d) << PAGE_SHIFT)
+#define KSU_PUD_TO_PHYS(pud) ((unsigned long)pud_pfn(pud) << PAGE_SHIFT)
+#define KSU_PMD_TO_PHYS(pmd) ((unsigned long)pmd_pfn(pmd) << PAGE_SHIFT)
+#define KSU_PTE_TO_PHYS(pte) ((unsigned long)pte_pfn(pte) << PAGE_SHIFT)
+
+// Translate a kernel virtual address to a physical address by walking the
+// init_mm page tables.
+unsigned long phys_from_virt(unsigned long addr, int *err)
+{
+    struct mm_struct *mm = &init_mm;
+    pgd_t *pgd;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+    p4d_t *p4d;
+#endif
+    pud_t *pud;
+    pmd_t *pmd;
+    pte_t *pte;
+
+    *err = 0;
+
+    pgd = pgd_offset(mm, addr);
+    if (pgd_none(*pgd) || pgd_bad(*pgd))
+        goto fail;
+    pr_debug("pgd of 0x%lx p=0x%lx v=0x%lx", addr, (uintptr_t)pgd,
+             (uintptr_t)pgd_val(*pgd));
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+    p4d = p4d_offset(pgd, addr);
+    if (p4d_none(*p4d) || p4d_bad(*p4d))
+        goto fail;
+    pr_debug("p4d of 0x%lx p=0x%lx v=0x%lx", addr, (uintptr_t)p4d,
+             (uintptr_t)p4d_val(*p4d));
+#if defined(p4d_leaf)
+    if (p4d_leaf(*p4d)) {
+        pr_debug("Address 0x%lx maps to a P4D-level huge page\n", addr);
+        return KSU_P4D_TO_PHYS(*p4d) + ((addr & ~P4D_MASK));
+    }
+#elif defined(p4d_large)
+    if (p4d_large(*p4d)) {
+        return KSU_P4D_TO_PHYS(*p4d) + ((addr & ~P4D_MASK));
+    }
+#endif
+
+    pud = pud_offset(p4d, addr);
+#else
+    pud = pud_offset(pgd, addr);
+#endif
+    if (pud_none(*pud) || pud_bad(*pud))
+        goto fail;
+    pr_debug("pud of 0x%lx p=0x%lx v=0x%lx", addr, (uintptr_t)pud,
+             (uintptr_t)pud_val(*pud));
+#if defined(pud_leaf)
+    if (pud_leaf(*pud)) {
+        pr_debug("Address 0x%lx maps to a PUD-level huge page\n", addr);
+        return KSU_PUD_TO_PHYS(*pud) + ((addr & ~PUD_MASK));
+    }
+#elif defined(pud_large)
+    if (pud_large(*pud)) {
+        return KSU_PUD_TO_PHYS(*pud) + ((addr & ~PUD_MASK));
+    }
+#endif
+
+    pmd = pmd_offset(pud, addr);
+    pr_debug("pmd of 0x%lx p=0x%lx v=0x%lx", addr, (uintptr_t)pmd,
+             (uintptr_t)pmd_val(*pmd));
+#if defined(pmd_leaf)
+    if (pmd_leaf(*pmd)) {
+        pr_debug("Address 0x%lx maps to a PMD-level huge page\n", addr);
+        return KSU_PMD_TO_PHYS(*pmd) + ((addr & ~PMD_MASK));
+    }
+#elif defined(pmd_large)
+    if (pmd_large(*pmd)) {
+        return KSU_PMD_TO_PHYS(*pmd) + ((addr & ~PMD_MASK));
+    }
+#endif
+
+    if (pmd_none(*pmd) || pmd_bad(*pmd))
+        goto fail;
+
+    pte = pte_offset_kernel(pmd, addr);
+    if (!pte)
+        goto fail;
+    if (!pte_present(*pte))
+        goto fail;
+
+    return KSU_PTE_TO_PHYS(*pte) + ((addr & ~PAGE_MASK));
+
+fail:
+    *err = -ENOENT;
+    return 0;
+}
+
+// --- Architecture-specific Cache Flushing & Barriers ---
+#define ksu_flush_dcache(start, sz) do {} while (0)
+#define ksu_flush_icache(start, end) do {} while (0)
+#define ksu_isb() smp_mb()
+
+struct patch_text_info {
+    void *dst;
+    void *src;
+    size_t len;
+    atomic_t cpu_count;
+    int flags;
+};
+
+static int ksu_patch_text_nosync(void *dst, void *src, size_t len, int flags)
+{
+    pr_debug("patch dst=0x%lx src=0x%lx len=%ld\n", (unsigned long)dst,
+             (unsigned long)src, len);
+
+    unsigned long p = (unsigned long)dst;
+    int ret;
+
+    int phy_err;
+    unsigned long phy = phys_from_virt(p, &phy_err);
+    if (phy_err) {
+        ret = phy_err;
+        pr_err("failed to find phy addr for patch dst addr 0x%lx\n", p);
+        goto err;
+    }
+    pr_debug("phy addr for patch 0x%lx: 0x%lx\n", p, phy);
+
+    // Modern x86 removes FIX_TEXT_POKE0. FIX_BTMAP_BEGIN is universal and safe here.
+    set_fixmap(FIX_BTMAP_BEGIN, phy & PAGE_MASK);
+    void *map = (void *)(fix_to_virt(FIX_BTMAP_BEGIN) + (phy & ~PAGE_MASK));
+
+    pr_debug("fixmap addr for patch 0x%lx: 0x%lx\n", p, (unsigned long)map);
+
+    ret = (int)copy_to_kernel_nofault(map, src, len);
+
+    clear_fixmap(FIX_BTMAP_BEGIN);
+
+    if (!ret) {
+        if (flags & KSU_PATCH_TEXT_FLUSH_ICACHE)
+            ksu_flush_icache((uintptr_t)dst, (uintptr_t)dst + len);
+        if (flags & KSU_PATCH_TEXT_FLUSH_DCACHE)
+            ksu_flush_dcache(dst, len);
+    }
+
+err:
+    pr_debug("patch result=%d\n", ret);
+    return ret;
+}
+
+static int ksu_patch_text_cb(void *arg)
+{
+    struct patch_text_info *pp = arg;
+    void *dst = pp->dst, *src = pp->src;
+    size_t len = pp->len;
+    int flags = pp->flags;
+
+    int ret = 0;
+
+    /* The last CPU becomes master */
+    if (atomic_inc_return(&pp->cpu_count) == num_online_cpus()) {
+        ret = ksu_patch_text_nosync(dst, src, len, flags);
+        /* Notify other processors with an additional increment. */
+        atomic_inc(&pp->cpu_count);
+    } else {
+        while (atomic_read(&pp->cpu_count) <= num_online_cpus())
+            cpu_relax();
+        ksu_isb();
+    }
+
+    return ret;
+}
+
+int ksu_patch_text(void *dst, void *src, size_t len, int flags)
+{
+    struct patch_text_info info = {
+        .dst = dst,
+        .src = src,
+        .len = len,
+        .cpu_count = ATOMIC_INIT(0),
+        .flags = flags,
+    };
+
+    return stop_machine(ksu_patch_text_cb, &info, cpu_online_mask);
+}
+
+// TODO:
+void *scan_call_to(void *start, size_t size, void *target)
+{
+    return NULL;
+}
+
+
+
+#else
+#error "Unsupported arch"
+#endif /* __aarch64__ / __x86_64__ */

--- a/kernel/hook/patch_memory.h
+++ b/kernel/hook/patch_memory.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (C) 2023 bmax121. All Rights Reserved.
+ */
+
+#ifndef __KSU_PATCH_MEMORY_H
+#define __KSU_PATCH_MEMORY_H
+
+#include <linux/types.h>
+#include "linux/version.h"
+
+#ifdef __aarch64__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+#include "asm/text-patching.h" // IWYU pragma: keep
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+#include "asm/patching.h" // IWYU pragma: keep
+#else
+#include "asm/insn.h" // IWYU pragma: keep
+#endif
+#elif __x86_64__
+#include <asm/ptrace.h>
+#else
+#error "Unsupported arch"
+#endif
+
+#define KSU_PATCH_TEXT_FLUSH_DCACHE 1
+#define KSU_PATCH_TEXT_FLUSH_ICACHE 2
+
+unsigned long phys_from_virt(unsigned long addr, int *err);
+int ksu_patch_text(void *dst, void *src, size_t len, int flags);
+void *scan_call_to(void *start, size_t size, void *target);
+
+#endif

--- a/kernel/hook/syscall_table_hook.c
+++ b/kernel/hook/syscall_table_hook.c
@@ -1,0 +1,308 @@
+#ifdef KSU_SYSCALL_TABLE_HOOK
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/preempt.h>
+#include <linux/uaccess.h>
+#include <linux/sched.h>
+#include <linux/version.h>
+#include <linux/errno.h>
+#include <linux/fcntl.h>
+#include <asm/ptrace.h>
+#if defined(__aarch64__)
+#include <asm/memory.h>
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#include <linux/sched/task_stack.h>
+#else
+#include <linux/sched.h>
+#endif
+
+#include "arch.h"
+#include "klog.h" // IWYU pragma: keep
+#include "compat/kernel_compat.h"
+#include "hook/syscall_table_hook.h"
+#include "hook/patch_memory.h"
+#include "infra/symbol_resolver.h"
+#include "policy/app_profile.h"
+#include "selinux/selinux.h"
+#include "feature/sucompat.h"
+#include "feature/adb_root.h"
+#include "runtime/ksud.h"
+
+// The pt_regs-based syscall ABI (__arm64_sys_*/__x64_sys_*) exists since 4.17
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+#error "syscall table hook requires kernel >= 4.17 (pt_regs syscall ABI)"
+#endif
+
+typedef long (*syscall_fn_t)(const struct pt_regs *regs);
+
+static syscall_fn_t *ksu_sth_syscall_table = NULL;
+
+#define KSU_STH_MAX_HOOKS 16
+
+struct ksu_sth_entry {
+	int nr;
+	syscall_fn_t orig;
+	syscall_fn_t wrapper;
+};
+
+static DEFINE_MUTEX(ksu_sth_lock);
+static struct ksu_sth_entry ksu_sth_entries[KSU_STH_MAX_HOOKS];
+static int ksu_sth_count = 0;
+
+// Some architectures (e.g. x86_64) do not provide untagged_addr()
+#ifndef untagged_addr
+#define untagged_addr(addr) (addr)
+#endif
+
+static syscall_fn_t ksu_sth_get_orig(int nr)
+{
+	int i;
+	for (i = 0; i < ksu_sth_count; i++) {
+		if (ksu_sth_entries[i].nr == nr)
+			return ksu_sth_entries[i].orig;
+	}
+	return NULL;
+}
+
+static inline long ksu_sth_call_orig(int nr, const struct pt_regs *regs)
+{
+	syscall_fn_t orig = ksu_sth_get_orig(nr);
+	if (unlikely(!orig))
+		return -ENOSYS;
+	return orig(regs);
+}
+
+static int ksu_sth_patch(int nr, syscall_fn_t fn)
+{
+	if (!ksu_sth_syscall_table)
+		return -ENOENT;
+
+	pr_info("sth: patch syscall %d: 0x%lx -> 0x%lx\n", nr,
+		(unsigned long)READ_ONCE(ksu_sth_syscall_table[nr]),
+		(unsigned long)fn);
+
+	if (ksu_patch_text(&ksu_sth_syscall_table[nr], &fn, sizeof(fn),
+			   KSU_PATCH_TEXT_FLUSH_DCACHE)) {
+		pr_err("sth: patch syscall %d failed\n", nr);
+		return -EIO;
+	}
+	return 0;
+}
+
+static void ksu_sth_record(int nr, syscall_fn_t orig)
+{
+	int i;
+	for (i = 0; i < ksu_sth_count; i++) {
+		if (ksu_sth_entries[i].nr == nr)
+			return;
+	}
+	if (ksu_sth_count >= KSU_STH_MAX_HOOKS) {
+		pr_err("sth: entry table full, cannot track syscall %d\n", nr);
+		return;
+	}
+	ksu_sth_entries[ksu_sth_count].nr = nr;
+	ksu_sth_entries[ksu_sth_count].orig = orig;
+	ksu_sth_entries[ksu_sth_count].wrapper = NULL;
+	ksu_sth_count++;
+}
+
+// init exec tracker for the table hook scheme: escape when init executes ksud.
+// The tracepoint-based unmark logic does not apply here (no task marking).
+static void ksu_sth_init_exec_tracker(const char __user *filename_user)
+{
+	char path[64];
+	unsigned long addr;
+	const char __user *fn;
+	long ret;
+
+	addr = untagged_addr((unsigned long)filename_user);
+	fn = (const char __user *)addr;
+
+	memset(path, 0, sizeof(path));
+	ret = strncpy_from_user_nofault(path, fn, sizeof(path));
+	if (ret < 0 && preempt_count()) {
+		preempt_enable_no_resched_notrace();
+		ret = strncpy_from_user(path, fn, sizeof(path));
+		preempt_disable_notrace();
+	}
+
+	if (ret < 0)
+		return;
+
+	if (unlikely(strcmp(path, KSUD_PATH) == 0)) {
+		pr_info("sth: escape to root for init executing ksud: %d\n",
+			current->pid);
+		escape_to_root_for_init();
+	}
+}
+
+#ifdef __NR_execve
+static long ksu_sth_execve(const struct pt_regs *regs)
+{
+	const char __user **filename_user =
+		(const char __user **)&PT_REGS_PARM1(regs);
+	long adb_ret = 0;
+
+	if (current->pid != 1 && is_init(current_cred())) {
+		ksu_sth_init_exec_tracker(*filename_user);
+		adb_ret = ksu_adb_root_handle_execve((struct pt_regs *)regs);
+		if (adb_ret)
+			pr_err("sth: adb root failed: %ld\n", adb_ret);
+	} else {
+		ksu_handle_execve_sucompat(filename_user, __NR_execve, regs);
+	}
+
+	return ksu_sth_call_orig(__NR_execve, regs);
+}
+#endif
+
+#ifdef __NR_execveat
+static long ksu_sth_execveat(const struct pt_regs *regs)
+{
+	const char __user **filename_user =
+		(const char __user **)&PT_REGS_PARM2(regs);
+	long adb_ret = 0;
+
+	// New bionic maps execve to execveat(AT_FDCWD, path, argv, envp, 0)
+	if ((int)PT_REGS_PARM1(regs) == AT_FDCWD &&
+	    (int)PT_REGS_SYSCALL_PARM4(regs) == 0) {
+		if (current->pid != 1 && is_init(current_cred())) {
+			ksu_sth_init_exec_tracker(*filename_user);
+			adb_ret = ksu_adb_root_handle_execveat(
+				(struct pt_regs *)regs);
+			if (adb_ret)
+				pr_err("sth: adb root failed: %ld\n", adb_ret);
+		} else {
+			ksu_handle_execveat_sucompat_user(filename_user,
+							  __NR_execveat, regs);
+		}
+	}
+
+	return ksu_sth_call_orig(__NR_execveat, regs);
+}
+#endif
+
+#ifdef __NR_faccessat
+static long ksu_sth_faccessat(const struct pt_regs *regs)
+{
+	int *dfd = (int *)&PT_REGS_PARM1(regs);
+	const char __user **filename_user =
+		(const char __user **)&PT_REGS_PARM2(regs);
+	int *mode = (int *)&PT_REGS_PARM3(regs);
+
+	ksu_handle_faccessat(dfd, filename_user, mode, NULL);
+
+	return ksu_sth_call_orig(__NR_faccessat, regs);
+}
+#endif
+
+#ifdef __NR_newfstatat
+static long ksu_sth_newfstatat(const struct pt_regs *regs)
+{
+	int *dfd = (int *)&PT_REGS_PARM1(regs);
+	const char __user **filename_user =
+		(const char __user **)&PT_REGS_PARM2(regs);
+	int *flags = (int *)&PT_REGS_SYSCALL_PARM4(regs);
+
+	ksu_handle_stat(dfd, filename_user, flags);
+
+	return ksu_sth_call_orig(__NR_newfstatat, regs);
+}
+#endif
+
+void __init ksu_syscall_table_hook_init(void)
+{
+	struct {
+		int nr;
+		syscall_fn_t wrapper;
+	} hooks[] = {
+#ifdef __NR_execve
+		{ __NR_execve, ksu_sth_execve },
+#endif
+#ifdef __NR_execveat
+		{ __NR_execveat, ksu_sth_execveat },
+#endif
+#ifdef __NR_faccessat
+		{ __NR_faccessat, ksu_sth_faccessat },
+#endif
+#ifdef __NR_newfstatat
+		{ __NR_newfstatat, ksu_sth_newfstatat },
+#endif
+	};
+	int i, patched = 0;
+
+	ksu_init_symbol_resolver();
+
+	ksu_sth_syscall_table =
+		(syscall_fn_t *)ksu_resolve_symbol_for_functable_hook(
+			"sys_call_table");
+	pr_info("sth: sys_call_table=0x%lx\n",
+		(unsigned long)ksu_sth_syscall_table);
+
+	if (!ksu_sth_syscall_table) {
+		pr_err("sth: sys_call_table not found, table hook disabled\n");
+		return;
+	}
+
+	mutex_lock(&ksu_sth_lock);
+
+	for (i = 0; i < ARRAY_SIZE(hooks); i++) {
+		syscall_fn_t orig =
+			READ_ONCE(ksu_sth_syscall_table[hooks[i].nr]);
+		if (!orig) {
+			pr_warn("sth: syscall %d has no original, skip\n",
+				hooks[i].nr);
+			continue;
+		}
+		ksu_sth_record(hooks[i].nr, orig);
+		if (!ksu_sth_patch(hooks[i].nr, hooks[i].wrapper))
+			patched++;
+	}
+
+	mutex_unlock(&ksu_sth_lock);
+
+	pr_info("sth: %d/%ld syscalls hooked\n", patched,
+		(long)ARRAY_SIZE(hooks));
+}
+
+void __exit ksu_syscall_table_hook_exit(void)
+{
+	int i;
+
+	if (!ksu_sth_syscall_table)
+		return;
+
+	mutex_lock(&ksu_sth_lock);
+
+	for (i = 0; i < ksu_sth_count; i++) {
+		int nr = ksu_sth_entries[i].nr;
+		syscall_fn_t orig = ksu_sth_entries[i].orig;
+
+		pr_info("sth: restore syscall %d to 0x%lx\n", nr,
+			(unsigned long)orig);
+		if (ksu_patch_text(&ksu_sth_syscall_table[nr], &orig,
+				   sizeof(orig),
+				   KSU_PATCH_TEXT_FLUSH_DCACHE))
+			pr_err("sth: restore syscall %d failed\n", nr);
+	}
+	ksu_sth_count = 0;
+
+	mutex_unlock(&ksu_sth_lock);
+}
+
+#else // !KSU_SYSCALL_TABLE_HOOK
+
+#include "hook/syscall_table_hook.h"
+
+void __init ksu_syscall_table_hook_init(void)
+{
+}
+
+void __exit ksu_syscall_table_hook_exit(void)
+{
+}
+
+#endif // KSU_SYSCALL_TABLE_HOOK

--- a/kernel/hook/syscall_table_hook.h
+++ b/kernel/hook/syscall_table_hook.h
@@ -1,0 +1,11 @@
+#ifndef __KSU_H_SYSCALL_TABLE_HOOK
+#define __KSU_H_SYSCALL_TABLE_HOOK
+
+// Syscall table patching hook scheme: directly patch sys_call_table entries
+// with wrapper functions instead of using kprobes/tracepoints.
+// Intended for non-GKI kernels where kprobes are unavailable or broken.
+
+void __init ksu_syscall_table_hook_init(void);
+void __exit ksu_syscall_table_hook_exit(void);
+
+#endif

--- a/kernel/hook/syscall_table_hook.h
+++ b/kernel/hook/syscall_table_hook.h
@@ -1,6 +1,8 @@
 #ifndef __KSU_H_SYSCALL_TABLE_HOOK
 #define __KSU_H_SYSCALL_TABLE_HOOK
 
+#include <linux/init.h>
+
 // Syscall table patching hook scheme: directly patch sys_call_table entries
 // with wrapper functions instead of using kprobes/tracepoints.
 // Intended for non-GKI kernels where kprobes are unavailable or broken.

--- a/kernel/include/arch.h
+++ b/kernel/include/arch.h
@@ -22,6 +22,7 @@
 #define REBOOT_SYMBOL "__arm64_sys_reboot"
 #define SYS_READ_SYMBOL "__arm64_sys_read"
 #define SYS_EXECVE_SYMBOL "__arm64_sys_execve"
+#define SYS_EXECVEAT_SYMBOL "__arm64_sys_execveat"
 #define SYS_SETNS_SYMBOL __arm64_sys_setns
 // https://cs.android.com/android/kernel/superproject/+/common-android-mainline:common/scripts/syscalltbl.sh;l=57;drc=9142be9e6443fd641ca37f820efe00d9cd890eb1
 // https://cs.android.com/android/kernel/superproject/+/common-android-mainline:common/scripts/syscall.tbl;l=104;drc=b36d4b6aa88ef039647228b98c59a875e92f8c8e
@@ -54,6 +55,7 @@
 #define REBOOT_SYMBOL "__x64_sys_reboot"
 #define SYS_READ_SYMBOL "__x64_sys_read"
 #define SYS_EXECVE_SYMBOL "__x64_sys_execve"
+#define SYS_EXECVEAT_SYMBOL "__x64_sys_execveat"
 #define SYS_SETNS_SYMBOL __x64_sys_setns
 #define SYS_FSTAT_SYMBOL "__x64_sys_newfstat"
 #else

--- a/kernel/include/arch.h
+++ b/kernel/include/arch.h
@@ -31,6 +31,7 @@
 #define REBOOT_SYMBOL "sys_reboot"
 #define SYS_READ_SYMBOL "sys_read"
 #define SYS_EXECVE_SYMBOL "sys_execve"
+#define SYS_EXECVEAT_SYMBOL "sys_execveat"
 #define SYS_SETNS_SYMBOL sys_setns
 #define SYS_FSTAT_SYMBOL "sys_newfstat"
 #endif
@@ -62,6 +63,7 @@
 #define REBOOT_SYMBOL "sys_reboot"
 #define SYS_READ_SYMBOL "sys_read"
 #define SYS_EXECVE_SYMBOL "sys_execve"
+#define SYS_EXECVEAT_SYMBOL "sys_execveat"
 #define SYS_SETNS_SYMBOL sys_setns
 #define SYS_FSTAT_SYMBOL "sys_newfstat"
 #endif

--- a/kernel/infra/event_queue.c
+++ b/kernel/infra/event_queue.c
@@ -339,6 +339,7 @@ ssize_t ksu_event_queue_read(struct ksu_event_queue *queue, char __user *buf, si
 
     ret = ksu_event_queue_wait_ready(queue, file_flags);
     if (ret) {
+        copied = ret;
         goto out_unlock;
     }
 

--- a/kernel/infra/symbol_resolver.c
+++ b/kernel/infra/symbol_resolver.c
@@ -1,0 +1,194 @@
+#include <linux/kallsyms.h>
+#include <linux/module.h>
+#include <linux/string.h>
+#include <linux/version.h>
+
+// __nocfi is an arm64-only attribute; make it a no-op elsewhere
+#ifndef __nocfi
+#define __nocfi
+#endif
+
+#include "infra/symbol_resolver.h"
+
+// https://github.com/torvalds/linux/commit/89245600941e4e0f87d77f60ee269b5e61ef4e49
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#define USE_KCFI 1
+#else
+#define USE_KCFI 0
+#endif
+
+#if !USE_KCFI
+static const char cfi_suffix[] = ".cfi_jt";
+static const size_t cfi_suffix_len = sizeof(cfi_suffix) - 1;
+#endif
+
+// It's not guaranteed to have this symbol exist in 5.x kernel
+// https://github.com/torvalds/linux/commit/d721def7392a7348ffb9f3583b264239cbd3702c
+// https://github.com/gregkh/linux/commit/2aa861ec72908b4bdc20d74725dc1c8c71a8d214
+// https://github.com/gregkh/linux/commit/318a206633c248d876ea72f7133d2a2e50ad7e35
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 0)
+#define ALWAYS_HAVE_ON_EACH_SYMBOL 1
+#else
+#define ALWAYS_HAVE_ON_EACH_SYMBOL 0
+#endif
+
+#if !ALWAYS_HAVE_ON_EACH_SYMBOL
+static int (*kallsyms_on_each_symbol_fn)(int (*fn)(void *, const char *, struct module *, unsigned long),
+                                         void *data) = NULL;
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#define HAVE_ON_EACH_MATCH_SYMBOL 1
+#else
+#define HAVE_ON_EACH_MATCH_SYMBOL 0
+#endif
+
+// https://github.com/torvalds/linux/commit/4dc533e0f2c04174e1ae4aa98e7cffc1c04b9998
+#if HAVE_ON_EACH_MATCH_SYMBOL
+static int (*kallsyms_on_each_match_symbol_fn)(int (*fn)(void *, unsigned long), const char *name, void *data) = NULL;
+static int find_kernel_symbol_exact_cb(void *data, unsigned long addr)
+{
+    *(unsigned long *)data = addr;
+    return 0;
+}
+#endif
+
+struct ksu_lookup_symbol_ctx {
+    const char *symbol_name;
+    size_t symbol_len;
+    void *match;
+};
+
+unsigned long __nocfi find_kernel_symbol_exact(const char *symbol_name)
+{
+    unsigned long addr = 0;
+#if HAVE_ON_EACH_MATCH_SYMBOL
+    if (likely(kallsyms_on_each_match_symbol_fn)) {
+        kallsyms_on_each_match_symbol_fn(find_kernel_symbol_exact_cb, symbol_name, &addr);
+        return addr;
+    }
+#endif
+    char *module_name = NULL;
+    char buf[KSYM_SYMBOL_LEN];
+
+    addr = kallsyms_lookup_name(symbol_name);
+    // check if it is kernel symbol
+    kallsyms_lookup(addr, NULL, NULL, &module_name, buf);
+    if (unlikely(module_name)) {
+        pr_warn("ignore symbol %s of module %s\n", symbol_name, module_name);
+        return 0;
+    }
+    return addr;
+}
+
+static inline bool ksu_symbol_has_suffix(const char *name, size_t name_len, const char *suffix, size_t suffix_len)
+{
+    return name_len >= suffix_len && strcmp(name + name_len - suffix_len, suffix) == 0;
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+static int lookup_symbol_variant_cb(void *data, const char *name, unsigned long addr)
+#else
+static int lookup_symbol_variant_cb(void *data, const char *name, struct module *mod, unsigned long addr)
+#endif
+{
+    struct ksu_lookup_symbol_ctx *ctx = data;
+    size_t name_len;
+
+    if (!name || !addr)
+        return 0;
+
+    name_len = strlen(name);
+
+    if (strcmp(name, ctx->symbol_name) != 0) {
+        if (name_len <= ctx->symbol_len || strncmp(name, ctx->symbol_name, ctx->symbol_len) != 0 ||
+            (name[ctx->symbol_len] != '.' && name[ctx->symbol_len] != '$'))
+            return 0;
+    }
+
+#if !USE_KCFI
+    if (ksu_symbol_has_suffix(name, name_len, cfi_suffix, cfi_suffix_len)) {
+        ctx->match = (void *)addr;
+        pr_info("use .cfi_jt variant: %s\n", name);
+        return 1;
+    }
+#endif
+
+    if (!ctx->match) {
+        ctx->match = (void *)addr;
+        pr_info("found variant: %s\n", name);
+#if USE_KCFI
+        return 1;
+#endif
+    }
+
+    return 0;
+}
+
+static __nocfi void *resolve_symbol_variant(const char *symbol_name, size_t symbol_len)
+{
+    struct ksu_lookup_symbol_ctx ctx = {
+        .symbol_name = symbol_name,
+        .symbol_len = symbol_len,
+    };
+
+#if !ALWAYS_HAVE_ON_EACH_SYMBOL
+    if (kallsyms_on_each_symbol_fn) {
+        kallsyms_on_each_symbol_fn(lookup_symbol_variant_cb, &ctx);
+    }
+    // TODO: iterate kallsyms by sprint_symbol
+#else
+    kallsyms_on_each_symbol(lookup_symbol_variant_cb, &ctx);
+#endif
+    return ctx.match;
+}
+
+void *ksu_resolve_symbol_for_functable_hook(const char *symbol_name)
+{
+    void *addr;
+    size_t symbol_len;
+
+    if (!symbol_name || !symbol_name[0])
+        return NULL;
+
+    symbol_len = strlen(symbol_name);
+
+    // Prefer find_kernel_symbol_exact since it uses binary search in higher kernel version
+
+#if !USE_KCFI
+    // Try .cfi_jt suffix first
+    char cfi_name[KSYM_NAME_LEN];
+    snprintf(cfi_name, sizeof(cfi_name), "%s.cfi_jt", symbol_name);
+    addr = (void *)find_kernel_symbol_exact(cfi_name);
+    if (addr)
+        return addr;
+
+    addr = resolve_symbol_variant(symbol_name, symbol_len);
+    if (addr)
+        return addr;
+
+    return (void *)find_kernel_symbol_exact(symbol_name);
+#else
+    addr = (void *)find_kernel_symbol_exact(symbol_name);
+    if (addr)
+        return addr;
+
+    return resolve_symbol_variant(symbol_name, symbol_len);
+#endif
+}
+
+void __init ksu_init_symbol_resolver()
+{
+#if !ALWAYS_HAVE_ON_EACH_SYMBOL
+    kallsyms_on_each_symbol_fn = find_kernel_symbol_exact("kallsyms_on_each_symbol");
+    if (!kallsyms_on_each_symbol_fn) {
+        pr_warn("kallsyms_on_each_symbol not found!\n");
+    }
+#endif
+#if HAVE_ON_EACH_MATCH_SYMBOL
+    kallsyms_on_each_match_symbol_fn = find_kernel_symbol_exact("kallsyms_on_each_match_symbol");
+    if (!kallsyms_on_each_match_symbol_fn) {
+        pr_warn("kallsyms_on_each_match_symbol not found!\n");
+    }
+#endif
+}

--- a/kernel/infra/symbol_resolver.h
+++ b/kernel/infra/symbol_resolver.h
@@ -1,0 +1,8 @@
+#ifndef __KSU_SYMBOL_RESOLVER_H
+#define __KSU_SYMBOL_RESOLVER_H
+
+void *ksu_resolve_symbol_for_functable_hook(const char *symbol_name);
+unsigned long find_kernel_symbol_exact(const char *symbol_name);
+void ksu_init_symbol_resolver();
+
+#endif

--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -160,7 +160,6 @@ static __always_inline bool check_v2_signature(char *path,
 	bool v3_signing_exist = false;
 	bool v3_1_signing_exist = false;
 
-	int i;
 	struct file *fp = ksu_filp_open_compat(path, O_RDONLY, 0);
 	if (IS_ERR(fp)) {
 		pr_err("open %s error.\n", path);
@@ -175,22 +174,54 @@ static __always_inline bool check_v2_signature(char *path,
 		goto clean;
 
 	// https://en.wikipedia.org/wiki/Zip_(file_format)#End_of_central_directory_record_(EOCD)
-	for (i = 0;; ++i) {
-		unsigned short comment_size;
-		u32 magic;
-		pos = file_size - i - 2;
-		if (!read_exact(fp, &comment_size, sizeof(comment_size), &pos, file_size))
+	// Buffered backward search (single read) instead of the upstream
+	// byte-by-byte loop: scanning /data/app at boot with thousands of
+	// 2-byte kernel_read() calls stalls the device for ages.
+	{
+		unsigned char *eocd_buffer;
+		long search_size;
+		long max_comment_size = 0xffff;
+		long eocd_min_size = 22;
+		bool eocd_found = false;
+
+		search_size = max_comment_size + eocd_min_size;
+		if (search_size > file_size)
+			search_size = file_size;
+
+		eocd_buffer = kvmalloc(search_size, GFP_KERNEL);
+		if (!eocd_buffer) {
+			pr_err("error: cannot allocate memory for eocd\n");
 			goto clean;
-		if (comment_size == i) {
-			pos -= 22;
-			if (!read_exact(fp, &magic, sizeof(magic), &pos, file_size))
-				goto clean;
-			if (magic == 0x06054b50) {
-				eocd_offset = pos - sizeof(magic);
-				break;
+		}
+
+		pos = file_size - search_size;
+		ksu_kernel_read_compat(fp, eocd_buffer, search_size, &pos);
+
+		if (search_size >= eocd_min_size) {
+			long j;
+			for (j = search_size - eocd_min_size; j >= 0; j--) {
+				if (eocd_buffer[j] == 0x50 &&
+				    eocd_buffer[j + 1] == 0x4b &&
+				    eocd_buffer[j + 2] == 0x05 &&
+				    eocd_buffer[j + 3] == 0x06) {
+					unsigned short comment_len =
+						eocd_buffer[j + 20] |
+						(eocd_buffer[j + 21] << 8);
+					if (comment_len ==
+					    search_size - j - eocd_min_size) {
+						eocd_offset =
+							file_size - search_size +
+							j;
+						eocd_found = true;
+						break;
+					}
+				}
 			}
 		}
-		if (i == 0xffff) {
+
+		kvfree(eocd_buffer);
+
+		if (!eocd_found) {
 			pr_info("error: cannot find eocd\n");
 			goto clean;
 		}

--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -2,6 +2,7 @@
 #include <linux/fs.h>
 #include <linux/gfp.h>
 #include <linux/kernel.h>
+#include <linux/limits.h>
 #include <linux/slab.h>
 #include <linux/version.h>
 #ifdef CONFIG_KSU_DEBUG
@@ -13,11 +14,14 @@
 #else
 #include <crypto/sha.h>
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+#include <linux/hex.h>
+#endif
 
 #include "apk_sign.h"
 #include "policy/app_profile.h"
-#include "klog.h" // IWYU pragma: keep
 #include "compat/kernel_compat.h"
+#include "klog.h" // IWYU pragma: keep
 
 struct sdesc {
 	struct shash_desc shash;
@@ -38,7 +42,7 @@ static struct sdesc *init_sdesc(struct crypto_shash *alg)
 }
 
 static int calc_hash(struct crypto_shash *alg, const unsigned char *data,
-			unsigned int datalen, unsigned char *digest)
+                     unsigned int datalen, unsigned char *digest)
 {
 	struct sdesc *sdesc;
 	int ret;
@@ -55,7 +59,7 @@ static int calc_hash(struct crypto_shash *alg, const unsigned char *data,
 }
 
 static int ksu_sha256(const unsigned char *data, unsigned int datalen,
-			unsigned char *digest)
+                      unsigned char *digest)
 {
 	struct crypto_shash *alg;
 	char *hash_alg_name = "sha256";
@@ -71,165 +75,85 @@ static int ksu_sha256(const unsigned char *data, unsigned int datalen,
 	return ret;
 }
 
-static bool check_block(struct file *fp, u32 *size4, loff_t *pos, u32 *offset,
-			unsigned expected_size, const char *expected_sha256)
+static bool read_exact(struct file *fp, void *buffer, size_t size, loff_t *pos, loff_t end)
 {
-	ksu_kernel_read_compat(fp, size4, 0x4, pos); // signer-sequence length
-	ksu_kernel_read_compat(fp, size4, 0x4, pos); // signer length
-	ksu_kernel_read_compat(fp, size4, 0x4, pos); // signed data length
+	if (*pos < 0 || *pos > end || size > (size_t)(end - *pos))
+		return false;
 
-	*offset += 0x4 * 3;
+	return ksu_kernel_read_compat(fp, buffer, size, pos) == (ssize_t)size;
+}
 
-	ksu_kernel_read_compat(fp, size4, 0x4, pos); // digests-sequence length
+static bool read_length_prefixed_end(struct file *fp, loff_t *pos, loff_t container_end, loff_t *value_end)
+{
+	u32 length;
 
-	*pos += *size4;
-	*offset += 0x4 + *size4;
+	if (!read_exact(fp, &length, sizeof(length), pos, container_end))
+		return false;
+	if (length > INT_MAX || length > (u64)(container_end - *pos))
+		return false;
 
-	ksu_kernel_read_compat(fp, size4, 0x4, pos); // certificates length
-	ksu_kernel_read_compat(fp, size4, 0x4, pos); // certificate length
-	*offset += 0x4 * 2;
+	*value_end = *pos + length;
+	return true;
+}
 
-	if (*size4 == expected_size) {
-		*offset += *size4;
+static bool check_block(struct file *fp, loff_t *pos, loff_t block_end, unsigned expected_size,
+			const char *expected_sha256)
+{
+	loff_t signers_end, signer_end, signed_data_end, digests_end, certificates_end;
+	u32 certificate_size;
+
+	// v2 block: signers sequence -> first signer -> signed data -> digests
+	if (!read_length_prefixed_end(fp, pos, block_end, &signers_end) ||
+		!read_length_prefixed_end(fp, pos, signers_end, &signer_end) ||
+		!read_length_prefixed_end(fp, pos, signer_end, &signed_data_end) ||
+		!read_length_prefixed_end(fp, pos, signed_data_end, &digests_end))
+		return false;
+
+	*pos = digests_end;
+	if (!read_length_prefixed_end(fp, pos, signed_data_end, &certificates_end) ||
+		!read_exact(fp, &certificate_size, sizeof(certificate_size), pos, certificates_end))
+		return false;
+
+	if (certificate_size > INT_MAX || certificate_size > (u64)(certificates_end - *pos))
+		return false;
 
 #define CERT_MAX_LENGTH 1024
-		char cert[CERT_MAX_LENGTH];
-		if (*size4 > CERT_MAX_LENGTH) {
-			pr_info("cert length overlimit\n");
-			return false;
-		}
-		ksu_kernel_read_compat(fp, cert, *size4, pos);
-		unsigned char digest[SHA256_DIGEST_SIZE];
-		if (ksu_sha256(cert, *size4, digest) < 0 ) {
-			pr_info("sha256 error\n");
-			return false;
-		}
+	if (certificate_size != expected_size)
+		return false;
 
-		char hash_str[SHA256_DIGEST_SIZE * 2 + 1];
-		hash_str[SHA256_DIGEST_SIZE * 2] = '\0';
-
-		bin2hex(hash_str, digest, SHA256_DIGEST_SIZE);
-		pr_info("sha256: %s, expected: %s\n", hash_str,
-			expected_sha256);
-		if (strcmp(expected_sha256, hash_str) == 0) {
-			return true;
-		}
-	}
-	return false;
-}
-
-struct zip_entry_header {
-	uint32_t signature;
-	uint16_t version;
-	uint16_t flags;
-	uint16_t compression;
-	uint16_t mod_time;
-	uint16_t mod_date;
-	uint32_t crc32;
-	uint32_t compressed_size;
-	uint32_t uncompressed_size;
-	uint16_t file_name_length;
-	uint16_t extra_field_length;
-} __attribute__((packed));
-
-struct ksu_buf_reader {
-	struct file *fp;
-	loff_t file_pos;
-	char buf[4096];
-	size_t buf_len;
-};
-
-static inline ssize_t ksu_bread(struct ksu_buf_reader *br, void *dst,
-				size_t count, loff_t *pos)
-{
-	if (*pos >= br->file_pos &&
-	    *pos + count <= br->file_pos + br->buf_len) {
-		memcpy(dst, br->buf + (*pos - br->file_pos), count);
-		*pos += count;
-		return count;
-	}
-
-	br->file_pos = *pos;
-	loff_t read_pos = br->file_pos;
-	ssize_t res = ksu_kernel_read_compat(br->fp, br->buf, sizeof(br->buf),
-					     &read_pos);
-	if (res <= 0) {
-		br->buf_len = 0;
-		return res;
-	}
-	br->buf_len = res;
-
-	if (count <= br->buf_len) {
-		memcpy(dst, br->buf, count);
-		*pos += count;
-		return count;
-	}
-
-	return 0;
-}
-
-// This is a necessary but not sufficient condition, but it is enough for us
-static bool has_v1_signature_file(struct file *fp)
-{
-	struct zip_entry_header header;
-	const char MANIFEST[] = "META-INF/MANIFEST.MF";
-	bool found = false;
-	loff_t pos = 0;
-
-	struct ksu_buf_reader *br =
-		kzalloc(sizeof(struct ksu_buf_reader), GFP_KERNEL);
-	if (!br) {
-		pr_err("ksu_buf_reader alloc failed\n");
+	if (certificate_size > CERT_MAX_LENGTH) {
+		pr_info("cert length overlimit\n");
 		return false;
 	}
 
-	br->fp = fp;
-	br->file_pos = 0;
-	br->buf_len = 0;
-	while (ksu_bread(br, &header,
-					sizeof(struct zip_entry_header), &pos) ==
-		sizeof(struct zip_entry_header)) {
-		if (header.signature != 0x04034b50) {
-			// ZIP magic: 'PK'
-			break;
-		}
-		// Read the entry file name
-		if (header.file_name_length == sizeof(MANIFEST) - 1) {
-			char fileName[sizeof(MANIFEST)];
-			if (ksu_bread(br, fileName, header.file_name_length,
-				      &pos) == header.file_name_length) {
-				fileName[header.file_name_length] = '\0';
+	char cert[CERT_MAX_LENGTH];
+	if (!read_exact(fp, cert, certificate_size, pos, certificates_end))
+		return false;
 
-				// Check if the entry matches META-INF/MANIFEST.MF
-				if (strncmp(MANIFEST, fileName, sizeof(MANIFEST) - 1) == 0) {
-					found = true;
-					break;
-				}
-			} else {
-				break;
-			}
-		} else {
-			// Skip the entry file name
-			pos += header.file_name_length;
-		}
-
-		// Skip to the next entry
-		pos += header.extra_field_length + header.compressed_size;
+	unsigned char digest[SHA256_DIGEST_SIZE];
+	if (ksu_sha256(cert, certificate_size, digest)) {
+		pr_info("sha256 error\n");
+		return false;
 	}
 
-	kfree(br);
-	return found;
+	char hash_str[SHA256_DIGEST_SIZE * 2 + 1];
+	hash_str[SHA256_DIGEST_SIZE * 2] = '\0';
+
+	bin2hex(hash_str, digest, SHA256_DIGEST_SIZE);
+	pr_info("sha256: %s, expected: %s\n", hash_str, expected_sha256);
+	return strcmp(expected_sha256, hash_str) == 0;
 }
 
 static __always_inline bool check_v2_signature(char *path,
-						unsigned expected_size,
-						const char *expected_sha256)
+                                               unsigned expected_size,
+                                               const char *expected_sha256)
 {
-	unsigned char buffer[0x11] = { 0 };
-	u32 size4;
-	u64 size8, size_of_block;
+	unsigned char buffer[0x10] = { 0 };
+	u32 cd_offset, cd_size;
+	u32 zip64_locator_magic;
+	u64 size_of_block, size_of_block_at_head;
 
-	loff_t pos;
+	loff_t pos, pairs_end, file_size, eocd_offset;
 
 	bool v2_signing_valid = false;
 	int v2_signing_blocks = 0;
@@ -246,89 +170,92 @@ static __always_inline bool check_v2_signature(char *path,
 	// disable inotify for this file
 	fp->f_mode |= FMODE_NONOTIFY;
 
+	file_size = generic_file_llseek(fp, 0, SEEK_END);
+	if (file_size < 0)
+		goto clean;
+
 	// https://en.wikipedia.org/wiki/Zip_(file_format)#End_of_central_directory_record_(EOCD)
-	{
-		unsigned char *eocd_buffer;
-		loff_t file_size;
-		long search_size;
-		long max_comment_size = 0xffff;
-		long eocd_min_size = 22;
-		long eocd_found = 0;
-
-		file_size = generic_file_llseek(fp, 0, SEEK_END);
-		search_size = max_comment_size + eocd_min_size;
-		if (search_size > file_size) {
-			search_size = file_size;
-		}
-
-		eocd_buffer = kvmalloc(search_size, GFP_KERNEL);
-		if (!eocd_buffer) {
-			pr_err("error: cannot allocate memory for eocd\n");
+	for (i = 0;; ++i) {
+		unsigned short comment_size;
+		u32 magic;
+		pos = file_size - i - 2;
+		if (!read_exact(fp, &comment_size, sizeof(comment_size), &pos, file_size))
 			goto clean;
-		}
-
-		pos = file_size - search_size;
-		ksu_kernel_read_compat(fp, eocd_buffer, search_size, &pos);
-
-		if (search_size >= eocd_min_size) {
-			long j;
-			for (j = search_size - eocd_min_size; j >= 0; j--) {
-				if (eocd_buffer[j] == 0x50 &&
-				    eocd_buffer[j + 1] == 0x4b &&
-				    eocd_buffer[j + 2] == 0x05 &&
-				    eocd_buffer[j + 3] == 0x06) {
-					unsigned short comment_len = 
-						eocd_buffer[j + 20] | (eocd_buffer[j + 21] << 8);
-					if (comment_len == search_size - j - eocd_min_size) {
-						pos = file_size - search_size + j;
-						eocd_found = 1;
-						break;
-					}
-				}
+		if (comment_size == i) {
+			pos -= 22;
+			if (!read_exact(fp, &magic, sizeof(magic), &pos, file_size))
+				goto clean;
+			if (magic == 0x06054b50) {
+				eocd_offset = pos - sizeof(magic);
+				break;
 			}
 		}
-
-		kvfree(eocd_buffer);
-
-		if (!eocd_found) {
+		if (i == 0xffff) {
 			pr_info("error: cannot find eocd\n");
 			goto clean;
 		}
 	}
 
-	pos += 16; // skip 4 bytes signature + 12 bytes
-	// offset
-	ksu_kernel_read_compat(fp, &size4, 0x4, &pos);
-	pos = size4 - 0x18;
-
-	ksu_kernel_read_compat(fp, &size8, 0x8, &pos);
-	ksu_kernel_read_compat(fp, buffer, 0x10, &pos);
-	if (strcmp((char *)buffer, "APK Sig Block 42")) {
-		goto clean;
+	// reject ZIP64 before looking for a signing block
+	if (eocd_offset >= 20) {
+		pos = eocd_offset - 20;
+		if (!read_exact(fp, &zip64_locator_magic, sizeof(zip64_locator_magic), &pos, file_size))
+			goto clean;
+		if (zip64_locator_magic == 0x07064b50)
+			goto clean;
 	}
 
-	pos = size4 - (size8 + 0x8);
-	ksu_kernel_read_compat(fp, &size_of_block, 0x8, &pos);
-	if (size_of_block != size8) {
+	pos = eocd_offset + 12;
+	// size of central directory
+	if (!read_exact(fp, &cd_size, sizeof(cd_size), &pos, file_size))
 		goto clean;
-	}
+	// offset of central directory
+	if (!read_exact(fp, &cd_offset, sizeof(cd_offset), &pos, file_size))
+		goto clean;
+	if ((u64)cd_offset > (u64)eocd_offset || (u64)cd_size != (u64)eocd_offset - cd_offset)
+		goto clean;
+	if (cd_offset < 0x20)
+		goto clean;
 
-	int loop_count = 0;
-	while (loop_count++ < 10) {
+	pairs_end = (loff_t)cd_offset - 0x18;
+	pos = pairs_end;
+
+	if (!read_exact(fp, &size_of_block, sizeof(size_of_block), &pos, cd_offset))
+		goto clean;
+	if (!read_exact(fp, buffer, sizeof(buffer), &pos, cd_offset))
+		goto clean;
+	if (memcmp((char *)buffer, "APK Sig Block 42", sizeof(buffer)))
+		goto clean;
+
+	if (size_of_block < 0x18 || size_of_block > INT_MAX - 0x8 || size_of_block > (u64)cd_offset - 0x8)
+		goto clean;
+
+	pos = (loff_t)cd_offset - (loff_t)size_of_block - 0x8;
+	if (!read_exact(fp, &size_of_block_at_head, sizeof(size_of_block_at_head), &pos, pairs_end))
+		goto clean;
+	if (size_of_block_at_head != size_of_block)
+		goto clean;
+
+	// Scan every length-prefixed pair, matching AOSP's signing block parser
+	// Each valid pair consumes an 8-byte length plus at least a 4-byte ID, so
+	// malformed entries fail below instead of spinning in place.
+	while (pos < pairs_end) {
 		uint32_t id;
-		uint32_t offset;
-		ksu_kernel_read_compat(fp, &size8, 0x8,
-					&pos); // sequence length
-		if (size8 == size_of_block) {
-			break;
-		}
-		ksu_kernel_read_compat(fp, &id, 0x4, &pos); // id
-		offset = 4;
+		u64 size_of_pair;
+		loff_t pair_end;
+
+		if (!read_exact(fp, &size_of_pair, sizeof(size_of_pair), &pos, pairs_end))
+			goto invalid;
+		if (size_of_pair < sizeof(id) || size_of_pair > INT_MAX || size_of_pair > (u64)(pairs_end - pos))
+			goto invalid;
+
+		pair_end = pos + (loff_t)size_of_pair;
+		if (!read_exact(fp, &id, sizeof(id), &pos, pair_end))
+			goto invalid;
+
 		if (id == 0x7109871au) {
 			v2_signing_blocks++;
-			v2_signing_valid =
-				check_block(fp, &size4, &pos, &offset,
-						expected_size, expected_sha256);
+			v2_signing_valid = check_block(fp, &pos, pair_end, expected_size, expected_sha256);
 		} else if (id == 0xf05368c0u) {
 			// http://aospxref.com/android-14.0.0_r2/xref/frameworks/base/core/java/android/util/apk/ApkSignatureSchemeV3Verifier.java#73
 			v3_signing_exist = true;
@@ -340,32 +267,25 @@ static __always_inline bool check_v2_signature(char *path,
 			pr_info("Unknown id: 0x%08x\n", id);
 #endif
 		}
-		pos += (size8 - offset);
+		pos = pair_end;
 	}
 
 	if (v2_signing_blocks != 1) {
 #ifdef CONFIG_KSU_DEBUG
-		pr_err("Unexpected v2 signature count: %d\n",
-			v2_signing_blocks);
+		pr_err("Unexpected v2 signature count: %d\n", v2_signing_blocks);
 #endif
 		v2_signing_valid = false;
 	}
 
-	if (v2_signing_valid) {
-		int has_v1_signing = has_v1_signature_file(fp);
-		if (has_v1_signing) {
-			pr_err("Unexpected v1 signature scheme found!\n");
-			filp_close(fp, 0);
-			return false;
-		}
-	}
+	goto clean;
+
+invalid:
+	v2_signing_valid = false;
 clean:
 	filp_close(fp, 0);
 
-	if (v3_signing_exist || v3_1_signing_exist) {
-#ifdef CONFIG_KSU_DEBUG
+	if (v2_signing_valid && (v3_signing_exist || v3_1_signing_exist)) {
 		pr_err("Unexpected v3 signature scheme found!\n");
-#endif
 		return false;
 	}
 
@@ -392,7 +312,7 @@ static struct kernel_param_ops expected_size_ops = {
 };
 
 module_param_cb(ksu_debug_manager_appid, &expected_size_ops,
-		&ksu_debug_manager_appid, S_IRUSR | S_IWUSR);
+                &ksu_debug_manager_appid, S_IRUSR | S_IWUSR);
 
 #endif
 

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -575,10 +575,10 @@ void ksu_load_allow_list()
 
         migrate_profile(version, &profile);
 
-        pr_info("load_allow_uid, name: %s, uid: %d, allow: %d\n", profile.key,
+		pr_info("load_allow_uid, name: %s, uid: %d, allow: %d\n", profile.key,
                 profile.current_uid, profile.allow_su);
-        ksu_set_app_profile(&profile);
-    }
+		ksu_set_app_profile(&profile);
+	}
 
 	ksu_show_allow_list();
 	filp_close(fp, 0);

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -534,13 +534,10 @@ bool ksu_is_safe_mode()
 
 #ifdef KSU_KPROBES_HOOK
 
-static int sys_execve_handler_pre(struct kprobe *p, struct pt_regs *regs)
+static int ksu_execve_syscall_common(struct pt_regs *real_regs,
+				     const char __user **filename_user,
+				     const char __user *const __user *__argv)
 {
-	struct pt_regs *real_regs = PT_REAL_REGS(regs);
-	const char __user **filename_user =
-		(const char **)&PT_REGS_PARM1(real_regs);
-	const char __user *const __user *__argv =
-		(const char __user *const __user *)PT_REGS_PARM2(real_regs);
 	struct user_arg_ptr argv = { .ptr.native = __argv };
 	struct filename filename_in, *filename_p;
 	char path[32];
@@ -569,7 +566,28 @@ static int sys_execve_handler_pre(struct kprobe *p, struct pt_regs *regs)
 	filename_in.name = path;
 
 	filename_p = &filename_in;
-	return ksu_handle_execveat_ksud(AT_FDCWD, &filename_p, &argv, NULL, NULL);
+	return ksu_handle_execveat_ksud(AT_FDCWD, &filename_p, &argv, NULL,
+					NULL);
+}
+
+static int sys_execve_handler_pre(struct kprobe *p, struct pt_regs *regs)
+{
+	struct pt_regs *real_regs = PT_REAL_REGS(regs);
+	return ksu_execve_syscall_common(real_regs,
+					 (const char __user **)&PT_REGS_PARM1(real_regs),
+					 (const char __user *const __user *)PT_REGS_PARM2(real_regs));
+}
+
+static int sys_execveat_handler_pre(struct kprobe *p, struct pt_regs *regs)
+{
+	struct pt_regs *real_regs = PT_REAL_REGS(regs);
+	// New bionic maps execve to execveat(AT_FDCWD, path, argv, envp, 0)
+	if ((int)PT_REGS_PARM1(real_regs) != AT_FDCWD ||
+	    (int)PT_REGS_SYSCALL_PARM4(real_regs) != 0)
+		return 0;
+	return ksu_execve_syscall_common(real_regs,
+					 (const char __user **)&PT_REGS_PARM2(real_regs),
+					 (const char __user *const __user *)PT_REGS_PARM3(real_regs));
 }
 
 static int sys_read_handler_pre(struct kprobe *p, struct pt_regs *regs)
@@ -663,6 +681,10 @@ static struct kprobe execve_kp = {
 	.symbol_name = SYS_EXECVE_SYMBOL,
 	.pre_handler = sys_execve_handler_pre,
 };
+static struct kprobe execveat_kp = {
+	.symbol_name = SYS_EXECVEAT_SYMBOL,
+	.pre_handler = sys_execveat_handler_pre,
+};
 static struct kprobe sys_read_kp = {
 	.symbol_name = SYS_READ_SYMBOL,
 	.pre_handler = sys_read_handler_pre,
@@ -688,6 +710,7 @@ static void do_stop_init_rc_hook(struct work_struct *work)
 
 static void do_stop_execve_hook(struct work_struct *work)
 {
+	unregister_kprobe(&execveat_kp);
 	unregister_kprobe(&execve_kp);
 }
 
@@ -887,6 +910,14 @@ void __init ksu_ksud_init()
 	ret = register_kprobe(&execve_kp);
 	pr_info("ksud: execve_kp: %d\n", ret);
 
+	ret = register_kprobe(&execveat_kp);
+	// execveat is always present on supported kernels, but do not
+	// fail hard if the symbol is unavailable (e.g. stripped kernels)
+	if (ret)
+		pr_info("ksud: execveat_kp not available: %d\n", ret);
+	else
+		pr_info("ksud: execveat_kp: %d\n", ret);
+
 	ret = register_kprobe(&sys_read_kp);
 	pr_info("ksud: sys_read_kp: %d\n", ret);
 
@@ -905,6 +936,7 @@ void __init ksu_ksud_init()
 void __exit ksu_ksud_exit()
 {
 #ifdef KSU_KPROBES_HOOK
+	unregister_kprobe(&execveat_kp);
 	unregister_kprobe(&execve_kp);
 	// this should be done before unregister sys_read_kp
 	// unregister_kprobe(&sys_read_kp);

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -73,10 +73,13 @@ static struct work_struct __maybe_unused stop_execve_hook_work;
 static struct work_struct __maybe_unused stop_input_hook_work;
 #else
 bool ksu_init_rc_hook __read_mostly = true;
+#endif
+
+// These are referenced directly from patched kernel sources (manual hook
+// integration points), so they must exist in every build configuration
 bool __maybe_unused ksu_vfs_read_hook = true;
 bool ksu_input_hook __read_mostly = true;
 bool ksu_execveat_hook __read_mostly = true;
-#endif
 
 #define MAX_ARG_STRINGS 0x7FFFFFFF
 struct user_arg_ptr {

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -172,6 +172,13 @@ static int apply_kernelsu_rules_fn(void *ptr)
     ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "getopt");
     ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "getattr");
 
+    // use memfd created by su domain
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "memfd_file", "execute");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "memfd_file", "getattr");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "memfd_file", "map");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "memfd_file", "read");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "memfd_file", "write");
+
     // bootctl
     ksu_allow(db, "hwservicemanager", KERNEL_SU_DOMAIN, "dir", "search");
     ksu_allow(db, "hwservicemanager", KERNEL_SU_DOMAIN, "file", "read");

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -492,6 +492,8 @@ static bool add_filename_trans(struct policydb *db, const char *s,
 {
     struct type_datum *src, *tgt, *def;
     struct class_datum *cls;
+    struct filename_trans_key *new_key = NULL;
+    int rc;
 
     src = symtab_search(&db->p_types, s);
     if (src == NULL) {
@@ -515,6 +517,8 @@ static bool add_filename_trans(struct policydb *db, const char *s,
     }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0)
+	struct filename_trans_key *new_key = NULL;
+	int rc;
 	struct filename_trans_key key;
 	key.ttype = tgt->value;
 	key.tclass = cls->value;
@@ -542,47 +546,86 @@ static bool add_filename_trans(struct policydb *db, const char *s,
     if (trans == NULL) {
         trans = (struct filename_trans_datum *)kcalloc(1, sizeof(*trans),
                                                        GFP_KERNEL);
-		struct filename_trans_key *new_key =
-			(struct filename_trans_key *)kzalloc(sizeof(*new_key), GFP_KERNEL);
-		*new_key = key;
-		new_key->name = kstrdup(key.name, GFP_KERNEL);
-		trans->next = last;
-		trans->otype = def->value;
-		hashtab_insert(&db->filename_trans, new_key, trans,
-                       filenametr_key_params);
-	}
+        if (!trans) {
+            pr_err("add_filename_trans: alloc filename_trans_datum failed\n");
+            goto out;
+        }
+        new_key = kzalloc(sizeof(*new_key), GFP_KERNEL);
+        if (!new_key) {
+            pr_err("add_filename_trans: alloc filename_trans_key failed\n");
+            goto free_trans;
+        }
+        *new_key = key;
+        new_key->name = kstrdup(key.name, GFP_KERNEL);
+        if (!new_key->name) {
+            pr_err("add_filename_trans: kstrdup name failed\n");
+            goto free_key;
+        }
+        trans->next = last;
+        trans->otype = def->value;
+        rc = hashtab_insert(&db->filename_trans, new_key, trans,
+                            filenametr_key_params);
+        if (rc) {
+            pr_err("add_filename_trans: hashtab_insert failed: %d\n", rc);
+            goto free_name;
+        }
+    }
 
-	db->compat_filename_trans_count++;
-	return ebitmap_set_bit(&trans->stypes, src->value - 1, 1) == 0;
+    db->compat_filename_trans_count++;
+    return ebitmap_set_bit(&trans->stypes, src->value - 1, 1) == 0;
+
+free_name:
+    kfree(new_key->name);
+free_key:
+    kfree(new_key);
+free_trans:
+    kfree(trans);
+out:
+    return false;
 #else // < 5.7.0, has no filename_trans_key, but struct filename_trans
 
-	struct filename_trans key;
-	key.ttype = tgt->value;
-	key.tclass = cls->value;
-	key.name = (char *)o;
+    struct filename_trans key;
+    key.ttype = tgt->value;
+    key.tclass = cls->value;
+    key.name = (char *)o;
 
-	struct filename_trans_datum *trans = hashtab_search(db->filename_trans, &key);
+    struct filename_trans_datum *trans = hashtab_search(db->filename_trans, &key);
 
-	if (trans == NULL) {
-		trans = (struct filename_trans_datum *)kcalloc(sizeof(*trans), 1,
+    if (trans == NULL) {
+        trans = (struct filename_trans_datum *)kcalloc(1, sizeof(*trans),
                                                        GFP_KERNEL);
-		if (!trans) {
-			pr_err("add_filename_trans: Failed to alloc datum\n");
-			return false;
-		}
-		struct filename_trans *new_key =
-			(struct filename_trans *)kzalloc(sizeof(*new_key), GFP_KERNEL);
-		if (!new_key) {
-			pr_err("add_filename_trans: Failed to alloc new_key\n");
-			return false;
-		}
-		*new_key = key;
-		new_key->name = kstrdup(key.name, GFP_KERNEL);
-		trans->otype = def->value;
-		hashtab_insert(db->filename_trans, new_key, trans);
-	}
+        if (!trans) {
+            pr_err("add_filename_trans: Failed to alloc datum\n");
+            return false;
+        }
+        struct filename_trans *new_key =
+            (struct filename_trans *)kzalloc(sizeof(*new_key), GFP_KERNEL);
+        if (!new_key) {
+            pr_err("add_filename_trans: Failed to alloc new_key\n");
+            goto free_trans_pre57;
+        }
+        *new_key = key;
+        new_key->name = kstrdup(key.name, GFP_KERNEL);
+        if (!new_key->name) {
+            pr_err("add_filename_trans: Failed to alloc name\n");
+            goto free_key_pre57;
+        }
+        trans->otype = def->value;
+        if (hashtab_insert(db->filename_trans, new_key, trans)) {
+            pr_err("add_filename_trans: hashtab_insert failed\n");
+            goto free_name_pre57;
+        }
+    }
 
-	return ebitmap_set_bit(&db->filename_trans_ttypes, src->value - 1, 1) == 0;
+    return ebitmap_set_bit(&db->filename_trans_ttypes, src->value - 1, 1) == 0;
+
+free_name_pre57:
+    kfree(new_key->name);
+free_key_pre57:
+    kfree(new_key);
+free_trans_pre57:
+    kfree(trans);
+    return false;
 #endif
 }
 

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -492,8 +492,6 @@ static bool add_filename_trans(struct policydb *db, const char *s,
 {
     struct type_datum *src, *tgt, *def;
     struct class_datum *cls;
-    struct filename_trans_key *new_key = NULL;
-    int rc;
 
     src = symtab_search(&db->p_types, s);
     if (src == NULL) {
@@ -585,6 +583,7 @@ out:
 #else // < 5.7.0, has no filename_trans_key, but struct filename_trans
 
     struct filename_trans key;
+    struct filename_trans *new_key = NULL;
     key.ttype = tgt->value;
     key.tclass = cls->value;
     key.name = (char *)o;
@@ -598,8 +597,7 @@ out:
             pr_err("add_filename_trans: Failed to alloc datum\n");
             return false;
         }
-        struct filename_trans *new_key =
-            (struct filename_trans *)kzalloc(sizeof(*new_key), GFP_KERNEL);
+        new_key = (struct filename_trans *)kzalloc(sizeof(*new_key), GFP_KERNEL);
         if (!new_key) {
             pr_err("add_filename_trans: Failed to alloc new_key\n");
             goto free_trans_pre57;

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -515,6 +515,8 @@ static bool add_filename_trans(struct policydb *db, const char *s,
     }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0)
+	struct filename_trans_key *new_key = NULL;
+	int rc;
 	struct filename_trans_key key;
 	key.ttype = tgt->value;
 	key.tclass = cls->value;
@@ -542,47 +544,86 @@ static bool add_filename_trans(struct policydb *db, const char *s,
     if (trans == NULL) {
         trans = (struct filename_trans_datum *)kcalloc(1, sizeof(*trans),
                                                        GFP_KERNEL);
-		struct filename_trans_key *new_key =
-			(struct filename_trans_key *)kzalloc(sizeof(*new_key), GFP_KERNEL);
-		*new_key = key;
-		new_key->name = kstrdup(key.name, GFP_KERNEL);
-		trans->next = last;
-		trans->otype = def->value;
-		hashtab_insert(&db->filename_trans, new_key, trans,
-                       filenametr_key_params);
-	}
+        if (!trans) {
+            pr_err("add_filename_trans: alloc filename_trans_datum failed\n");
+            goto out;
+        }
+        new_key = kzalloc(sizeof(*new_key), GFP_KERNEL);
+        if (!new_key) {
+            pr_err("add_filename_trans: alloc filename_trans_key failed\n");
+            goto free_trans;
+        }
+        *new_key = key;
+        new_key->name = kstrdup(key.name, GFP_KERNEL);
+        if (!new_key->name) {
+            pr_err("add_filename_trans: kstrdup name failed\n");
+            goto free_key;
+        }
+        trans->next = last;
+        trans->otype = def->value;
+        rc = hashtab_insert(&db->filename_trans, new_key, trans,
+                            filenametr_key_params);
+        if (rc) {
+            pr_err("add_filename_trans: hashtab_insert failed: %d\n", rc);
+            goto free_name;
+        }
+    }
 
-	db->compat_filename_trans_count++;
-	return ebitmap_set_bit(&trans->stypes, src->value - 1, 1) == 0;
+    db->compat_filename_trans_count++;
+    return ebitmap_set_bit(&trans->stypes, src->value - 1, 1) == 0;
+
+free_name:
+    kfree(new_key->name);
+free_key:
+    kfree(new_key);
+free_trans:
+    kfree(trans);
+out:
+    return false;
 #else // < 5.7.0, has no filename_trans_key, but struct filename_trans
 
-	struct filename_trans key;
-	key.ttype = tgt->value;
-	key.tclass = cls->value;
-	key.name = (char *)o;
+    struct filename_trans key;
+    struct filename_trans *new_key = NULL;
+    key.ttype = tgt->value;
+    key.tclass = cls->value;
+    key.name = (char *)o;
 
-	struct filename_trans_datum *trans = hashtab_search(db->filename_trans, &key);
+    struct filename_trans_datum *trans = hashtab_search(db->filename_trans, &key);
 
-	if (trans == NULL) {
-		trans = (struct filename_trans_datum *)kcalloc(sizeof(*trans), 1,
+    if (trans == NULL) {
+        trans = (struct filename_trans_datum *)kcalloc(1, sizeof(*trans),
                                                        GFP_KERNEL);
-		if (!trans) {
-			pr_err("add_filename_trans: Failed to alloc datum\n");
-			return false;
-		}
-		struct filename_trans *new_key =
-			(struct filename_trans *)kzalloc(sizeof(*new_key), GFP_KERNEL);
-		if (!new_key) {
-			pr_err("add_filename_trans: Failed to alloc new_key\n");
-			return false;
-		}
-		*new_key = key;
-		new_key->name = kstrdup(key.name, GFP_KERNEL);
-		trans->otype = def->value;
-		hashtab_insert(db->filename_trans, new_key, trans);
-	}
+        if (!trans) {
+            pr_err("add_filename_trans: Failed to alloc datum\n");
+            return false;
+        }
+        new_key = (struct filename_trans *)kzalloc(sizeof(*new_key), GFP_KERNEL);
+        if (!new_key) {
+            pr_err("add_filename_trans: Failed to alloc new_key\n");
+            goto free_trans_pre57;
+        }
+        *new_key = key;
+        new_key->name = kstrdup(key.name, GFP_KERNEL);
+        if (!new_key->name) {
+            pr_err("add_filename_trans: Failed to alloc name\n");
+            goto free_key_pre57;
+        }
+        trans->otype = def->value;
+        if (hashtab_insert(db->filename_trans, new_key, trans)) {
+            pr_err("add_filename_trans: hashtab_insert failed\n");
+            goto free_name_pre57;
+        }
+    }
 
-	return ebitmap_set_bit(&db->filename_trans_ttypes, src->value - 1, 1) == 0;
+    return ebitmap_set_bit(&db->filename_trans_ttypes, src->value - 1, 1) == 0;
+
+free_name_pre57:
+    kfree(new_key->name);
+free_key_pre57:
+    kfree(new_key);
+free_trans_pre57:
+    kfree(trans);
+    return false;
 #endif
 }
 

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -515,8 +515,6 @@ static bool add_filename_trans(struct policydb *db, const char *s,
     }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0)
-	struct filename_trans_key *new_key = NULL;
-	int rc;
 	struct filename_trans_key key;
 	key.ttype = tgt->value;
 	key.tclass = cls->value;
@@ -544,86 +542,47 @@ static bool add_filename_trans(struct policydb *db, const char *s,
     if (trans == NULL) {
         trans = (struct filename_trans_datum *)kcalloc(1, sizeof(*trans),
                                                        GFP_KERNEL);
-        if (!trans) {
-            pr_err("add_filename_trans: alloc filename_trans_datum failed\n");
-            goto out;
-        }
-        new_key = kzalloc(sizeof(*new_key), GFP_KERNEL);
-        if (!new_key) {
-            pr_err("add_filename_trans: alloc filename_trans_key failed\n");
-            goto free_trans;
-        }
-        *new_key = key;
-        new_key->name = kstrdup(key.name, GFP_KERNEL);
-        if (!new_key->name) {
-            pr_err("add_filename_trans: kstrdup name failed\n");
-            goto free_key;
-        }
-        trans->next = last;
-        trans->otype = def->value;
-        rc = hashtab_insert(&db->filename_trans, new_key, trans,
-                            filenametr_key_params);
-        if (rc) {
-            pr_err("add_filename_trans: hashtab_insert failed: %d\n", rc);
-            goto free_name;
-        }
-    }
+		struct filename_trans_key *new_key =
+			(struct filename_trans_key *)kzalloc(sizeof(*new_key), GFP_KERNEL);
+		*new_key = key;
+		new_key->name = kstrdup(key.name, GFP_KERNEL);
+		trans->next = last;
+		trans->otype = def->value;
+		hashtab_insert(&db->filename_trans, new_key, trans,
+                       filenametr_key_params);
+	}
 
-    db->compat_filename_trans_count++;
-    return ebitmap_set_bit(&trans->stypes, src->value - 1, 1) == 0;
-
-free_name:
-    kfree(new_key->name);
-free_key:
-    kfree(new_key);
-free_trans:
-    kfree(trans);
-out:
-    return false;
+	db->compat_filename_trans_count++;
+	return ebitmap_set_bit(&trans->stypes, src->value - 1, 1) == 0;
 #else // < 5.7.0, has no filename_trans_key, but struct filename_trans
 
-    struct filename_trans key;
-    struct filename_trans *new_key = NULL;
-    key.ttype = tgt->value;
-    key.tclass = cls->value;
-    key.name = (char *)o;
+	struct filename_trans key;
+	key.ttype = tgt->value;
+	key.tclass = cls->value;
+	key.name = (char *)o;
 
-    struct filename_trans_datum *trans = hashtab_search(db->filename_trans, &key);
+	struct filename_trans_datum *trans = hashtab_search(db->filename_trans, &key);
 
-    if (trans == NULL) {
-        trans = (struct filename_trans_datum *)kcalloc(1, sizeof(*trans),
+	if (trans == NULL) {
+		trans = (struct filename_trans_datum *)kcalloc(sizeof(*trans), 1,
                                                        GFP_KERNEL);
-        if (!trans) {
-            pr_err("add_filename_trans: Failed to alloc datum\n");
-            return false;
-        }
-        new_key = (struct filename_trans *)kzalloc(sizeof(*new_key), GFP_KERNEL);
-        if (!new_key) {
-            pr_err("add_filename_trans: Failed to alloc new_key\n");
-            goto free_trans_pre57;
-        }
-        *new_key = key;
-        new_key->name = kstrdup(key.name, GFP_KERNEL);
-        if (!new_key->name) {
-            pr_err("add_filename_trans: Failed to alloc name\n");
-            goto free_key_pre57;
-        }
-        trans->otype = def->value;
-        if (hashtab_insert(db->filename_trans, new_key, trans)) {
-            pr_err("add_filename_trans: hashtab_insert failed\n");
-            goto free_name_pre57;
-        }
-    }
+		if (!trans) {
+			pr_err("add_filename_trans: Failed to alloc datum\n");
+			return false;
+		}
+		struct filename_trans *new_key =
+			(struct filename_trans *)kzalloc(sizeof(*new_key), GFP_KERNEL);
+		if (!new_key) {
+			pr_err("add_filename_trans: Failed to alloc new_key\n");
+			return false;
+		}
+		*new_key = key;
+		new_key->name = kstrdup(key.name, GFP_KERNEL);
+		trans->otype = def->value;
+		hashtab_insert(db->filename_trans, new_key, trans);
+	}
 
-    return ebitmap_set_bit(&db->filename_trans_ttypes, src->value - 1, 1) == 0;
-
-free_name_pre57:
-    kfree(new_key->name);
-free_key_pre57:
-    kfree(new_key);
-free_trans_pre57:
-    kfree(trans);
-    return false;
+	return ebitmap_set_bit(&db->filename_trans_ttypes, src->value - 1, 1) == 0;
 #endif
 }
 

--- a/kernel/sulog/event.c
+++ b/kernel/sulog/event.c
@@ -13,6 +13,11 @@
 #include <linux/string.h>
 #include <linux/uaccess.h>
 
+// untagged_addr is a macro in mm.h on x86 before 6.2
+#if defined(__x86_64__) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#include <linux/mm.h>
+#endif
+
 #include "compat/kernel_compat.h"
 #include "feature/sulog.h"
 #include "infra/event_queue.h"


### PR DESCRIPTION
## Summary

Update for the legacy (non-GKI) branch, build-tested on a real non-GKI kernel (Xiaomi sm8150 raphael 4.14 vendor tree) in **both** `KSU_MANUAL_HOOK` and `KSU_KPROBES_HOOK` configurations, and verified working on device.

### New: third hooking scheme — syscall table patching (`CONFIG_KSU_SYSCALL_TABLE_HOOK`)
For non-GKI kernels where kprobes are missing or broken (arm64/x86_64, >= 4.17):
- `infra/symbol_resolver`: kallsyms lookup with `.cfi_jt` / variant handling
- `hook/patch_memory`: fixmap-based text poking via stop_machine (merged arm64+x86_64 implementations with compat down to pre-4.12 p4d / pre-5.8 probe_kernel_write)
- `hook/syscall_table_hook`: patches sys_call_table entries for execve/execveat/faccessat/newfstatat with wrappers running the existing KSU handlers, then calling the original syscall; originals restored on exit
- Kconfig: kprobe-hook and table-hook are now a proper choice

### execveat support for new bionic (A17 QPR2+ maps execve -> execveat(AT_FDCWD, ...))
- sucompat: common handler + AT_FDCWD/flags validation, new exported execveat variant
- adb_root: refactor + `ksu_adb_root_handle_execveat()`
- hook_manager: separate execve/execveat dispatch; adb_root wired into the init exec path (was previously never called from any hook); sucompat now receives real pt_regs (argv was read through a NULL regs pointer)
- ksud_integration: additional kprobe on `sys_execveat` so init->ksud detection keeps working when execve is remapped

### Hardening / fixes ported from dev
- apk_sign: AOSP-aligned signing block parser (length-prefixed pairs walk, ZIP64 rejection), kernel_read() result checks via compat wrapper, dropped v1 signature check. EOCD search uses the buffered 64K backward scan — the upstream byte-by-byte variant performs up to 65535 two-byte reads per APK and stalls boot while scanning /data/app (confirmed on device)
- sepolicy: missing NULL checks in add_filename_trans for both >=5.7 and <5.7 paths
- tracepoint registered with minimum priority so perf/bpf probes run first (>= 4.4 guard)
- stub_zygote no longer unmarked (fixes Meta Quest soft-reboot issue)
- SELinux rule: allow domain to use memfd created by ksu domain
- event_queue: propagate wait_ready error as read() return value
- selinux_hide: fake status sequence computed from policyload

### Old-kernel build fixes (found while validating on 4.14)
sepolicy variable scoping (<5.7), SYS_EXECVEAT_SYMBOL for pre-4.16 symbol names, hook state bools defined in every mode (referenced from patched kernel sources), patch_memory pte/icache compat, sulog untagged_addr include for x86 < 6.2, header init.h include.

### Kbuild
Allow pinning `KSU_VERSION` / `KSU_VERSION_TAG` from the make command line for integrators backporting onto release branches.