### PR TITLE
feat: new version matching detection mechanism (https://github.com/tiann/KernelSU/pull/3516)

### DIFF
--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -84,6 +84,11 @@ module_param(allow_shell, bool, 0);
 bool ksu_no_custom_rc = false;
 module_param_named(norc, ksu_no_custom_rc, bool, 0);
 
+#ifdef MODULE
+bool ksu_bundled = false;
+module_param_named(bundled, ksu_bundled, bool, 0);
+#endif
+
 int __init kernelsu_init(void)
 {
 #if defined(__x86_64__) && !defined(CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER)

--- a/kernel/include/ksu.h
+++ b/kernel/include/ksu.h
@@ -11,6 +11,9 @@
 extern struct cred *ksu_cred;
 extern bool ksu_late_loaded;
 extern bool allow_shell;
+#ifdef MODULE
+extern bool ksu_bundled;
+#endif
 extern struct selinux_policy *backup_sepolicy;
 extern bool ksu_no_custom_rc;
 

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -45,6 +45,9 @@ static int do_get_info(void __user *arg)
 
 #ifdef MODULE
     cmd.flags |= KSU_GET_INFO_FLAG_LKM;
+    if (ksu_bundled) {
+        cmd.flags |= KSU_GET_INFO_FLAG_BUNDLED;
+    }
 #endif
 
     if (ksuver_override)
@@ -76,6 +79,9 @@ static int do_get_info_legacy(void __user *arg)
 
 #ifdef MODULE
     cmd.flags |= KSU_GET_INFO_FLAG_LKM;
+    if (ksu_bundled) {
+        cmd.flags |= KSU_GET_INFO_FLAG_BUNDLED;
+    }
 #endif
 
     if (is_manager()) {

--- a/manager/app/src/main/cpp/jni.cc
+++ b/manager/app/src/main/cpp/jni.cc
@@ -98,6 +98,12 @@ Java_com_rifsxd_ksunext_Natives_isLkmMode(JNIEnv *env, jclass clazz) {
 
 extern "C"
 JNIEXPORT jboolean JNICALL
+Java_com_rifsxd_ksunext_Natives_isLkmBundled(JNIEnv *env, jclass clazz) {
+    return is_lkm_bundled();
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
 Java_com_rifsxd_ksunext_Natives_isLateLoadMode(JNIEnv *env, jclass clazz) {
     return is_late_load_mode();
 }

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -119,6 +119,12 @@ bool is_lkm_mode() {
     return (legacy_get_info().second & KSU_GET_INFO_FLAG_LKM) != 0;
 }
 
+bool is_lkm_bundled() {
+    auto info = get_info();
+    return (info.flags & KSU_GET_INFO_FLAG_LKM) != 0 &&
+           (info.flags & KSU_GET_INFO_FLAG_BUNDLED) != 0;
+}
+
 bool is_late_load_mode() {
     auto info = get_info();
     if (info.version > 0) {

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -24,6 +24,8 @@ bool is_safe_mode();
 
 bool is_lkm_mode();
 
+bool is_lkm_bundled();
+
 bool is_late_load_mode();
 
 bool is_manager();

--- a/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
@@ -46,6 +46,9 @@ object Natives {
     val isLkmMode: Boolean
         external get
 
+    val isLkmBundled: Boolean
+        external get
+
     val isLateLoadMode: Boolean
         external get
 
@@ -167,12 +170,8 @@ object Natives {
     val managerUAPIVersion: Int
         external get
 
-    fun checkUAPIMismatch(): Boolean {
-        return kernelUAPIVersion != managerUAPIVersion
-    }
-
-    fun requireNewKernel(): Boolean {
-        return (version != -1 && version < MINIMAL_SUPPORTED_KERNEL) || checkUAPIMismatch()
+    fun isFullFeatured(): Boolean {
+        return isManager && kernelUAPIVersion == managerUAPIVersion && com.rifsxd.ksunext.ui.util.rootAvailable()
     }
 
     val KSU_WORK_DIR = "/data/adb/ksu/"

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/MainActivity.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/MainActivity.kt
@@ -250,7 +250,7 @@ class MainActivity : ComponentActivity() {
                 val navigator = navController.rememberDestinationsNavigator()
 
                 val isManager = Natives.isManager
-                val fullFeatured = isManager && !Natives.requireNewKernel() && rootAvailable()
+                val fullFeatured = Natives.isFullFeatured()
 
                 val currentBackStackEntry by navController.currentBackStackEntryAsState()
                 val currentRoute = currentBackStackEntry?.destination?.route
@@ -531,7 +531,7 @@ private fun BottomBar(
 ) {
     val navigator = navController.rememberDestinationsNavigator()
     val isManager = Natives.isManager
-    val fullFeatured = isManager && !Natives.requireNewKernel() && rootAvailable()
+    val fullFeatured = Natives.isFullFeatured()
 
     val visibleDestinations = remember(fullFeatured) {
         BottomBarDestination.entries.filter { fullFeatured || !it.rootRequired }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Home.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Home.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.automirrored.filled.*
 import androidx.compose.material3.*
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -98,7 +99,7 @@ fun HomeScreen(navigator: DestinationsNavigator) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
 
     val isManager = Natives.isManager
-    val fullFeatured = isManager && !Natives.requireNewKernel() && rootAvailable()
+    val fullFeatured = Natives.isFullFeatured()
     val ksuVersion = if (isManager) Natives.version else null
     val ksuVersionTag = if (isManager) Natives.getVersionTag() else null
     val kernelUAPIVersion = if (isManager) Natives.kernelUAPIVersion else null
@@ -211,35 +212,37 @@ fun HomeScreen(navigator: DestinationsNavigator) {
                 }
             }
 
-            if (isManager && Natives.requireNewKernel()) {
-                if (Natives.checkUAPIMismatch()) {
-                    WarningCard(
-                        stringResource(
-                            id = R.string.uapi_mismatch,
-                            managerUAPIVersion,
-                            kernelUAPIVersion ?: 0,
-                        )
-                    )
-                }
+            val currentVersionCode = getManagerVersion(context).second
+            val requiresNewKernel = isManager && kernelUAPIVersion != null && managerUAPIVersion > kernelUAPIVersion
+            val requiresNewManager = isManager && kernelUAPIVersion != null && managerUAPIVersion < kernelUAPIVersion
 
-                val currentVersionCode = getManagerVersion(context).second
-                if (ksuVersion != null && currentVersionCode < ksuVersion.toLong()) {
-                    WarningCard(
-                        stringResource(
-                            id = R.string.require_manager_version,
-                            currentVersionCode,
-                            ksuVersion
-                        )
+            if (requiresNewKernel) {
+                WarningCard(
+                    stringResource(
+                        id = if (lkmMode == true) R.string.require_kernel_version else R.string.require_kernel_version_gki
+                    ),
+                    onClick = if (lkmMode == true) {
+                        { navigator.navigate(InstallScreenDestination) }
+                    } else null
+                )
+            }
+
+            if (requiresNewManager) {
+                WarningCard(
+                    stringResource(
+                        id = R.string.require_manager_version
                     )
-                } else if (ksuVersion != null && ksuVersion < Natives.MINIMAL_SUPPORTED_KERNEL) {
-                    WarningCard(
-                        stringResource(
-                            id = R.string.require_kernel_version,
-                            ksuVersion,
-                            Natives.MINIMAL_SUPPORTED_KERNEL
-                        )
-                    )
-                }
+                )
+            }
+
+            val showLkmUpdate = isManager && lkmMode == true && Natives.isLkmBundled && ksuVersion?.toLong() != currentVersionCode && !requiresNewKernel && !requiresNewManager
+
+            if (showLkmUpdate) {
+                WarningCard(
+                    message = stringResource(R.string.home_lkm_update_available),
+                    color = MaterialTheme.colorScheme.tertiary,
+                    onClick = { navigator.navigate(InstallScreenDestination) }
+                )
             }
 
             if (ksuVersion != null && !rootAvailable()) {
@@ -884,10 +887,26 @@ private fun StatusCard(
                             tag,
                             "$ksuVer-$uapiVer"
                         )
-                        Text(
-                            text = versionText,
-                            style = MaterialTheme.typography.bodySmall
-                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = versionText,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                            if (lkmModeParam == true && !Natives.isLkmBundled) {
+                                Spacer(Modifier.width(8.dp))
+                                Surface(
+                                    color = MaterialTheme.colorScheme.tertiaryContainer,
+                                    shape = RoundedCornerShape(4.dp)
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.home_lkm_custom),
+                                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
 

--- a/manager/app/src/main/res/values-bg-rBG/strings.xml
+++ b/manager/app/src/main/res/values-bg-rBG/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Fix selinux context leak caused by avc denial in audit log.</string>
   <string name="manage_repositories">Manage Repositories</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
   <string name="profile_umount_modules_summary">Enabling this option will allow KernelSU-Next to restore any modified files by the modules for this app.</string>
   <string name="settings_uninstall_temporary_message">Temporarily uninstall KernelSU-Next, restore to original state after next reboot.</string>
   <string name="settings_uninstall_permanent_message">Uninstalling KernelSU-Next (root and all modules) completely and permanently.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Granted root access via KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon restarted</string>
   <string name="sulog_entry_title_dropped_events">Dropped events</string>
-  <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
-  <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Prevent further privilege escalation via KernelSU from within the context of this root profile.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Success</string>
   <string name="sulog_status_exit">Exit %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">The current KernelSU-Next manager version %1$d is too low for KernelSU-Next to work properly. Please upgrade manager to version %2$d or higher!</string>
+  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-bn-rBD/strings.xml
+++ b/manager/app/src/main/res/values-bn-rBD/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Fix selinux context leak caused by avc denial in audit log.</string>
   <string name="manage_repositories">Manage Repositories</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
   <string name="profile_umount_modules_summary">Enabling this option will allow KernelSU-Next to restore any modified files by the modules for this app.</string>
   <string name="settings_uninstall_temporary_message">Temporarily uninstall KernelSU-Next, restore to original state after next reboot.</string>
   <string name="settings_uninstall_permanent_message">Uninstalling KernelSU-Next (root and all modules) completely and permanently.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Granted root access via KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon restarted</string>
   <string name="sulog_entry_title_dropped_events">Dropped events</string>
-  <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
-  <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Prevent further privilege escalation via KernelSU from within the context of this root profile.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Success</string>
   <string name="sulog_status_exit">Exit %1$d</string>
+  <string name="home_lkm_update_available">একটি নতুন বিল্ট-ইন LKM উপলভ্য। আপডেট করতে চাপুন।</string>
+  <string name="home_lkm_custom">কাস্টম</string>
+  <string name="require_manager_version">The current KernelSU-Next manager version %1$d is too low for KernelSU-Next to work properly. Please upgrade manager to version %2$d or higher!</string>
+  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
+  <string name="require_kernel_version_gki">কার্নেল আপডেট করা প্রয়োজন।</string>
 </resources>

--- a/manager/app/src/main/res/values-de-rDE/strings.xml
+++ b/manager/app/src/main/res/values-de-rDE/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Fix selinux context leak caused by avc denial in audit log.</string>
   <string name="manage_repositories">Manage Repositories</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
   <string name="profile_umount_modules_summary">Enabling this option will allow KernelSU-Next to restore any modified files by the modules for this app.</string>
   <string name="settings_uninstall_temporary_message">Temporarily uninstall KernelSU-Next, restore to original state after next reboot.</string>
   <string name="settings_uninstall_permanent_message">Uninstalling KernelSU-Next (root and all modules) completely and permanently.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Granted root access via KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon restarted</string>
   <string name="sulog_entry_title_dropped_events">Dropped events</string>
-  <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
-  <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Prevent further privilege escalation via KernelSU from within the context of this root profile.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Success</string>
   <string name="sulog_status_exit">Exit %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">The current KernelSU-Next manager version %1$d is too low for KernelSU-Next to work properly. Please upgrade manager to version %2$d or higher!</string>
+  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-es-rEM/strings.xml
+++ b/manager/app/src/main/res/values-es-rEM/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Se soluciona la fuga de contenido de Selinux causada por la denegación de Avc en el registro de auditoría.</string>
   <string name="manage_repositories">Gestionar repositorios</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">La versión actual de KernelSU-Next %1$d es demasiado baja para que el administrador funcione correctamente. ¡Actualice a la versión %2$d o superior!</string>
   <string name="profile_umount_modules_summary">Activar esta opción permitirá a KernelSU Next restaurar cualquier archivo modificado por los módulos para esta apliacion.</string>
   <string name="settings_uninstall_temporary_message">Desinstalar temporalmente KernelSU Next, restaurar al estado original después del próximo reinicio.</string>
   <string name="settings_uninstall_permanent_message">Desinstalar KernelSU Next (root y todos los módulos) de forma completa y permanente.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Granted root access via KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon restarted</string>
   <string name="sulog_entry_title_dropped_events">Dropped events</string>
-  <string name="uapi_mismatch">La versión del gestor de uapi (%1$d) y la versión del controlador de KernelSU de uapi (%2$d) no coinciden.</string>
-  <string name="require_manager_version">La versión actual del gestor de KernelSU %1$d es demasiado baja para que KernelSU funcione correctamente. ¡Actualice el administrador a la versión %2$d o superior!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Prevent further privilege escalation via KernelSU from within the context of this root profile.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Completado con éxito</string>
   <string name="sulog_status_exit">Salir de %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">La versión actual del gestor de KernelSU-Next %1$d es demasiado baja para que KernelSU-Next funcione correctamente. ¡Actualice el administrador a la versión %2$d o superior!</string>
+  <string name="require_kernel_version">La versión actual de KernelSU-Next %1$d es demasiado baja para que el administrador funcione correctamente. ¡Actualice a la versión %2$d o superior!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-fa-rIR/strings.xml
+++ b/manager/app/src/main/res/values-fa-rIR/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">رفع نشت Context مربوط به Selinux که بر اثر Avc denial در گزارش Audit ایجاد میشود.</string>
   <string name="manage_repositories">مدیریت مخازن</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">نسخه فعلی KernelSU-Next %1$d برای عملکرد صحیح مدیریت، بسیار ضعیف است. لطفاً به نسخه %2$d یا بالاتر ارتقا دهید!</string>
   <string name="profile_umount_modules_summary">فعال کردن این گزینه به KernelSU-Next اجازه می‌دهد تا هرگونه فایل تغییر یافته توسط ماژول‌های این برنامه را بازیابی کند.</string>
   <string name="settings_uninstall_temporary_message">KernelSU-Next را موقتاً حذف نصب کنید، سپس پس از راه‌اندازی مجدد بعدی، سیستم را به حالت اولیه بازگردانید.</string>
   <string name="settings_uninstall_permanent_message">حذف کامل و دائمی KernelSU-Next (روت و تمام ماژول‌ها).</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">اعطای دسترسی روت با KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon مجددا راه‌اندازی شد</string>
   <string name="sulog_entry_title_dropped_events">رویداد‌های از دست رفته</string>
-  <string name="uapi_mismatch">نسخه uapi منیجر (%1$d) و نسخه uapi KernelSU درایور (%2$d) با هم تداخل دارند.</string>
-  <string name="require_manager_version">نسخه فعلی KernelSU منیجر %1$d برای عملکرد صحیح مدیریت، بسیار ضعیف است. لطفاً به نسخه %2$d یا بالاتر ارتقا دهید!</string>
   <string name="profile_flags">علامت‌ها</string>
   <string name="profile_flags_desc_no_new_privs">از ارتقای بیشتر سطح دسترسی از طریق KernelSU در این نمایه روت جلوگیری می‌کند.</string>
   <string name="settings_sulog">گزارش SU</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">شناسه کاربر%1$s</string>
   <string name="sulog_status_success">موفقیت آمیز بود</string>
   <string name="sulog_status_exit">خروج %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">نسخه فعلی KernelSU-Next منیجر %1$d برای عملکرد صحیح مدیریت، بسیار ضعیف است. لطفاً به نسخه %2$d یا بالاتر ارتقا دهید!</string>
+  <string name="require_kernel_version">نسخه فعلی KernelSU-Next %1$d برای عملکرد صحیح مدیریت، بسیار ضعیف است. لطفاً به نسخه %2$d یا بالاتر ارتقا دهید!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-fr-rFR/strings.xml
+++ b/manager/app/src/main/res/values-fr-rFR/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Fix selinux context leak caused by avc denial in audit log.</string>
   <string name="manage_repositories">Manage Repositories</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
   <string name="profile_umount_modules_summary">Enabling this option will allow KernelSU-Next to restore any modified files by the modules for this app.</string>
   <string name="settings_uninstall_temporary_message">Temporarily uninstall KernelSU-Next, restore to original state after next reboot.</string>
   <string name="settings_uninstall_permanent_message">Uninstalling KernelSU-Next (root and all modules) completely and permanently.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Granted root access via KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon restarted</string>
   <string name="sulog_entry_title_dropped_events">Dropped events</string>
-  <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
-  <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Prevent further privilege escalation via KernelSU from within the context of this root profile.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Success</string>
   <string name="sulog_status_exit">Exit %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">The current KernelSU-Next manager version %1$d is too low for KernelSU-Next to work properly. Please upgrade manager to version %2$d or higher!</string>
+  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-hi-rIN/strings.xml
+++ b/manager/app/src/main/res/values-hi-rIN/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Fix selinux context leak caused by avc denial in audit log.</string>
   <string name="manage_repositories">Manage Repositories</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
   <string name="profile_umount_modules_summary">Enabling this option will allow KernelSU-Next to restore any modified files by the modules for this app.</string>
   <string name="settings_uninstall_temporary_message">Temporarily uninstall KernelSU-Next, restore to original state after next reboot.</string>
   <string name="settings_uninstall_permanent_message">Uninstalling KernelSU-Next (root and all modules) completely and permanently.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Granted root access via KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon restarted</string>
   <string name="sulog_entry_title_dropped_events">Dropped events</string>
-  <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
-  <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Prevent further privilege escalation via KernelSU from within the context of this root profile.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Success</string>
   <string name="sulog_status_exit">Exit %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">The current KernelSU-Next manager version %1$d is too low for KernelSU-Next to work properly. Please upgrade manager to version %2$d or higher!</string>
+  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-hu-rHU/strings.xml
+++ b/manager/app/src/main/res/values-hu-rHU/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Fix selinux context leak caused by avc denial in audit log.</string>
   <string name="manage_repositories">Manage Repositories</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
   <string name="profile_umount_modules_summary">Enabling this option will allow KernelSU-Next to restore any modified files by the modules for this app.</string>
   <string name="settings_uninstall_temporary_message">Temporarily uninstall KernelSU-Next, restore to original state after next reboot.</string>
   <string name="settings_uninstall_permanent_message">Uninstalling KernelSU-Next (root and all modules) completely and permanently.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Granted root access via KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon restarted</string>
   <string name="sulog_entry_title_dropped_events">Dropped events</string>
-  <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
-  <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Prevent further privilege escalation via KernelSU from within the context of this root profile.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Success</string>
   <string name="sulog_status_exit">Exit %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">The current KernelSU-Next manager version %1$d is too low for KernelSU-Next to work properly. Please upgrade manager to version %2$d or higher!</string>
+  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-in-rID/strings.xml
+++ b/manager/app/src/main/res/values-in-rID/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Memperbaiki kebocoran konteks SELinux akibat penolakan AVC yang tercatat di log audit.</string>
   <string name="manage_repositories">Kelola Repositori</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">Versi KernelSU-Next saat ini %1$d terlalu rendah agar manajer dapat berfungsi dengan baik. Silakan perbarui ke versi %2$d atau lebih baru!</string>
   <string name="profile_umount_modules_summary">Mengaktifkan opsi ini akan memungkinkan KernelSU-Next untuk memulihkan berkas apa pun yang telah dimodifikasi oleh modul untuk aplikasi ini.</string>
   <string name="settings_uninstall_temporary_message">Hapus sementara KernelSU-Next, dipulihkan ke keadaan semula setelah mulai ulang berikutnya.</string>
   <string name="settings_uninstall_permanent_message">Menghapus KernelSU-Next (root dan semua modul) sepenuhnya dan secara permanen.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Akses root diberikan melalui ioctl KernelSU</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon dimulai ulang</string>
   <string name="sulog_entry_title_dropped_events">Kejadian yang terlewat</string>
-  <string name="uapi_mismatch">Versi uapi manajer (%1$d) dan versi uapi driver KernelSU (%2$d) tidak cocok.</string>
-  <string name="require_manager_version">Versi manajer KernelSU saat ini %1$d terlalu rendah agar KernelSU dapat berfungsi dengan benar. Harap perbaharui manajer ke versi %2$d atau lebih yang tinggi!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Mencegah peningkatan hak akses lebih lanjut melalui KernelSU dari dalam konteks profil root ini.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Berhasil</string>
   <string name="sulog_status_exit">Keluar %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">Versi manajer KernelSU-Next saat ini %1$d terlalu rendah agar KernelSU-Next dapat berfungsi dengan benar. Harap perbaharui manajer ke versi %2$d atau lebih yang tinggi!</string>
+  <string name="require_kernel_version">Versi KernelSU-Next saat ini %1$d terlalu rendah agar manajer dapat berfungsi dengan baik. Silakan perbarui ke versi %2$d atau lebih baru!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-it-rIT/strings.xml
+++ b/manager/app/src/main/res/values-it-rIT/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Correggi la perdita di contesto di selinux causata dal rifiuto di avc nel registro di controllo.</string>
   <string name="manage_repositories">Gestisci Repository</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">La versione attualmente installata di KernelSU-Next %1$d è troppo vecchia ed il manager non può funzionare correttamente. Si prega di aggiornare alla versione %2$d o successiva!</string>
   <string name="profile_umount_modules_summary">Abilitando questa opzione, KernelSU-Next potrà ripristinare tutti i file modificati dai moduli per questa app.</string>
   <string name="settings_uninstall_temporary_message">Disinstalla temporaneamente KernelSU-Next e recupera il suo stato originale dopo il prossimo riavvio.</string>
   <string name="settings_uninstall_permanent_message">Disinstallazione completa e permanente di KernelSU-Next (root e tutti i moduli).</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Accesso root consentito tramite KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Demone riavviato</string>
   <string name="sulog_entry_title_dropped_events">Eventi scartati</string>
-  <string name="uapi_mismatch">Mancata corrispondenza tra la versione uapi del manager (%1$d) e la versione uapi del driver KernelSU (%2$d).</string>
-  <string name="require_manager_version">La versione attualmente installata del manager KernelSU %1$d è troppo vecchia e KernelSU non può funzionare correttamente. Si prega di aggiornare alla versione %2$d o successiva!</string>
   <string name="profile_flags">Segnalazioni</string>
   <string name="profile_flags_desc_no_new_privs">Evitare un\'ulteriore escalation dei privilegi tramite KernelSU nel contesto di questo profilo di root.</string>
   <string name="settings_sulog">Log SU</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Successo</string>
   <string name="sulog_status_exit">Esci %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">La versione attualmente installata del manager KernelSU-Next %1$d è troppo vecchia e KernelSU-Next non può funzionare correttamente. Si prega di aggiornare alla versione %2$d o successiva!</string>
+  <string name="require_kernel_version">La versione attualmente installata di KernelSU-Next %1$d è troppo vecchia ed il manager non può funzionare correttamente. Si prega di aggiornare alla versione %2$d o successiva!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-ja-rJP/strings.xml
+++ b/manager/app/src/main/res/values-ja-rJP/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">監査ログでのAVC拒否によって発生するSELinuxコンテキストリークを修正します。</string>
   <string name="manage_repositories">リポジトリの管理</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">このKernelSU Nextマネージャーのバージョンは%1$dと低く適切に動作しません。バージョン%2$d以上に更新して下さい！</string>
   <string name="profile_umount_modules_summary">このオプションを有効にすると、モジュールがこのアプリ対して行った全てのファイルの変更をKernelSU Nextが復元できるようになります。</string>
   <string name="settings_uninstall_temporary_message">KernelSU Nextを一時的にアンインストールして、次回の再起動後に元の状態に戻します。</string>
   <string name="settings_uninstall_permanent_message">KernelSU Next (Root およびすべてのモジュール) を完全に永続的にアンインストールします。</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">KernelSUのioctl経由によるroot権限付与</string>
   <string name="sulog_entry_title_daemon_restarted">デーモン再起動</string>
   <string name="sulog_entry_title_dropped_events">欠落したイベント</string>
-  <string name="uapi_mismatch">マネージャーのuapiのバージョン(%1$d)とKernelSUドライバーのuapiのバージョン(%2$d)が異なります。</string>
-  <string name="require_manager_version">このKernelSUマネージャーのバージョンは%1$dと低く適切に動作しません。バージョン%2$d以上に更新して下さい！</string>
   <string name="profile_flags">フラグ</string>
   <string name="profile_flags_desc_no_new_privs">このルートプロファイルのコンテキスト内からKernelSUを介したさらなる権限昇格を防止します。</string>
   <string name="settings_sulog">SUログ</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">成功</string>
   <string name="sulog_status_exit">終了 %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">このKernelSU-Nextマネージャーのバージョンは%1$dと低く適切に動作しません。バージョン%2$d以上に更新して下さい！</string>
+  <string name="require_kernel_version">このKernelSU-Nextマネージャーのバージョンは%1$dと低く適切に動作しません。バージョン%2$d以上に更新して下さい！</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-ko-rKR/strings.xml
+++ b/manager/app/src/main/res/values-ko-rKR/strings.xml
@@ -237,7 +237,6 @@
   <string name="settings_enable_avc_spoof_summary">감사 로그에서 avc 거부로 인해 발생한 selinux 컨텍스트 누수를 수정하세요.</string>
   <string name="manage_repositories">저장소 관리</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">KernelSU Next 버전 %1$d이 너무 낮아서 Manager가 작동하지 않습니다. %2$d 이상의 버전을 사용하세요!</string>
   <string name="profile_umount_modules_summary">이 옵션이 활성화되면, KernelSU는 이 앱에 대한 모듈의 모든 수정사항을 복구합니다.</string>
   <string name="settings_uninstall_temporary_message">임시로 KernelSU를 삭제하고, 다음 재부팅에 원래대로 복구합니다.</string>
   <string name="settings_uninstall_permanent_message">완전히, 그리고 영구히 KernelSU (루트 및 모든 모듈)를 삭제합니다.</string>
@@ -289,8 +288,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">KernelSU ioctl를 통해 루트 권한을 부여했습니다</string>
   <string name="sulog_entry_title_daemon_restarted">데몬 다시 시작됨</string>
   <string name="sulog_entry_title_dropped_events">발생한 이벤트</string>
-  <string name="uapi_mismatch">Manager uapi 버전(%1$d)과 KernelSU 드라이버 uapi 버전(%2$d)이 일치하지 않습니다.</string>
-  <string name="require_manager_version">KernelSU Manager 버전 %1$d이 너무 낮아서 KernelSU가 작동하지 않습니다. Manager를 %2$d 이상의 버전을 사용하세요!</string>
   <string name="profile_flags">플래그</string>
   <string name="profile_flags_desc_no_new_privs">이 루트 프로필 내에서 KernelSU를 통해 권한이 추가로 상승하는 것을 방지합니다.</string>
   <string name="settings_sulog">SU 로그</string>
@@ -308,4 +305,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">성공</string>
   <string name="sulog_status_exit">Exit %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">KernelSU-Next Manager 버전 %1$d이 너무 낮아서 KernelSU-Next가 작동하지 않습니다. Manager를 %2$d 이상의 버전을 사용하세요!</string>
+  <string name="require_kernel_version">KernelSU-Next 버전 %1$d이 너무 낮아서 Manager가 작동하지 않습니다. %2$d 이상의 버전을 사용하세요!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-pl-rPL/strings.xml
+++ b/manager/app/src/main/res/values-pl-rPL/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Naprawa wycieku kontekstu SELinux spowodowanego odmową AVC w logu audytu.</string>
   <string name="manage_repositories">Zarządzaj repozytoriami</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">Aktualna wersja KernelSU-Next %1$d jest zbyt niska, aby menedżer działał poprawnie. Uaktualnij do wersji %2$d lub wyższej!</string>
   <string name="profile_umount_modules_summary">Włączenie tej opcji pozwoli KernelSU-Next przywrócić zmodyfikowane pliki przez moduły dla tej aplikacji.</string>
   <string name="settings_uninstall_temporary_message">Tymczasowo odinstaluj KernelSU-Next, przywróć do stanu oryginalnego po następnym restarcie.</string>
   <string name="settings_uninstall_permanent_message">Odinstaluj KernelSU-Next (root i wszystkie moduły) całkowicie i nieodwracalnie.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Przyznano dostęp do roota przez KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Deamon zrestartowany</string>
   <string name="sulog_entry_title_dropped_events">Porzucone zdarzenia</string>
-  <string name="uapi_mismatch">Wersja uapi (%1$d) menedżera i uapi (%2$d) sterownika KernelSU nie pasują do siebie.</string>
-  <string name="require_manager_version">Aktualna wersja KernelSU-Next (wbudowana w jądrze) %1$d jest zbyt niska, aby menedżer działał poprawnie. Zaktualizuj do wersji %2$d lub wyższej!</string>
   <string name="profile_flags">Flagi</string>
   <string name="profile_flags_desc_no_new_privs">Zapobiegaj dalszej eskalacji uprawnień przez KernelSU w kontekście tego profilu głównego.</string>
   <string name="settings_sulog">Logi SU</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Powodzenie</string>
   <string name="sulog_status_exit">Wyszedł %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">Aktualna wersja KernelSU-Next (wbudowana w jądrze) %1$d jest zbyt niska, aby menedżer działał poprawnie. Zaktualizuj do wersji %2$d lub wyższej!</string>
+  <string name="require_kernel_version">Aktualna wersja KernelSU-Next %1$d jest zbyt niska, aby menedżer działał poprawnie. Uaktualnij do wersji %2$d lub wyższej!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-pt-rBR/strings.xml
+++ b/manager/app/src/main/res/values-pt-rBR/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Corrigir vazamento de contexto do Selinux causado por negação de Avc no log de auditoria.</string>
   <string name="manage_repositories">Gerenciar Repositórios</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">A versão atual do KernelSU-Next, %1$d, é muito antiga para o gerenciador funcionar corretamente. Atualize para a versão %2$d ou superior!</string>
   <string name="profile_umount_modules_summary">Habilitar esta opção permitirá que o KernelSU-Next restaure quaisquer arquivos modificados pelos módulos deste aplicativo.</string>
   <string name="settings_uninstall_temporary_message">Desinstale temporariamente o KernelSU-Next e restaure o estado original após a próxima reinicialização.</string>
   <string name="settings_uninstall_permanent_message">Desinstalar o KernelSU-Next (root e todos os módulos) completa e permanentemente.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Acesso root concedido via ioctl do KernelSU</string>
   <string name="sulog_entry_title_daemon_restarted">O daemon foi reiniciado</string>
   <string name="sulog_entry_title_dropped_events">Eventos cancelados</string>
-  <string name="uapi_mismatch">Incompatibilidade entre a versão da uapi do gerenciador (%1$d) e a versão da uapi do driver KernelSU (%2$d).</string>
-  <string name="require_manager_version">A versão atual do gerenciador KernelSU, %1$d, é muito antiga para o funcionamento correto do KernelSU. Atualize o gerenciador para a versão %2$d ou superior!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Impeça a escalada de privilégios adicional via KernelSU a partir do contexto deste perfil de root.</string>
   <string name="settings_sulog">Log do SU</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Sucesso</string>
   <string name="sulog_status_exit">Saída %1$d</string>
+  <string name="home_lkm_update_available">Uma versão mais recente do LKM integrado está disponível. Toque para atualizar.</string>
+  <string name="home_lkm_custom">Personalizado</string>
+  <string name="require_manager_version">A versão atual do gerenciador KernelSU-Next, %1$d, é muito antiga para o funcionamento correto do KernelSU-Next. Atualize o gerenciador para a versão %2$d ou superior!</string>
+  <string name="require_kernel_version">A versão atual do KernelSU-Next, %1$d, é muito antiga para o gerenciador funcionar corretamente. Atualize para a versão %2$d ou superior!</string>
+  <string name="require_kernel_version_gki">É necessário atualizar o kernel.</string>
 </resources>

--- a/manager/app/src/main/res/values-ru-rRU/strings.xml
+++ b/manager/app/src/main/res/values-ru-rRU/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Исправить утечку контекста SELinux, вызванную отказом avc в журнале аудита.</string>
   <string name="manage_repositories">Управление репозиториями</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">Текущая версия KernelSU-Next %1$d слишком стара для корректной работы менеджера. Пожалуйста, обновитесь до версии %2$d или выше!</string>
   <string name="profile_umount_modules_summary">Если этот параметр включен, то все изменения файлов, внесённые модулями, будут восстановлены для данного приложения.</string>
   <string name="settings_uninstall_temporary_message">Временно удаляет KernelSU-Next, восстанавливая исходное состояние после следующей перезагрузки.</string>
   <string name="settings_uninstall_permanent_message">Полностью и навсегда удаляет KernelSU-Next, включая root и все модули.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Root права предоставлены через KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Демон перезапущен</string>
   <string name="sulog_entry_title_dropped_events">Пропущенные события</string>
-  <string name="uapi_mismatch">Версия uapi менеджера (%1$d) и версия uapi драйвера KernelSU (%2$d) не соответствуют.</string>
-  <string name="require_manager_version">Текущая версия менеджера KernelSU %1$d слишком низкая для корректной работы KernelSU. Пожалуйста, обновите версию менеджера до %2$d или выше!</string>
   <string name="profile_flags">Флаги</string>
   <string name="profile_flags_desc_no_new_privs">Предотвратить повышение привилегий через KernelSU из контекста этого root профиля.</string>
   <string name="settings_sulog">Логи SU</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Успешно</string>
   <string name="sulog_status_exit">Выход %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">Текущая версия менеджера KernelSU-Next %1$d слишком низкая для корректной работы KernelSU-Next. Пожалуйста, обновите версию менеджера до %2$d или выше!</string>
+  <string name="require_kernel_version">Текущая версия KernelSU-Next %1$d слишком стара для корректной работы менеджера. Пожалуйста, обновитесь до версии %2$d или выше!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-sv-rSE/strings.xml
+++ b/manager/app/src/main/res/values-sv-rSE/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Fix selinux context leak caused by avc denial in audit log.</string>
   <string name="manage_repositories">Manage Repositories</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
   <string name="profile_umount_modules_summary">Enabling this option will allow KernelSU-Next to restore any modified files by the modules for this app.</string>
   <string name="settings_uninstall_temporary_message">Temporarily uninstall KernelSU-Next, restore to original state after next reboot.</string>
   <string name="settings_uninstall_permanent_message">Uninstalling KernelSU-Next (root and all modules) completely and permanently.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Granted root access via KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon restarted</string>
   <string name="sulog_entry_title_dropped_events">Dropped events</string>
-  <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
-  <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Prevent further privilege escalation via KernelSU from within the context of this root profile.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Success</string>
   <string name="sulog_status_exit">Exit %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">The current KernelSU-Next manager version %1$d is too low for KernelSU-Next to work properly. Please upgrade manager to version %2$d or higher!</string>
+  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-th-rTH/strings.xml
+++ b/manager/app/src/main/res/values-th-rTH/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Fix selinux context leak caused by avc denial in audit log.</string>
   <string name="manage_repositories">Manage Repositories</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
   <string name="profile_umount_modules_summary">Enabling this option will allow KernelSU-Next to restore any modified files by the modules for this app.</string>
   <string name="settings_uninstall_temporary_message">Temporarily uninstall KernelSU-Next, restore to original state after next reboot.</string>
   <string name="settings_uninstall_permanent_message">Uninstalling KernelSU-Next (root and all modules) completely and permanently.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Granted root access via KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon restarted</string>
   <string name="sulog_entry_title_dropped_events">Dropped events</string>
-  <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
-  <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Prevent further privilege escalation via KernelSU from within the context of this root profile.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Success</string>
   <string name="sulog_status_exit">Exit %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">The current KernelSU-Next manager version %1$d is too low for KernelSU-Next to work properly. Please upgrade manager to version %2$d or higher!</string>
+  <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-tr-rTR/strings.xml
+++ b/manager/app/src/main/res/values-tr-rTR/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Denetim günlüğünde avc reddi nedeniyle oluşan selinux bağlam sızıntısını düzeltin.</string>
   <string name="manage_repositories">Depoları Yönet</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">Geçerli KernelSU Next sürümü %1$d, yöneticinin düzgün çalışması için çok düşük. Lütfen %2$d veya daha yüksek bir sürüme yükseltin!</string>
   <string name="profile_umount_modules_summary">Bu seçeneğin etkinleştirilmesi, KernelSU Next\'in bu uygulama için modüller tarafından değiştirilen tüm dosyaları geri yüklemesine izin verecektir.</string>
   <string name="settings_uninstall_temporary_message">KernelSU\'yu geçici olarak kaldırın, bir sonraki yeniden başlatmadan sonra orijinal duruma geri dönün.</string>
   <string name="settings_uninstall_permanent_message">KernelSU-Next\'i (kök ve tüm modüller) tamamen ve kalıcı olarak kaldırın.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">KernelSU ioctl aracılığıyla kök erişimi verildi</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon yeniden başlatıldı</string>
   <string name="sulog_entry_title_dropped_events">İptal edilen etkinlikler</string>
-  <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
-  <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
   <string name="profile_flags">Flags</string>
   <string name="profile_flags_desc_no_new_privs">Prevent further privilege escalation via KernelSU from within the context of this root profile.</string>
   <string name="settings_sulog">SU Log</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Success</string>
   <string name="sulog_status_exit">Exit %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">The current KernelSU-Next manager version %1$d is too low for KernelSU-Next to work properly. Please upgrade manager to version %2$d or higher!</string>
+  <string name="require_kernel_version">Geçerli KernelSU-Next sürümü %1$d, yöneticinin düzgün çalışması için çok düşük. Lütfen %2$d veya daha yüksek bir sürüme yükseltin!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-uk-rUA/strings.xml
+++ b/manager/app/src/main/res/values-uk-rUA/strings.xml
@@ -238,7 +238,6 @@
   <string name="settings_enable_avc_spoof_summary">Виправити витік контексту selinux викликаний відхиленням avc в журналі аудиту.</string>
   <string name="manage_repositories">Керування репозиторіями</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">Поточна версія KernelSU Next %1$d надто низька для коректної роботи менеджера. Будь ласка, оновіться до версії %2$d або вище!</string>
   <string name="profile_umount_modules_summary">Увімкнення цієї опції дозволить KernelSU-Next відновлювати для цього додатка будь-які файли, змінені модулями.</string>
   <string name="settings_uninstall_temporary_message">Тимчасово видалити KernelSU-Next, відновити початковий стан після наступного перезавантаження.</string>
   <string name="settings_uninstall_permanent_message">Повне та остаточне видалення KernelSU Next (Root та всіх модулів).</string>
@@ -290,8 +289,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Дозволений root доступ через KernelSU ioctl</string>
   <string name="sulog_entry_title_daemon_restarted">Службу перезавантажено</string>
   <string name="sulog_entry_title_dropped_events">Втрачені події</string>
-  <string name="uapi_mismatch">Версія uapi менеджера (%1$d) та версія uapi драйвера KernelSU (%2$d) не збігаються.</string>
-  <string name="require_manager_version">Поточна версія менеджера KernelSU %1$d є занадто низькою для коректної роботи KernelSU. Будь ласка, оновіть менеджер до версії %2$d або вище!</string>
   <string name="profile_flags">Прапорці</string>
   <string name="profile_flags_desc_no_new_privs">Запобігти подальшому підвищенню привілеїв через KernelSU в контексті цього root-профілю.</string>
   <string name="settings_sulog">Журнал SU</string>
@@ -309,4 +306,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Успішно</string>
   <string name="sulog_status_exit">Вийти з %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">Поточна версія менеджера KernelSU-Next %1$d є занадто низькою для коректної роботи KernelSU-Next. Будь ласка, оновіть менеджер до версії %2$d або вище!</string>
+  <string name="require_kernel_version">Поточна версія KernelSU-Next %1$d надто низька для коректної роботи менеджера. Будь ласка, оновіться до версії %2$d або вище!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-vi-rVN/strings.xml
+++ b/manager/app/src/main/res/values-vi-rVN/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">Khắc phục lỗi rò rỉ ngữ cảnh selinux do từ chối avc gây ra trong nhật ký kiểm tra.</string>
   <string name="manage_repositories">Quản lý Kho</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">Phiên bản KernelSU-Next hiện tại %1$d quá thấp để trình quản lý có thể hoạt động bình thường. Vui lòng nâng cấp lên phiên bản %2$d hoặc cao hơn!</string>
   <string name="profile_umount_modules_summary">Bật tùy chọn này sẽ cho phép KernelSU-Next khôi phục bất kỳ tệp nào đã được sửa đổi bởi các mô-đun cho ứng dụng này.</string>
   <string name="settings_uninstall_temporary_message">Tạm thời gỡ cài đặt KernelSU-Next, khôi phục về trạng thái ban đầu sau lần khởi động lại tiếp theo.</string>
   <string name="settings_uninstall_permanent_message">Gỡ cài đặt KernelSU-Next (root và tất cả các mô-đun) hoàn toàn và vĩnh viễn.</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">Đã cấp quyền thông qua KernelSU iotcl</string>
   <string name="sulog_entry_title_daemon_restarted">Đã khởi động lại Daemon</string>
   <string name="sulog_entry_title_dropped_events">Sự kiện bị hủy</string>
-  <string name="uapi_mismatch">Phiên bản uapi của trình quản lý (%1$d) và phiên bản uapi của trình điều khiển KernelSU (%2$d) không khớp.</string>
-  <string name="require_manager_version">Phiên bản trình quản lý KernelSU hiện tại %1$d quá thấp để KernelSU hoạt động đúng cách. Vui lòng nâng cấp trình quản lý lên phiên bản %2$d hoặc cao hơn!</string>
   <string name="profile_flags">Cờ</string>
   <string name="profile_flags_desc_no_new_privs">Ngăn chặn việc leo thang đặc quyền hơn nữa thông qua KernelSU từ bên trong phạm vi cấu hình root này.</string>
   <string name="settings_sulog">Nhật ký SU</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">Thành công</string>
   <string name="sulog_status_exit">Thoát %1$d</string>
+  <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+  <string name="home_lkm_custom">Custom</string>
+  <string name="require_manager_version">Phiên bản trình quản lý KernelSU-Next hiện tại %1$d quá thấp để KernelSU-Next hoạt động đúng cách. Vui lòng nâng cấp trình quản lý lên phiên bản %2$d hoặc cao hơn!</string>
+  <string name="require_kernel_version">Phiên bản KernelSU-Next hiện tại %1$d quá thấp để trình quản lý có thể hoạt động bình thường. Vui lòng nâng cấp lên phiên bản %2$d hoặc cao hơn!</string>
+  <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">修复日志中 avc denial 导致的 SELinux 上下文泄漏。</string>
   <string name="manage_repositories">管理仓库</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">当前 KernelSU-Next 版本 %1$d 过低，管理器无法正常工作。请升级到 %2$d 或更高版本！</string>
   <string name="profile_umount_modules_summary">启用该选项后将允许 KernelSU-Next 为本应用还原被模块修改过的文件。</string>
   <string name="settings_uninstall_temporary_message">临时卸载 KernelSU-Next，设备下次重启后将恢复原状。</string>
   <string name="settings_uninstall_permanent_message">彻底永久卸载 KernelSU-Next（包括 root 和所有模块）。</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">通过 KernelSU ioctl 授予的 root 权限</string>
   <string name="sulog_entry_title_daemon_restarted">守护进程已重启</string>
   <string name="sulog_entry_title_dropped_events">丢弃的事件</string>
-  <string name="uapi_mismatch">管理器 uapi 版本 (%1$d) 与 KernelSU 驱动 uapi 版本 (%2$d) 不匹配。</string>
-  <string name="require_manager_version">当前 KernelSU 管理器版本 %1$d 过低，KernelSU 无法正常工作。请将 KernelSU 管理器版本升级至 %2$d 或以上！</string>
   <string name="profile_flags">标志</string>
   <string name="profile_flags_desc_no_new_privs">禁止从此 Root Profile 的上下文中通过 KernelSU 进一步提升权限。</string>
   <string name="settings_sulog">SU 日志</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">成功</string>
   <string name="sulog_status_exit">退出码 %1$d</string>
+  <string name="home_lkm_update_available">内嵌 LKM 有可用更新，点击更新</string>
+  <string name="home_lkm_custom">自定义</string>
+  <string name="require_manager_version">当前 KernelSU-Next 管理器版本 %1$d 过低，KernelSU-Next 无法正常工作。请将 KernelSU-Next 管理器版本升级至 %2$d 或以上！</string>
+  <string name="require_kernel_version">当前 KernelSU-Next 版本 %1$d 过低，管理器无法正常工作。请升级到 %2$d 或更高版本！</string>
+  <string name="require_kernel_version_gki">需要更新内核</string>
 </resources>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -236,7 +236,6 @@
   <string name="settings_enable_avc_spoof_summary">修復日誌中 avc denial 導致的 Selinux 上下文洩漏。</string>
   <string name="manage_repositories">管理儲存庫</string>
   <string name="app_name">KernelSU-Next</string>
-  <string name="require_kernel_version">目前 KernelSU-Next 版本 %1$d 過低，管理員無法正常工作，請升級內核 KernelSU-Next 版本至 %2$d 或以上！</string>
   <string name="profile_umount_modules_summary">啟用選項後，KernelSU 會將應用程式內遭模組修改的檔案恢復原狀。</string>
   <string name="settings_uninstall_temporary_message">暫時移除 KernelSU Next， 設備下次重新啓動後還原至原始狀態。</string>
   <string name="settings_uninstall_permanent_message">徹底永久移除 KernelSU Next，將失去 Root 權限及所有已安裝的模組。</string>
@@ -288,8 +287,6 @@
   <string name="sulog_entry_description_ioctl_grant_root">已透過 KernelSU ioctl 授予 Root 權限</string>
   <string name="sulog_entry_title_daemon_restarted">Daemon 已重新啟動</string>
   <string name="sulog_entry_title_dropped_events">已捨棄事件</string>
-  <string name="uapi_mismatch">管理器的 uapi 版本 (%1$d) 與目前 KernelSU 驅動的 uapi 版本 (%2$d) 不相符。</string>
-  <string name="require_manager_version">當前 KernelSU 管理器版本 %1$d 過低，KernelSU 無法正常工作。請將 KernelSU 管理器版本升級至 %2$d 或以上！</string>
   <string name="profile_flags">標誌</string>
   <string name="profile_flags_desc_no_new_privs">禁止從此 Root Profile 的上下文中通過 KernelSU 進一步提升權限。</string>
   <string name="settings_sulog">SU 日誌</string>
@@ -307,4 +304,9 @@
   <string name="sulog_uid">UID %1$s</string>
   <string name="sulog_status_success">成功</string>
   <string name="sulog_status_exit">退出碼 %1$d</string>
+  <string name="home_lkm_update_available">有可用的內建 LKM 更新，點選更新</string>
+  <string name="home_lkm_custom">自訂</string>
+  <string name="require_manager_version">當前 KernelSU-Next 管理器版本 %1$d 過低，KernelSU-Next 無法正常工作。請將 KernelSU-Next 管理器版本升級至 %2$d 或以上！</string>
+  <string name="require_kernel_version">目前 KernelSU-Next 版本 %1$d 過低，管理員無法正常工作，請升級內核 KernelSU-Next 版本至 %2$d 或以上！</string>
+  <string name="require_kernel_version_gki">需要更新核心</string>
 </resources>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -125,9 +125,6 @@
     <string name="profile_selinux_context">SELinux context</string>
     <string name="profile_umount_modules">Umount modules</string>
     <string name="failed_to_update_app_profile">Failed to update App Profile for %s</string>
-    <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
-    <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
-    <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
     <string name="settings_umount_modules_default">Umount modules</string>
     <string name="settings_umount_modules_default_summary">The global default value for \"Umount modules\" in App Profile. If enabled, it will remove all module modifications to the system for apps that don\'t have a profile set.</string>
     <string name="profile_umount_modules_summary">Enabling this option will allow KernelSU-Next to restore any modified files by the modules for this app.</string>
@@ -307,4 +304,9 @@
     <string name="sulog_uid">UID %1$s</string>
     <string name="sulog_status_success">Success</string>
     <string name="sulog_status_exit">Exit %1$d</string>
+    <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+    <string name="home_lkm_custom">Custom</string>
+    <string name="require_manager_version">The current KernelSU-Next manager version %1$d is too low for KernelSU-Next to work properly. Please upgrade manager to version %2$d or higher!</string>
+    <string name="require_kernel_version">The current KernelSU-Next version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
+    <string name="require_kernel_version_gki">Kernel update required</string>
 </resources>

--- a/uapi/supercall.h
+++ b/uapi/supercall.h
@@ -8,7 +8,8 @@
 
 // 2: allowlist v4 root profile flags
 // 3: scoped su-session driver fd
-static const __u32 KERNEL_SU_UAPI_VERSION = 3;
+// 4: add KSU_GET_INFO_FLAG_BUNDLED
+static const __u32 KERNEL_SU_UAPI_VERSION = 4;
 
 /* Magic numbers for reboot hook to install fd */
 static const __u32 KSU_INSTALL_MAGIC1 = 0xDEADBEEF;
@@ -34,6 +35,7 @@ static const __u32 KSU_GET_INFO_FLAG_LKM = (1U << 0);
 static const __u32 KSU_GET_INFO_FLAG_MANAGER = (1U << 1);
 static const __u32 KSU_GET_INFO_FLAG_LATE_LOAD = (1U << 2);
 static const __u32 KSU_GET_INFO_FLAG_PR_BUILD = (1U << 3);
+static const __u32 KSU_GET_INFO_FLAG_BUNDLED = (1U << 4);
 
 struct ksu_get_info_cmd {
     __u32 version; /* Output: KERNEL_SU_VERSION */

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -536,6 +536,9 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
             );
         }
 
+        // None means --no-install: preserve the marker for the existing LKM.
+        let bundled_lkm = (!no_install).then_some(kmod.is_none());
+
         let kmi = kmi.map_or_else(
             || -> Result<_> {
                 #[cfg(target_os = "android")]
@@ -711,6 +714,9 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
 
         apply_config("no custom rc", "norc=1", no_custom_rc);
         apply_config("allow shell", "allow_shell=1", allow_shell);
+        if let Some(bundled) = bundled_lkm {
+            apply_config("bundled LKM", "bundled=1", bundled);
+        }
 
         if ksu_config.is_empty() {
             cpio.rm("ksu_config", false);

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -706,6 +706,10 @@ pub fn run() -> Result<()> {
                 println!("uapi_version: {}", info.uapi_version);
                 println!("features: 0x{:x}", info.features);
                 println!("lkm: {}", ksucalls::is_lkm());
+                println!(
+                    "bundled: {}",
+                    (info.flags & ksu_uapi::KSU_GET_INFO_FLAG_BUNDLED) != 0
+                );
                 println!("late_load: {}", ksucalls::is_late_load());
                 println!("runtime_mode: {}", ksucalls::runtime_mode());
                 println!(

--- a/userspace/ksud/src/ksucalls.rs
+++ b/userspace/ksud/src/ksucalls.rs
@@ -10,7 +10,9 @@ use std::sync::OnceLock;
 
 // sigsys handler
 std::thread_local! {
+    #[allow(clippy::missing_const_for_thread_local)]
     static SVC_IN_FLIGHT: Cell<bool> = const { Cell::new(false) };
+    #[allow(clippy::missing_const_for_thread_local)]
     static SIGSYS_OCCURRED: Cell<bool> = const { Cell::new(false) };
 }
 

--- a/userspace/ksud/src/late_load.rs
+++ b/userspace/ksud/src/late_load.rs
@@ -59,6 +59,7 @@ pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Res
 
         // 4. Load kernelsu.ko from memory with manual relocation
         info!("Loading kernelsu.ko for KMI {kmi}...");
+        // bundled flag is meaningless in jailbreak mode since we can't flash boot to update it.
         let params = if allow_shell {
             cstr!("allow_shell=1")
         } else {


### PR DESCRIPTION
```
Author: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>
Date:   Mon Sep 7 11:02:54 2026 +0800
```

KernelSU's version checking mechanism requires users to always use the corresponding manager, kernel, and ksud. If a version mismatch occurs, a banner warning will appear at the top of the manager, reminding the user to update. This is to ensure that updating one component will also update the others for proper functionality. However, this can be confusing in some situations because certain kernels are not yet compatible with the official LKM. Users may need to compile and add commits themselves while still using the official manager, leading to a version mismatch between the compiled LKM and the manager, resulting in a warning that is actually unnecessary.

To address this, this commit improves the version checking mechanism. Now, the manager will only issue a warning and force the user to update the LKM if the UAPI version is mismatched. Furthermore, to ensure that users using the manager's built-in LKM receive update prompts correctly, a bundled lkm flag has been introduced. If a user uses the built-in LKM, an update prompt will be issued if the version is incompatible. However, if using an external LKM, this prompt will not be received; instead, the word "Custom" will be displayed in the version field, indicating that the user needs to maintain the functionality's availability. Finally, the text and interaction logic of update prompts and warnings have been optimized, simplifying the descriptions and allowing users to click to jump to the LKM installation page.

---------

-strings: Append '-Next' where applicable

---------

Co-authored-by: YuKongA <70465933+YuKongA@users.noreply.github.com>