### PR TITLE
manager: use in-app language picker

### DIFF
--- a/manager/app/build.gradle.kts
+++ b/manager/app/build.gradle.kts
@@ -87,9 +87,12 @@ android {
         includeInBundle = false
     }
 
-    androidResources {
-        generateLocaleConfig = true
+    bundle {
+        language {
+            enableSplit = false
+        }
     }
+
 }
 
 ksp {

--- a/manager/app/src/main/AndroidManifest.xml
+++ b/manager/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.KernelSU"

--- a/manager/app/src/main/java/com/rifsxd/ksunext/KernelSUApplication.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/KernelSUApplication.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
 import coil.Coil
 import coil.ImageLoader
+import com.rifsxd.ksunext.ui.util.LocaleHelper
 import com.rifsxd.ksunext.ui.util.createRootShellBuilder
 import com.rifsxd.ksunext.ui.viewmodel.ModuleViewModel
 import com.rifsxd.ksunext.ui.viewmodel.SuperUserViewModel
@@ -30,6 +31,7 @@ class KernelSUApplication : Application(), ViewModelStoreOwner {
 
     override fun onCreate() {
         super.onCreate()
+        LocaleHelper.migrateLegacyLocale(this)
         ksuApp = this
         Shell.setDefaultBuilder(createRootShellBuilder(true))
         Shell.enableVerboseLogging = BuildConfig.DEBUG

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Customization.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Customization.kt
@@ -1,7 +1,6 @@
 package com.rifsxd.ksunext.ui.screen
 
 import android.content.Context
-import android.content.Intent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
@@ -25,6 +24,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.edit
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.dropUnlessResumed
 import com.rifsxd.ksunext.ui.MainActivity
 import com.maxkeppeker.sheets.core.models.base.Header
@@ -102,157 +103,69 @@ fun CustomizationScreen(navigator: DestinationsNavigator) {
         ) {
 
             val context = LocalContext.current
-            val scope = rememberCoroutineScope()
-
             val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
+            var currentAppLocale by remember {
+                mutableStateOf(LocaleHelper.getCurrentAppLocale(context))
+            }
 
-            // Track language state with current app locale
-            var currentAppLocale by remember { mutableStateOf(LocaleHelper.getCurrentAppLocale(context)) }
-            
-            // Listen for preference changes
-            LaunchedEffect(Unit) {
+            LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
                 currentAppLocale = LocaleHelper.getCurrentAppLocale(context)
             }
 
-            // Language setting with selection dialog
             val languageDialog = rememberCustomDialog { dismiss ->
-                // Check if should use system language settings
-                if (LocaleHelper.useSystemLanguageSettings) {
-                    // Android 13+ - Jump to system settings
-                    LocaleHelper.launchSystemLanguageSettings(context)
-                    dismiss()
-                } else {
-                    // Android < 13 - Show app language selector
-                    // Dynamically detect supported locales from resources
-                    val supportedLocales = remember {
-                        val locales = mutableListOf<java.util.Locale>()
-                        
-                        // Add system default first
-                        locales.add(java.util.Locale.ROOT) // This will represent "System Default"
-                        
-                        // Dynamically detect available locales by checking resource directories
-                        val resourceDirs = listOf(
-                            "ar", "bg", "de", "fa", "fr", "hu", "in", "it", 
-                            "ja", "ko", "pl", "pt-rBR", "ru", "th", "tr", 
-                            "uk", "vi", "zh-rCN", "zh-rTW"
-                        )
-                        
-                        resourceDirs.forEach { dir ->
-                            try {
-                                val locale = when {
-                                    dir.contains("-r") -> {
-                                        val parts = dir.split("-r")
-                                        java.util.Locale.Builder()
-                                            .setLanguage(parts[0])
-                                            .setRegion(parts[1])
-                                            .build()
-                                    }
-                                    else -> java.util.Locale.Builder()
-                                        .setLanguage(dir)
-                                        .build()
-                                }
-                                
-                                // Test if this locale has translated resources
-                                val config = android.content.res.Configuration()
-                                config.setLocale(locale)
-                                val localizedContext = context.createConfigurationContext(config)
-                                
-                                // Try to get a translated string to verify the locale is supported
-                                val testString = localizedContext.getString(R.string.settings_language)
-                                val defaultString = context.getString(R.string.settings_language)
-                                
-                                // If the string is different or it's English, it's supported
-                                if (testString != defaultString || locale.language == "en") {
-                                    locales.add(locale)
-                                }
-                            } catch (_: Exception) {
-                                // Skip unsupported locales
-                            }
-                        }
-                        
-                        // Sort by display name
-                        val sortedLocales = locales.drop(1).sortedBy { it.getDisplayName(it) }
-                        mutableListOf<java.util.Locale>().apply {
-                            add(locales.first()) // System default first
-                            addAll(sortedLocales)
-                        }
-                    }
-                    
-                    val allOptions = supportedLocales.map { locale ->
-                        val tag = if (locale == java.util.Locale.ROOT) {
-                            "system"
-                        } else if (locale.country.isEmpty()) {
-                            locale.language
-                        } else {
-                            "${locale.language}_${locale.country}"
-                        }
-                        
-                        val displayName = if (locale == java.util.Locale.ROOT) {
-                            context.getString(R.string.system_default)
-                        } else {
-                            locale.getDisplayName(locale)
-                        }
-                        
-                        tag to displayName
-                    }
-                    
-                    val currentLocale = prefs.getString("app_locale", "system") ?: "system"
-                    val options = allOptions.map { (tag, displayName) ->
-                        ListOption(
-                            titleText = displayName,
-                            selected = currentLocale == tag
-                        )
-                    }
-                    
-                    var selectedIndex by remember { 
-                        mutableIntStateOf(allOptions.indexOfFirst { (tag, _) -> currentLocale == tag })
-                    }
-                    
-                    ListDialog(
-                        state = rememberUseCaseState(
-                            visible = true,
-                            onFinishedRequest = {
-                                if (selectedIndex >= 0 && selectedIndex < allOptions.size) {
-                                    val newLocale = allOptions[selectedIndex].first
-                                    prefs.edit { putString("app_locale", newLocale) }
-                                    
-                                    // Update local state immediately
-                                    currentAppLocale = LocaleHelper.getCurrentAppLocale(context)
-                                    
-                                    // Apply locale change immediately for Android < 13
-                                    refreshActivity(context)
-                                }
-                                dismiss()
-                            },
-                            onCloseRequest = {
-                                dismiss()
-                            }
-                        ),
-                        header = Header.Default(
-                            title = stringResource(R.string.settings_language),
-                        ),
-                        selection = ListSelection.Single(
-                            showRadioButtons = true,
-                            options = options
-                        ) { index, _ ->
-                            selectedIndex = index
-                        }
+                val allOptions = remember {
+                    listOf(
+                        LocaleHelper.SYSTEM_LANGUAGE_TAG to context.getString(R.string.system_default)
+                    ) + LocaleHelper.getSupportedLocales(context)
+                        .map { it.toLanguageTag() to it.getDisplayName(it) }
+                        .sortedBy { (_, displayName) -> displayName }
+                }
+                val currentLanguageTag = currentAppLocale?.toLanguageTag()
+                    ?: LocaleHelper.SYSTEM_LANGUAGE_TAG
+                val options = allOptions.map { (tag, displayName) ->
+                    ListOption(
+                        titleText = displayName,
+                        selected = currentLanguageTag == tag
                     )
                 }
+                var selectedIndex by remember(currentLanguageTag) {
+                    mutableIntStateOf(
+                        allOptions.indexOfFirst { (tag, _) -> currentLanguageTag == tag }
+                    )
+                }
+
+                ListDialog(
+                    state = rememberUseCaseState(
+                        visible = true,
+                        onFinishedRequest = {
+                            val languageTag = allOptions.getOrNull(selectedIndex)?.first
+                            dismiss()
+                            if (languageTag != null && languageTag != currentLanguageTag) {
+                                LocaleHelper.setAppLocale(context, languageTag)
+                                currentAppLocale = LocaleHelper.getCurrentAppLocale(context)
+                                if (!LocaleHelper.usesFrameworkLocaleManager) {
+                                    refreshActivity(context)
+                                }
+                            }
+                        },
+                        onCloseRequest = { dismiss() }
+                    ),
+                    header = Header.Default(
+                        title = stringResource(R.string.settings_language),
+                    ),
+                    selection = ListSelection.Single(
+                        showRadioButtons = true,
+                        options = options
+                    ) { index, _ ->
+                        selectedIndex = index
+                    }
+                )
             }
 
             val language = stringResource(id = R.string.settings_language)
-            
-            // Compute display name based on current app locale (similar to the reference implementation)
-            val currentLanguageDisplay = remember(currentAppLocale) {
-                val locale = currentAppLocale
-                if (locale != null) {
-                    locale.getDisplayName(locale)
-                } else {
-                    context.getString(R.string.system_default)
-                }
-            }
-            
+            val currentLanguageDisplay = currentAppLocale?.let { it.getDisplayName(it) }
+                ?: stringResource(R.string.system_default)
+
             ListItem(
                 leadingContent = { Icon(Icons.Filled.Translate, language) },
                 headlineContent = { Text(

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Customization.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Customization.kt
@@ -4,7 +4,11 @@ import android.content.Context
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -17,6 +21,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import com.rifsxd.ksunext.ui.LocalScrollState
 import com.rifsxd.ksunext.ui.rememberScrollConnection
 import androidx.compose.ui.res.stringResource
@@ -28,20 +35,13 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.dropUnlessResumed
 import com.rifsxd.ksunext.ui.MainActivity
-import com.maxkeppeker.sheets.core.models.base.Header
-import com.maxkeppeker.sheets.core.models.base.rememberUseCaseState
-import com.maxkeppeler.sheets.list.ListDialog
-import com.maxkeppeler.sheets.list.models.ListOption
-import com.maxkeppeler.sheets.list.models.ListSelection
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootGraph
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
 import com.rifsxd.ksunext.Natives
 import com.rifsxd.ksunext.R
-import com.rifsxd.ksunext.ksuApp
 import com.rifsxd.ksunext.ui.component.SwitchItem
-import com.rifsxd.ksunext.ui.component.rememberCustomDialog
 import com.rifsxd.ksunext.ui.util.refreshActivity
 import com.rifsxd.ksunext.ui.util.LocalSnackbarHost
 import com.rifsxd.ksunext.ui.util.LocaleHelper
@@ -74,6 +74,27 @@ fun CustomizationScreen(navigator: DestinationsNavigator) {
     val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
+    val context = LocalContext.current
+    val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
+    var currentAppLocale by remember {
+        mutableStateOf(LocaleHelper.getCurrentAppLocale(context))
+    }
+    var showLanguageSheet by remember { mutableStateOf(false) }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        currentAppLocale = LocaleHelper.getCurrentAppLocale(context)
+    }
+
+    val languageOptions = remember(context) {
+        listOf(
+            LocaleHelper.SYSTEM_LANGUAGE_TAG to context.getString(R.string.system_default)
+        ) + LocaleHelper.getSupportedLocales(context)
+            .map { it.toLanguageTag() to it.getDisplayName(it) }
+            .sortedBy { (_, displayName) -> displayName }
+    }
+    val currentLanguageTag = currentAppLocale?.toLanguageTag()
+        ?: LocaleHelper.SYSTEM_LANGUAGE_TAG
+
     Scaffold(
         topBar = {
             TopBar(
@@ -102,66 +123,6 @@ fun CustomizationScreen(navigator: DestinationsNavigator) {
                 .verticalScroll(rememberScrollState())
         ) {
 
-            val context = LocalContext.current
-            val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
-            var currentAppLocale by remember {
-                mutableStateOf(LocaleHelper.getCurrentAppLocale(context))
-            }
-
-            LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-                currentAppLocale = LocaleHelper.getCurrentAppLocale(context)
-            }
-
-            val languageDialog = rememberCustomDialog { dismiss ->
-                val allOptions = remember {
-                    listOf(
-                        LocaleHelper.SYSTEM_LANGUAGE_TAG to context.getString(R.string.system_default)
-                    ) + LocaleHelper.getSupportedLocales(context)
-                        .map { it.toLanguageTag() to it.getDisplayName(it) }
-                        .sortedBy { (_, displayName) -> displayName }
-                }
-                val currentLanguageTag = currentAppLocale?.toLanguageTag()
-                    ?: LocaleHelper.SYSTEM_LANGUAGE_TAG
-                val options = allOptions.map { (tag, displayName) ->
-                    ListOption(
-                        titleText = displayName,
-                        selected = currentLanguageTag == tag
-                    )
-                }
-                var selectedIndex by remember(currentLanguageTag) {
-                    mutableIntStateOf(
-                        allOptions.indexOfFirst { (tag, _) -> currentLanguageTag == tag }
-                    )
-                }
-
-                ListDialog(
-                    state = rememberUseCaseState(
-                        visible = true,
-                        onFinishedRequest = {
-                            val languageTag = allOptions.getOrNull(selectedIndex)?.first
-                            dismiss()
-                            if (languageTag != null && languageTag != currentLanguageTag) {
-                                LocaleHelper.setAppLocale(context, languageTag)
-                                currentAppLocale = LocaleHelper.getCurrentAppLocale(context)
-                                if (!LocaleHelper.usesFrameworkLocaleManager) {
-                                    refreshActivity(context)
-                                }
-                            }
-                        },
-                        onCloseRequest = { dismiss() }
-                    ),
-                    header = Header.Default(
-                        title = stringResource(R.string.settings_language),
-                    ),
-                    selection = ListSelection.Single(
-                        showRadioButtons = true,
-                        options = options
-                    ) { index, _ ->
-                        selectedIndex = index
-                    }
-                )
-            }
-
             val language = stringResource(id = R.string.settings_language)
             val currentLanguageDisplay = currentAppLocale?.let { it.getDisplayName(it) }
                 ?: stringResource(R.string.system_default)
@@ -175,7 +136,7 @@ fun CustomizationScreen(navigator: DestinationsNavigator) {
                 ) },
                 supportingContent = { Text(currentLanguageDisplay) },
                 modifier = Modifier.clickable {
-                    languageDialog.show()
+                    showLanguageSheet = true
                 }
             )
 
@@ -212,6 +173,78 @@ fun CustomizationScreen(navigator: DestinationsNavigator) {
                     activity?.setAmoledMode(checked)
                     enableAmoled = checked
                 }
+            }
+        }
+    }
+
+    if (showLanguageSheet) {
+        LanguageBottomSheet(
+            options = languageOptions,
+            selectedLanguageTag = currentLanguageTag,
+            onDismiss = { showLanguageSheet = false },
+            onLanguageSelected = { languageTag ->
+                showLanguageSheet = false
+                if (languageTag != currentLanguageTag) {
+                    LocaleHelper.setAppLocale(context, languageTag)
+                    currentAppLocale = LocaleHelper.getCurrentAppLocale(context)
+                    if (!LocaleHelper.usesFrameworkLocaleManager) {
+                        refreshActivity(context)
+                    }
+                }
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LanguageBottomSheet(
+    options: List<Pair<String, String>>,
+    selectedLanguageTag: String,
+    onDismiss: () -> Unit,
+    onLanguageSelected: (String) -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background
+    ) {
+        Text(
+            text = stringResource(R.string.select_language),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Black,
+            modifier = Modifier
+                .padding(horizontal = 24.dp, vertical = 8.dp)
+                .semantics { heading() }
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f, fill = false)
+                .selectableGroup(),
+            contentPadding = PaddingValues(bottom = 24.dp)
+        ) {
+            items(options, key = { (tag, _) -> tag }) { (tag, displayName) ->
+                val selected = tag == selectedLanguageTag
+                ListItem(
+                    headlineContent = { Text(displayName) },
+                    trailingContent = {
+                        RadioButton(selected = selected, onClick = null)
+                    },
+                    colors = ListItemDefaults.colors(
+                        containerColor = MaterialTheme.colorScheme.background
+                    ),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = selected,
+                            role = Role.RadioButton,
+                            onClick = { onLanguageSelected(tag) }
+                        )
+                )
             }
         }
     }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/LocaleHelper.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/LocaleHelper.kt
@@ -1,141 +1,132 @@
 package com.rifsxd.ksunext.ui.util
 
-import android.annotation.TargetApi
-import android.app.Activity
+import android.app.LocaleManager
 import android.content.Context
-import android.content.Intent
 import android.content.res.Configuration
-import android.net.Uri
 import android.os.Build
-import android.provider.Settings
-import java.util.*
+import android.os.LocaleList
+import androidx.annotation.ChecksSdkIntAtLeast
+import androidx.annotation.RequiresApi
+import androidx.core.content.edit
+import com.rifsxd.ksunext.R
+import org.xmlpull.v1.XmlPullParser
+import java.util.Locale
 
 object LocaleHelper {
-    
-    /**
-     * Check if should use system language settings (Android 13+)
-     */
-    val useSystemLanguageSettings: Boolean
+
+    const val SYSTEM_LANGUAGE_TAG = ""
+
+    private const val PREFS_NAME = "settings"
+    private const val PREF_LANGUAGE = "app_locale"
+    private const val LEGACY_SYSTEM_LANGUAGE = "system"
+    private const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
+
+    @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
+    val usesFrameworkLocaleManager: Boolean
         get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-    
-    /**
-     * Launch system app locale settings (Android 13+)
-     */
-    fun launchSystemLanguageSettings(context: Context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            try {
-                val intent = Intent(Settings.ACTION_APP_LOCALE_SETTINGS).apply {
-                    data = Uri.fromParts("package", context.packageName, null)
-                }
-                context.startActivity(intent)
-            } catch (_: Exception) {
-                // Fallback to app language settings if system settings not available
-            }
-        }
-    }
-    
-    /**
-     * Apply saved language setting to context (for Android < 13)
-     */
-    fun applyLanguage(context: Context): Context {
-        // On Android 13+, language is handled by system
-        if (useSystemLanguageSettings) {
-            return context
-        }
-        
-        val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
-        val localeTag = prefs.getString("app_locale", "system") ?: "system"
-        
-        return if (localeTag == "system") {
-            context
-        } else {
-            val locale = parseLocaleTag(localeTag)
-            setLocale(context, locale)
-        }
-    }
-    
-    /**
-     * Set locale for context (Android < 13)
-     */
-    private fun setLocale(context: Context, locale: Locale): Context {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            updateResources(context, locale)
-        } else {
-            updateResourcesLegacy(context, locale)
-        }
-    }
-    
-    @TargetApi(Build.VERSION_CODES.N)
-    private fun updateResources(context: Context, locale: Locale): Context {
-        val configuration = Configuration()
-        configuration.setLocale(locale)
-        configuration.setLayoutDirection(locale)
-        return context.createConfigurationContext(configuration)
-    }
-    
-    @Suppress("DEPRECATION")
-    @SuppressWarnings("deprecation")
-    private fun updateResourcesLegacy(context: Context, locale: Locale): Context {
-        Locale.setDefault(locale)
-        val resources = context.resources
-        val configuration = resources.configuration
-        configuration.locale = locale
-        configuration.setLayoutDirection(locale)
-        resources.updateConfiguration(configuration, resources.displayMetrics)
-        return context
-    }
-    
-    /**
-     * Parse locale tag to Locale object
-     */
-    private fun parseLocaleTag(tag: String): Locale {
+
+    fun getSupportedLocales(context: Context): List<Locale> {
+        val parser = context.resources.getXml(R.xml.locales_config)
         return try {
-            if (tag.contains("_")) {
-                val parts = tag.split("_")
-                Locale.Builder()
-                    .setLanguage(parts[0])
-                    .setRegion(parts.getOrNull(1) ?: "")
-                    .build()
-            } else {
-                Locale.Builder()
-                    .setLanguage(tag)
-                    .build()
-            }
-        } catch (_: Exception) {
-            Locale.getDefault()
+            buildList {
+                while (parser.eventType != XmlPullParser.END_DOCUMENT) {
+                    if (parser.eventType == XmlPullParser.START_TAG && parser.name == "locale") {
+                        val tag = parser.getAttributeValue(ANDROID_NAMESPACE, "name")
+                        val locale = tag?.let(Locale::forLanguageTag)
+                        if (locale != null && locale.language.isNotEmpty()) {
+                            add(locale)
+                        }
+                    }
+                    parser.next()
+                }
+            }.distinctBy(Locale::toLanguageTag)
+        } finally {
+            parser.close()
         }
     }
-    
-    /**
-     * Get current app locale
-     */
-    fun getCurrentAppLocale(context: Context): Locale? {
-        return if (useSystemLanguageSettings) {
-            // Android 13+ - get from system app locale settings
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                try {
-                    val localeManager = context.getSystemService(Context.LOCALE_SERVICE) as? android.app.LocaleManager
-                    val locales = localeManager?.applicationLocales
-                    if (locales != null && !locales.isEmpty) {
-                        locales.get(0)
-                    } else {
-                        null // System default
-                    }
-                } catch (_: Exception) {
-                    null // System default
-                }
-            } else {
-                null // System default
-            }
+
+    fun setAppLocale(context: Context, languageTag: String) {
+        if (usesFrameworkLocaleManager) {
+            setFrameworkLocales(context, LocaleList.forLanguageTags(languageTag))
         } else {
-            // Android < 13 - get from SharedPreferences
-            val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
-            val localeTag = prefs.getString("app_locale", "system") ?: "system"
-            if (localeTag == "system") {
-                null // System default
-            } else {
-                parseLocaleTag(localeTag)
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit {
+                putString(PREF_LANGUAGE, languageTag.ifEmpty { LEGACY_SYSTEM_LANGUAGE })
             }
         }
+    }
+
+    fun applyLanguage(context: Context): Context {
+        if (usesFrameworkLocaleManager) return context
+
+        val selected = getStoredLocale(context)?.let { resolveSupportedLocale(context, it) }
+            ?: return context
+        val locales = buildList {
+            add(selected)
+            val systemLocales = context.resources.configuration.locales
+            for (index in 0 until systemLocales.size()) {
+                val locale = systemLocales[index]
+                if (none { it.toLanguageTag() == locale.toLanguageTag() }) {
+                    add(locale)
+                }
+            }
+        }
+        val override = Configuration().apply {
+            setLocales(LocaleList(*locales.toTypedArray()))
+        }
+        return context.createConfigurationContext(override)
+    }
+
+    fun getCurrentAppLocale(context: Context): Locale? {
+        if (usesFrameworkLocaleManager) {
+            val locales = getFrameworkLocales(context)
+            val locale = if (locales.isEmpty) null else locales[0]
+            return locale?.let { resolveSupportedLocale(context, it) ?: it }
+        }
+
+        return getStoredLocale(context)?.let { resolveSupportedLocale(context, it) }
+    }
+
+    fun migrateLegacyLocale(context: Context) {
+        if (!usesFrameworkLocaleManager) return
+
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        if (!prefs.contains(PREF_LANGUAGE)) return
+
+        val locale = getStoredLocale(context)?.let { resolveSupportedLocale(context, it) }
+        if (getFrameworkLocales(context).isEmpty && locale != null) {
+            setFrameworkLocales(context, LocaleList.forLanguageTags(locale.toLanguageTag()))
+        }
+        prefs.edit { remove(PREF_LANGUAGE) }
+    }
+
+    private fun getStoredLocale(context: Context): Locale? {
+        val stored = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(PREF_LANGUAGE, LEGACY_SYSTEM_LANGUAGE)
+            .orEmpty()
+        if (stored.isEmpty() || stored == LEGACY_SYSTEM_LANGUAGE) {
+            return null
+        }
+
+        val locale = Locale.forLanguageTag(stored.replace('_', '-'))
+        return locale.takeIf { it.language.isNotEmpty() }
+    }
+
+    private fun resolveSupportedLocale(context: Context, locale: Locale): Locale? {
+        val supported = getSupportedLocales(context)
+        return supported.firstOrNull {
+            it.toLanguageTag().equals(locale.toLanguageTag(), ignoreCase = true)
+        } ?: supported.firstOrNull {
+            locale.country.isEmpty() && locale.script.isEmpty() && it.language == locale.language
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private fun getFrameworkLocales(context: Context): LocaleList {
+        return context.getSystemService(LocaleManager::class.java).applicationLocales
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private fun setFrameworkLocales(context: Context, locales: LocaleList) {
+        context.getSystemService(LocaleManager::class.java).applicationLocales = locales
     }
 }

--- a/manager/app/src/main/res/values-bg-rBG/strings.xml
+++ b/manager/app/src/main/res/values-bg-rBG/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Logs saved</string>
   <string name="send_log">Share logs</string>
   <string name="settings_language">Language</string>
+  <string name="select_language">Избор на език</string>
   <string name="system_default">System default</string>
   <string name="settings_banner">Enable banners</string>
   <string name="settings_banner_summary">Show background banners for modules.</string>

--- a/manager/app/src/main/res/values-bn-rBD/strings.xml
+++ b/manager/app/src/main/res/values-bn-rBD/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Logs saved</string>
   <string name="send_log">Share logs</string>
   <string name="settings_language">Language</string>
+  <string name="select_language">ভাষা নির্বাচন করুন</string>
   <string name="system_default">System default</string>
   <string name="settings_banner">Enable banners</string>
   <string name="settings_banner_summary">Show background banners for modules.</string>

--- a/manager/app/src/main/res/values-de-rDE/strings.xml
+++ b/manager/app/src/main/res/values-de-rDE/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Logs saved</string>
   <string name="send_log">Share logs</string>
   <string name="settings_language">Language</string>
+  <string name="select_language">Sprache auswählen</string>
   <string name="system_default">System default</string>
   <string name="settings_banner">Enable banners</string>
   <string name="settings_banner_summary">Show background banners for modules.</string>

--- a/manager/app/src/main/res/values-es-rEM/strings.xml
+++ b/manager/app/src/main/res/values-es-rEM/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Logs guardados</string>
   <string name="send_log">Enviar logs</string>
   <string name="settings_language">Idioma</string>
+  <string name="select_language">Seleccionar idioma</string>
   <string name="system_default">Predeterminado del sistema</string>
   <string name="settings_banner">Activar banners</string>
   <string name="settings_banner_summary">Mostrar banners de fondo para los módulos.</string>

--- a/manager/app/src/main/res/values-fa-rIR/strings.xml
+++ b/manager/app/src/main/res/values-fa-rIR/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">اشکال زدایی ها ذخیره شد</string>
   <string name="send_log">اشتراک گذاری اشکال زدایی ها</string>
   <string name="settings_language">زبان</string>
+  <string name="select_language">انتخاب زبان</string>
   <string name="system_default">پیش فرض سیستم</string>
   <string name="settings_banner">فعال کردن بنرها</string>
   <string name="settings_banner_summary">نمایش بنرهای پس‌زمینه برای ماژول‌ها.</string>

--- a/manager/app/src/main/res/values-fr-rFR/strings.xml
+++ b/manager/app/src/main/res/values-fr-rFR/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Logs saved</string>
   <string name="send_log">Share logs</string>
   <string name="settings_language">Language</string>
+  <string name="select_language">Sélectionner la langue</string>
   <string name="system_default">System default</string>
   <string name="settings_banner">Enable banners</string>
   <string name="settings_banner_summary">Show background banners for modules.</string>

--- a/manager/app/src/main/res/values-hi-rIN/strings.xml
+++ b/manager/app/src/main/res/values-hi-rIN/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Logs saved</string>
   <string name="send_log">Share logs</string>
   <string name="settings_language">Language</string>
+  <string name="select_language">भाषा चुनें</string>
   <string name="system_default">System default</string>
   <string name="settings_banner">Enable banners</string>
   <string name="settings_banner_summary">Show background banners for modules.</string>

--- a/manager/app/src/main/res/values-hu-rHU/strings.xml
+++ b/manager/app/src/main/res/values-hu-rHU/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Logs saved</string>
   <string name="send_log">Share logs</string>
   <string name="settings_language">Language</string>
+  <string name="select_language">Nyelv kiválasztása</string>
   <string name="system_default">System default</string>
   <string name="settings_banner">Enable banners</string>
   <string name="settings_banner_summary">Show background banners for modules.</string>

--- a/manager/app/src/main/res/values-in-rID/strings.xml
+++ b/manager/app/src/main/res/values-in-rID/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Log disimpan</string>
   <string name="send_log">Bagikan log</string>
   <string name="settings_language">Bahasa</string>
+  <string name="select_language">Pilih bahasa</string>
   <string name="system_default">Bawaan sistem</string>
   <string name="settings_banner">Aktifkan banner</string>
   <string name="settings_banner_summary">Tampilkan banner latar belakang pada modul.</string>

--- a/manager/app/src/main/res/values-it-rIT/strings.xml
+++ b/manager/app/src/main/res/values-it-rIT/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Log salvati</string>
   <string name="send_log">Condividi i log</string>
   <string name="settings_language">Lingua</string>
+  <string name="select_language">Seleziona la lingua</string>
   <string name="system_default">Predefinito di sistema</string>
   <string name="settings_banner">Attiva i banner</string>
   <string name="settings_banner_summary">Mostra uno sfondo dietro ai moduli.</string>

--- a/manager/app/src/main/res/values-ja-rJP/strings.xml
+++ b/manager/app/src/main/res/values-ja-rJP/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">ログを保存しました</string>
   <string name="send_log">ログを共有</string>
   <string name="settings_language">言語</string>
+  <string name="select_language">言語を選択</string>
   <string name="system_default">システムのデフォルト</string>
   <string name="settings_banner">バナーを有効化</string>
   <string name="settings_banner_summary">モジュールの背景バナーを表示します。</string>

--- a/manager/app/src/main/res/values-ko-rKR/strings.xml
+++ b/manager/app/src/main/res/values-ko-rKR/strings.xml
@@ -176,6 +176,7 @@
   <string name="log_saved">로그가 저장되었습니다</string>
   <string name="send_log">로그 공유</string>
   <string name="settings_language">언어</string>
+  <string name="select_language">언어 선택</string>
   <string name="system_default">시스템 기본값</string>
   <string name="settings_banner">배너 활성화</string>
   <string name="settings_banner_summary">모듈 백그라운드 배너 보이기</string>

--- a/manager/app/src/main/res/values-pl-rPL/strings.xml
+++ b/manager/app/src/main/res/values-pl-rPL/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Logi zapisane</string>
   <string name="send_log">Udostępnij logi</string>
   <string name="settings_language">Język</string>
+  <string name="select_language">Wybierz język</string>
   <string name="system_default">Domyślny systemowy</string>
   <string name="settings_banner">Włącz banery</string>
   <string name="settings_banner_summary">Pokaż banery w tle dla modułów.</string>

--- a/manager/app/src/main/res/values-pt-rBR/strings.xml
+++ b/manager/app/src/main/res/values-pt-rBR/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Registros salvos</string>
   <string name="send_log">Compartilhar registros</string>
   <string name="settings_language">Idioma</string>
+  <string name="select_language">Selecionar idioma</string>
   <string name="system_default">Padrão do sistema</string>
   <string name="settings_banner">Ativar banners</string>
   <string name="settings_banner_summary">Mostre banners de fundo para módulos.</string>

--- a/manager/app/src/main/res/values-ru-rRU/strings.xml
+++ b/manager/app/src/main/res/values-ru-rRU/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Лог-файлы сохранены</string>
   <string name="send_log">Поделиться лог-файлами</string>
   <string name="settings_language">Язык</string>
+  <string name="select_language">Выберите язык</string>
   <string name="system_default">Системный</string>
   <string name="settings_banner">Включить баннеры</string>
   <string name="settings_banner_summary">Показывать фоновые баннеры для модулей.</string>

--- a/manager/app/src/main/res/values-sv-rSE/strings.xml
+++ b/manager/app/src/main/res/values-sv-rSE/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Logs saved</string>
   <string name="send_log">Share logs</string>
   <string name="settings_language">Language</string>
+  <string name="select_language">Välj språk</string>
   <string name="system_default">System default</string>
   <string name="settings_banner">Enable banners</string>
   <string name="settings_banner_summary">Show background banners for modules.</string>

--- a/manager/app/src/main/res/values-th-rTH/strings.xml
+++ b/manager/app/src/main/res/values-th-rTH/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Logs saved</string>
   <string name="send_log">Share logs</string>
   <string name="settings_language">Language</string>
+  <string name="select_language">เลือกภาษา</string>
   <string name="system_default">System default</string>
   <string name="settings_banner">Enable banners</string>
   <string name="settings_banner_summary">Show background banners for modules.</string>

--- a/manager/app/src/main/res/values-tr-rTR/strings.xml
+++ b/manager/app/src/main/res/values-tr-rTR/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Günlükler kaydedildi</string>
   <string name="send_log">Günlükleri paylaş</string>
   <string name="settings_language">Dil</string>
+  <string name="select_language">Dil seçin</string>
   <string name="system_default">Sistem varsayılanı</string>
   <string name="settings_banner">Afişleri etkinleştirin</string>
   <string name="settings_banner_summary">Modüller için arka plan afişlerini gösterin.</string>

--- a/manager/app/src/main/res/values-uk-rUA/strings.xml
+++ b/manager/app/src/main/res/values-uk-rUA/strings.xml
@@ -177,6 +177,7 @@
   <string name="log_saved">Журнали збережено</string>
   <string name="send_log">Поділитися журналами</string>
   <string name="settings_language">Мова</string>
+  <string name="select_language">Виберіть мову</string>
   <string name="system_default">Налаштування за замовчуванням</string>
   <string name="settings_banner">Увімкнути банери</string>
   <string name="settings_banner_summary">Показувати фонові банери для модулів.</string>

--- a/manager/app/src/main/res/values-vi-rVN/strings.xml
+++ b/manager/app/src/main/res/values-vi-rVN/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">Đã lưu nhật ký</string>
   <string name="send_log">Chia sẻ nhật ký</string>
   <string name="settings_language">Ngôn ngữ</string>
+  <string name="select_language">Chọn ngôn ngữ</string>
   <string name="system_default">Mặc định hệ thống</string>
   <string name="settings_banner">Bật biểu ngữ</string>
   <string name="settings_banner_summary">Hiện biểu ngữ nền cho các mô-đun.</string>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">日志已保存</string>
   <string name="send_log">分享日志</string>
   <string name="settings_language">语言</string>
+  <string name="select_language">选择语言</string>
   <string name="system_default">系统默认设置</string>
   <string name="settings_banner">启用横幅</string>
   <string name="settings_banner_summary">显示模块背景横幅。</string>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -175,6 +175,7 @@
   <string name="log_saved">日誌已儲存</string>
   <string name="send_log">分享日誌</string>
   <string name="settings_language">語言設定</string>
+  <string name="select_language">選擇語言</string>
   <string name="system_default">系統預設值</string>
   <string name="settings_banner">啓用橫幅</string>
   <string name="settings_banner_summary">展示模組背景橫幅。</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -208,6 +208,7 @@
     <string name="settings_enable_su">SU compatibility</string>
     <string name="settings_enable_su_summary">Allow the ability of any app to gain root privileges via the ⁠su command (existing root processes won\'t be affected).</string>
     <string name="settings_language">Language</string>
+    <string name="select_language">Select Language</string>
     <string name="system_default">System default</string>
     <string name="settings_banner">Enable banners</string>
     <string name="settings_banner_summary">Show background banners for modules.</string>

--- a/manager/app/src/main/res/xml/locales_config.xml
+++ b/manager/app/src/main/res/xml/locales_config.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale-config xmlns:android="http://schemas.android.com/apk/res/android">
     <locale android:name="en-US" />
-    <locale android:name="bg-BG" />
     <locale android:name="bn-BD" />
     <locale android:name="de-DE" />
     <locale android:name="es-EM" />
     <locale android:name="fa-IR" />
     <locale android:name="fr-FR" />
     <locale android:name="hi-IN" />
-    <locale android:name="hu-HU" />
     <locale android:name="in-ID" />
     <locale android:name="it-IT" />
     <locale android:name="ja-JP" />
@@ -16,8 +14,6 @@
     <locale android:name="pl-PL" />
     <locale android:name="pt-BR" />
     <locale android:name="ru-RU" />
-    <locale android:name="sv-SE" />
-    <locale android:name="th-TH" />
     <locale android:name="tr-TR" />
     <locale android:name="uk-UA" />
     <locale android:name="vi-VN" />

--- a/manager/app/src/main/res/xml/locales_config.xml
+++ b/manager/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en-US" />
+    <locale android:name="bg-BG" />
+    <locale android:name="bn-BD" />
+    <locale android:name="de-DE" />
+    <locale android:name="es-EM" />
+    <locale android:name="fa-IR" />
+    <locale android:name="fr-FR" />
+    <locale android:name="hi-IN" />
+    <locale android:name="hu-HU" />
+    <locale android:name="in-ID" />
+    <locale android:name="it-IT" />
+    <locale android:name="ja-JP" />
+    <locale android:name="ko-KR" />
+    <locale android:name="pl-PL" />
+    <locale android:name="pt-BR" />
+    <locale android:name="ru-RU" />
+    <locale android:name="sv-SE" />
+    <locale android:name="th-TH" />
+    <locale android:name="tr-TR" />
+    <locale android:name="uk-UA" />
+    <locale android:name="vi-VN" />
+    <locale android:name="zh-CN" />
+    <locale android:name="zh-TW" />
+</locale-config>


### PR DESCRIPTION
I traced #987 through the attached log. The manager successfully starts `AppLocalePickerActivity`, then the Nubia Settings process crashes with a `NullPointerException` in `canDisplayLocaleUi()`. Because the failure happens in another process, the exception handler around `startActivity()` cannot recover from it.

This keeps language selection inside the manager on every supported Android version. Android 13 and newer still write to `LocaleManager.applicationLocales`, so the choice stays integrated with Android's app-language setting. Android 8–12 save the BCP 47 tag, recreate `MainActivity`, and wrap its base context with the selected locale plus the system locales as fallbacks. `MainActivity` remains a `ComponentActivity`; this does not introduce `AppCompatDelegate` or require changing its base class.

The picker is now a Material 3 modal bottom sheet. It opens at the half-height anchor and expands through Material's nested-scroll behavior when the user scrolls. The heading stays above the scrolling list, each row is one accessible radio-button target, and tapping a row applies it immediately. The sheet and rows use the same theme background, including AMOLED mode.

The manifest and picker share one explicit locale catalog. It contains English and the 18 locale resource sets that already have translated app content. The Bulgarian, Hungarian, Swedish, and Thai folders otherwise duplicate the English catalog, so they are not advertised as selectable languages. The new “Select Language” heading is translated in every resource locale, and bundle language splitting is disabled so every offered translation is installed.

Existing pre-Android 13 preferences are normalized and migrated once when the app next runs on Android 13 or newer. An existing framework choice still wins. The selected-language row refreshes after saving and after returning to the screen, including English ↔ System Default when the effective configuration does not change. The sheet closes before applying the locale so recreation cannot restore it as open.

Validation:

- `:app:compileDebugKotlin` and `:app:assembleDebug` pass with JBR 21.
- API 36: the sheet opens halfway, expands while scrolling, reaches the complete locale list, and uses one background in the normal dark and AMOLED themes. German applies and persists; explicit English and System Default update correctly; an old unsupported override can be cleared.
- API 30: the sheet opens halfway and expands while scrolling. Locale selection closes the sheet and recreates `MainActivity`; German persists after a force-stop/relaunch, and System Default restores the device locale.
- The runtime picker contains 19 languages plus System Default; the four English-placeholder locale folders are absent.
- `:app:lintDebug` reports no locale, API-level, resource-translation, or bundle-language findings. It still stops on the same two unrelated existing errors in the AMOLED row and `AppProfile`.

Fixes #987
