### PR TITLE
fix changes in 6.18+ (https://github.com/tiann/KernelSU/pull/3480)

### DIFF
--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -974,7 +974,8 @@ struct selinux_policy *ksu_dup_sepolicy(struct selinux_policy *old_pol)
         pr_err("sepolicy: policydb_write: %d\n", ret);
         goto out_free_data;
     }
-
+    // https://android.googlesource.com/kernel/common/+/35a7845718734ae638b85b420534cb859498dab6%5E%21
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
     // https://android-review.googlesource.com/c/kernel/common/+/3009995/11/security/selinux/ss/policydb.c
     // fixup config
     // 4*2+8+4
@@ -992,7 +993,7 @@ struct selinux_policy *ksu_dup_sepolicy(struct selinux_policy *old_pol)
         }
         pr_info("new config: %u\n", *config_ptr);
     }
-
+#endif
     new_pol = kmemdup(old_pol, sizeof(*old_pol), GFP_KERNEL);
     if (!new_pol) {
         ret = -ENOMEM;


### PR DESCRIPTION
```
Author: libingxuan <84086386+aaaaaaaa-815@users.noreply.github.com>
Date:   Fri Aug 28 15:27:51 2026 +0800
```
The platform policy has been updated to use the upstream extended permission "nlmsg" instead.