### PR TITLE
selinux hide: spoof status page and avd seqno (https://github.com/tiann/KernelSU/pull/3647)

### DIFF
--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -188,6 +188,8 @@ static ssize_t my_write_access(struct file *file, char *buf, size_t size)
     security_compute_av_user(&fake_state, ssid, tsid, tclass, &avd);
 #endif
 
+    // stock reads 1; a loader load_policy may have bumped the backup before we load
+    avd.seqno = 1;
     length = scnprintf(buf, SIMPLE_TRANSACTION_LIMIT, "%x %x %x %x %u %x", avd.allowed, 0xffffffff, avd.auditallow,
                        avd.auditdeny, avd.seqno, avd.flags);
 out:
@@ -269,12 +271,21 @@ static void initialize_fake_status()
 
     struct selinux_kernel_status *new_status = page_address(new_page);
     memcpy(new_status, status, sizeof(*status));
-    if (ksu_late_loaded && !new_status->enforcing) {
-        // In late_load mode, we may be loaded when selinux was set to permissive
-        // So we need to modify the sequence value
-        // We assume that setenforce 0 is just called once
-        new_status->enforcing = 1;
-        new_status->sequence = new_status->policyload ? 4 : 0;
+    if (ksu_late_loaded) {
+        // In late_load mode the loader may have reloaded sepolicy before us,
+        // so the captured page is not stock. Serve what a stock boot ends
+        // with instead: creation sentinel below 6.10, one load plus one
+        // setenforce above.
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
+        new_status->sequence = 4;
+        new_status->policyload = 1;
+#else
+        new_status->sequence = 0;
+        new_status->policyload = 0;
+#endif
+        if (!new_status->enforcing) {
+            new_status->enforcing = 1;
+        }
     }
 
     fake_status = new_page;


### PR DESCRIPTION
```
Author: chise <lqff.yt@gmail.com>
Date:   Tue Aug 25 16:18:55 2026 +0700
```
sets both to the stock value for the kernel: sequence 0 and policyload 0 below 6.10, sequence 4 and policyload 1 on 6.10 and up.

on late load, the backup can be done after policy is modified (such as when we use exploit to turn selinux to permissive then do loadd_policy to reload policy after the exploit fucks it up. so restore avd seqno to 1