### PR TITLE
refactor(kernel): Perform umount for webview zygote (https://github.com/tiann/KernelSU/pull/3630)

### DIFF
--- a/kernel/feature/kernel_umount.c
+++ b/kernel/feature/kernel_umount.c
@@ -2,6 +2,7 @@
 #include <linux/slab.h>
 #include <linux/task_work.h>
 #include <linux/cred.h>
+#include <linux/compiler.h>
 #include <linux/fs.h>
 #include <linux/mount.h>
 #include <linux/namei.h>
@@ -19,6 +20,7 @@
 #include "ksu.h"
 
 static bool ksu_kernel_umount_enabled = true;
+bool ksu_webview_zygote_umount_enabled = false;
 
 static int kernel_umount_feature_get(u64 *value)
 {
@@ -39,6 +41,27 @@ static const struct ksu_feature_handler kernel_umount_handler = {
 	.name = "kernel_umount",
 	.get_handler = kernel_umount_feature_get,
 	.set_handler = kernel_umount_feature_set,
+};
+
+static int webview_zygote_umount_feature_get(u64 *value)
+{
+	*value = ksu_webview_zygote_umount_enabled ? 1 : 0;
+	return 0;
+}
+
+static int webview_zygote_umount_feature_set(u64 value)
+{
+	bool enable = value != 0;
+	ksu_webview_zygote_umount_enabled = enable;
+	pr_info("webview_zygote_umount: set to %d\n", enable);
+	return 0;
+}
+
+static const struct ksu_feature_handler webview_zygote_umount_handler = {
+	.feature_id = KSU_FEATURE_WEBVIEW_ZYGOTE_UMOUNT,
+	.name = "webview_zygote_umount",
+	.get_handler = webview_zygote_umount_feature_get,
+	.set_handler = webview_zygote_umount_feature_set,
 };
 
 extern int path_umount(struct path *path, int flags);
@@ -87,10 +110,10 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
 	// 1. Normal app: zygote -> appuid
 	// 2. Isolated process forked from zygote: zygote -> isolated_process
 	// 3. App zygote forked from zygote: zygote -> appuid
-	// 4. Webview zygote forked from zygote: zygote -> WEBVIEW_ZYGOTE_UID (no need to handle, app cannot run custom code)
+	// 4. Webview zygote forked from zygote: zygote -> webview_zygote (controlled by feature policy)
 	// 5. Isolated process forked from app zygote: appuid -> isolated_process (already handled by 3)
-	// 6. Isolated process forked from webview zygote (no need to handle, app cannot run custom code)
-	if (!is_appuid(new_uid) && !is_isolated_process(new_uid)) {
+	// 6. Isolated process forked from webview zygote (already handled by 4)
+	if (!is_appuid(new_uid) && new_uid != WEBVIEW_ZYGOTE_UID && !is_isolated_process(new_uid)) {
 		return 0;
 	}
 
@@ -130,9 +153,13 @@ void __init ksu_kernel_umount_init(void)
 	if (ksu_register_feature_handler(&kernel_umount_handler)) {
 		pr_err("Failed to register kernel_umount feature handler\n");
 	}
+	if (ksu_register_feature_handler(&webview_zygote_umount_handler)) {
+		pr_err("Failed to register webview_zygote_umount feature handler\n");
+	}
 }
 
 void __exit ksu_kernel_umount_exit(void)
 {
+	ksu_unregister_feature_handler(KSU_FEATURE_WEBVIEW_ZYGOTE_UMOUNT);
 	ksu_unregister_feature_handler(KSU_FEATURE_KERNEL_UMOUNT);
 }

--- a/kernel/feature/kernel_umount.h
+++ b/kernel/feature/kernel_umount.h
@@ -7,6 +7,7 @@
 
 void ksu_kernel_umount_init(void);
 void ksu_kernel_umount_exit(void);
+extern bool ksu_webview_zygote_umount_enabled;
 
 // Handler function to be called from setresuid hook
 int ksu_handle_umount(uid_t old_uid, uid_t new_uid);

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -18,6 +18,7 @@
 
 #include "klog.h" // IWYU pragma: keep
 #include "ksu.h"
+#include "feature/kernel_umount.h"
 #include "runtime/ksud_boot.h"
 #include "selinux/selinux.h"
 #include "policy/allowlist.h"
@@ -302,8 +303,7 @@ bool ksu_uid_should_umount(uid_t uid)
         return false;
     }
     if (unlikely(uid == WEBVIEW_ZYGOTE_UID)) {
-        // we should not umount for webview zygote
-        return false;
+        return ksu_webview_zygote_umount_enabled;
     }
 #ifdef CONFIG_KSU_DISABLE_POLICY
     return !__ksu_is_allow_uid(uid);

--- a/manager/app/src/main/cpp/jni.cc
+++ b/manager/app/src/main/cpp/jni.cc
@@ -400,6 +400,18 @@ Java_com_rifsxd_ksunext_Natives_setAdbRootEnabled(JNIEnv *env, jobject thiz, jbo
 
 extern "C"
 JNIEXPORT jboolean JNICALL
+Java_com_rifsxd_ksunext_Natives_isWebViewZygoteUmountEnabled(JNIEnv *env, jobject thiz) {
+    return is_webview_zygote_umount_enabled();
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_rifsxd_ksunext_Natives_setWebViewZygoteUmountEnabled(JNIEnv *env, jobject thiz, jboolean enabled) {
+    return set_webview_zygote_umount_enabled(enabled);
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
 Java_com_rifsxd_ksunext_Natives_isSelinuxHideEnabled(JNIEnv *env, jobject thiz) {
     return is_selinux_hide_enabled();
 }

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -224,6 +224,22 @@ bool is_adb_root_enabled() {
     return value != 0;
 }
 
+bool set_webview_zygote_umount_enabled(bool enabled) {
+    return set_feature(KSU_FEATURE_WEBVIEW_ZYGOTE_UMOUNT, enabled ? 1 : 0);
+}
+
+bool is_webview_zygote_umount_enabled() {
+    uint64_t value = 0;
+    bool supported = false;
+    if (!get_feature(KSU_FEATURE_WEBVIEW_ZYGOTE_UMOUNT, &value, &supported)) {
+        return false;
+    }
+    if (!supported) {
+        return false;
+    }
+    return value != 0;
+}
+
 int set_selinux_hide_enabled(bool enabled) {
     if (!set_feature(KSU_FEATURE_SELINUX_HIDE, enabled ? 1 : 0)) {
         return -errno;

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -52,6 +52,11 @@ bool set_kernel_umount_enabled(bool enabled);
 
 bool is_kernel_umount_enabled();
 
+// WebView zygote umount
+bool set_webview_zygote_umount_enabled(bool enabled);
+
+bool is_webview_zygote_umount_enabled();
+
 // ADB root
 bool set_adb_root_enabled(bool enabled);
 

--- a/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
@@ -107,6 +107,9 @@ object Natives {
     external fun isKernelUmountEnabled(): Boolean
     external fun setKernelUmountEnabled(enabled: Boolean): Boolean
 
+    external fun isWebViewZygoteUmountEnabled(): Boolean
+    external fun setWebViewZygoteUmountEnabled(enabled: Boolean): Boolean
+
     /**
      * ADB root can be enabled/disabled.
      *  0: disabled

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
@@ -116,6 +116,7 @@ fun SettingScreen(navigator: DestinationsNavigator) {
 
     var suCompatStatus by rememberSaveable { mutableStateOf("") }
     var kernelUmountStatus by rememberSaveable { mutableStateOf("") }
+    var webViewZygoteUmountStatus by rememberSaveable { mutableStateOf("") }
     var adbRootStatus by rememberSaveable { mutableStateOf("") }
     var selinuxHideStatus by rememberSaveable { mutableStateOf("") }
     var sulogStatus by rememberSaveable { mutableStateOf("") }
@@ -125,6 +126,7 @@ fun SettingScreen(navigator: DestinationsNavigator) {
     LaunchedEffect(Unit) {
         suCompatStatus = getFeatureStatus("su_compat")
         kernelUmountStatus = getFeatureStatus("kernel_umount")
+        webViewZygoteUmountStatus = getFeatureStatus("webview_zygote_umount")
         sulogStatus = getFeatureStatus("sulog")
         isSulogEnabled = getFeaturePersistValue("sulog") == 1L
         adbRootStatus = getFeatureStatus("adb_root")
@@ -162,6 +164,7 @@ fun SettingScreen(navigator: DestinationsNavigator) {
                 KernelFeaturesCard(
                     suCompatStatus = suCompatStatus,
                     kernelUmountStatus = kernelUmountStatus,
+                    webViewZygoteUmountStatus = webViewZygoteUmountStatus,
                     sulogStatusParam = sulogStatus,
                     isSulogEnabled = isSulogEnabled,
                     onSulogEnabledChange = { isSulogEnabled = it },
@@ -195,6 +198,7 @@ fun SettingScreen(navigator: DestinationsNavigator) {
 private fun KernelFeaturesCard(
     suCompatStatus: String,
     kernelUmountStatus: String,
+    webViewZygoteUmountStatus: String,
     sulogStatusParam: String,
     isSulogEnabled: Boolean,
     onSulogEnabledChange: (Boolean) -> Unit,
@@ -206,6 +210,7 @@ private fun KernelFeaturesCard(
     val context = LocalContext.current
     val suCompatSupported = suCompatStatus == "supported"
     val kernelUmountSupported = kernelUmountStatus == "supported"
+    val webViewZygoteUmountSupported = webViewZygoteUmountStatus == "supported"
     val sulogSupported = sulogStatusParam == "supported"
     val adbRootSupported = adbRootStatus == "supported"
     val selinuxHideSupported = selinuxHideStatus == "supported"
@@ -278,6 +283,28 @@ private fun KernelFeaturesCard(
                     execKsud("feature save", true)
                     prefsLocal.edit { putInt("kernel_umount_mode", if (checked) 0 else 2) }
                     isKernelUmountEnabled = checked
+                }
+            }
+
+            var isWebViewZygoteUmountEnabled by rememberSaveable {
+                mutableStateOf(Natives.isWebViewZygoteUmountEnabled())
+            }
+            SwitchItem(
+                icon = Icons.Filled.Language,
+                title = stringResource(id = R.string.settings_webview_zygote_umount),
+                summary = if (webViewZygoteUmountSupported) {
+                    stringResource(id = R.string.settings_webview_zygote_umount_summary)
+                } else {
+                    stringResource(id = R.string.feature_status_unsupported_summary)
+                },
+                checked = isWebViewZygoteUmountEnabled,
+                enabled = webViewZygoteUmountSupported,
+                modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp)),
+                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+            ) { checked ->
+                if (Natives.setWebViewZygoteUmountEnabled(checked)) {
+                    execKsud("feature save", true)
+                    isWebViewZygoteUmountEnabled = checked
                 }
             }
 

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -232,6 +232,8 @@
   <string name="settings_enable_su_summary">允许任何应用通过 su 命令获取 root 权限（已有的 root 进程不受影响）。</string>
   <string name="settings_enable_kernel_umount">内核处理卸载模块</string>
   <string name="settings_enable_kernel_umount_summary">在内核层面卸载模块。</string>
+  <string name="settings_webview_zygote_umount">为 WebView 卸载模块</string>
+  <string name="settings_webview_zygote_umount_summary">防止 WebView 进程泄露信息，但可能会导致模块失效。重启后生效</string>
   <string name="settings_enable_avc_spoof">AVC 日志伪装</string>
   <string name="settings_enable_avc_spoof_summary">修复日志中 avc denial 导致的 SELinux 上下文泄漏。</string>
   <string name="manage_repositories">管理仓库</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -226,6 +226,8 @@
     <string name="module_sort_webui_first">Sort (WebUI first)</string>
     <string name="settings_enable_kernel_umount">Kernel umount</string>
     <string name="settings_enable_kernel_umount_summary">Umount modules at kernel-level.</string>
+    <string name="settings_webview_zygote_umount">Unmount for WebView</string>
+    <string name="settings_webview_zygote_umount_summary">Prevent information leaks from WebView process but may break modules. Reboot to apply</string>
     <string name="settings_sulog">SU Log</string>
     <string name="settings_sulog_summary">Record root requests into KernelSU sulog files.</string>
     <string name="settings_adb_root" translatable="false">ADB Root</string>

--- a/uapi/feature.h
+++ b/uapi/feature.h
@@ -7,6 +7,7 @@ enum ksu_feature_id {
     KSU_FEATURE_SULOG = 2,
     KSU_FEATURE_ADB_ROOT = 3,
     KSU_FEATURE_SELINUX_HIDE = 4,
+    KSU_FEATURE_WEBVIEW_ZYGOTE_UMOUNT = 5,
 
     // custom extensions
     KSU_FEATURE_AVC_SPOOF = 10003,

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -410,7 +410,7 @@ enum Profile {
 enum Feature {
     /// Get feature value and support status
     Get {
-        /// Feature ID or name (su_compat, kernel_umount, sulog, adb_root, selinux_hide)
+        /// Feature ID or name (su_compat, kernel_umount, sulog, adb_root, selinux_hide, webview_zygote_umount)
         id: String,
         /// Read from config file
         #[arg(long, default_value_t = false)]
@@ -430,7 +430,7 @@ enum Feature {
 
     /// Check feature status (supported/unsupported/managed)
     Check {
-        /// Feature ID or name (su_compat, kernel_umount, sulog, adb_root, selinux_hide)
+        /// Feature ID or name (su_compat, kernel_umount, sulog, adb_root, selinux_hide, webview_zygote_umount)
         id: String,
     },
 

--- a/userspace/ksud/src/feature.rs
+++ b/userspace/ksud/src/feature.rs
@@ -21,6 +21,7 @@ pub enum FeatureId {
     Sulog = 2,
     AdbRoot = 3,
     SelinuxHide = 4,
+    WebviewZygoteUmount = 5,
     AvcSpoof = 10003,
 }
 
@@ -32,6 +33,7 @@ impl FeatureId {
             2 => Some(Self::Sulog),
             3 => Some(Self::AdbRoot),
             4 => Some(Self::SelinuxHide),
+            5 => Some(Self::WebviewZygoteUmount),
             10003 => Some(Self::AvcSpoof),
             _ => None,
         }
@@ -44,6 +46,7 @@ impl FeatureId {
             Self::Sulog => "sulog",
             Self::AdbRoot => "adb_root",
             Self::SelinuxHide => "selinux_hide",
+            Self::WebviewZygoteUmount => "webview_zygote_umount",
             Self::AvcSpoof => "avc_spoof",
         }
     }
@@ -63,6 +66,9 @@ impl FeatureId {
             Self::SelinuxHide => {
                 "SELinux Hide - sanitize /sys/fs/selinux access results for app UIDs"
             }
+            Self::WebviewZygoteUmount => {
+                "WebView Zygote Umount - unmount modules from WebView zygote and its isolated children"
+            }
             Self::AvcSpoof => {
                 "AVC Spoof - fix selinux context leak due to avc denial"
             }
@@ -77,6 +83,7 @@ fn parse_feature_id(name: &str) -> Result<FeatureId> {
         "sulog" | "2" | "enhanced_security" => Ok(FeatureId::Sulog),
         "adb_root" | "3" => Ok(FeatureId::AdbRoot),
         "selinux_hide" | "4" => Ok(FeatureId::SelinuxHide),
+        "webview_zygote_umount" | "5" => Ok(FeatureId::WebviewZygoteUmount),
         "avc_spoof" | "10003" => Ok(FeatureId::AvcSpoof),
         _ => bail!("Unknown feature: {name}"),
     }
@@ -324,6 +331,7 @@ pub fn list_features() {
         FeatureId::Sulog,
         FeatureId::AdbRoot,
         FeatureId::SelinuxHide,
+        FeatureId::WebviewZygoteUmount,
         FeatureId::AvcSpoof,
     ];
 
@@ -388,6 +396,7 @@ pub fn save_config() -> Result<()> {
         FeatureId::Sulog,
         FeatureId::AdbRoot,
         FeatureId::SelinuxHide,
+        FeatureId::WebviewZygoteUmount,
         FeatureId::AvcSpoof,
     ];
 


### PR DESCRIPTION
```
Author: Wang Han <416810799@qq.com>
Date:   Tue Aug 25 22:57:18 2026 +0800
```

This was deliberately not done because app cannot run custom code from isolated processes forked from webview zygote. However, hidepid=2 is broken for android again.

In 2020, Jann Horn discovered that when zygote forks and specializes to app zygote, process groups are not cleaned. This makes app zygote and its child have AID_READPROC and bypass hidepid=2. This was marked as CVE-2020-0257 and fixed in 2020-08-01.

However, it is ignored that isolated process can get directly forked from zygote while no app zygote fork is needed. So isolated_app context process still may have AID_READPROC, which provides a way to bypass the hidepid=2 restrictions on /proc.

The impact is limited by SELinux because isolated_app does not have mlstrustedsubject. But it can still read cmdline, comm, maps, mountinfo etc of other isolated processes, mainly webview sandboxed processes.

Bangcle, a famous commercial app protection service in China, started to make use of this recently. An isolated process is forked and iterates through all pids, trying to open their mountinfo.

This is no doubt an exploit (almost same with CVE-2020-0257) and we have already reported it to Google. Before Google fixes it, we have no way but unmount anything for webview zygote. This is expected to break some font modules aimed at webview, but we have no choice.