### PR TITLE
kernel: selinux: Bypass dynamic wrappers conditionally

### DIFF
--- a/kernel/include/ksu.h
+++ b/kernel/include/ksu.h
@@ -17,7 +17,12 @@ extern bool ksu_bundled;
 extern struct selinux_policy *backup_sepolicy;
 extern bool ksu_no_custom_rc;
 
+#ifdef CONFIG_ANDROID
+#include <linux/security.h>
+#define ksu_security_secctx_to_secid security_secctx_to_secid
+#else
 int ksu_security_secctx_to_secid(const char *secdata, u32 seclen, u32 *secid);
+#endif
 
 static inline int startswith(char *s, char *prefix)
 {

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -7,6 +7,10 @@
 #include "ksu.h"
 #include "infra/symbol_resolver.h"
 
+#ifdef CONFIG_ANDROID
+#define ksu_security_secid_to_secctx security_secid_to_secctx
+#define ksu_security_release_secctx security_release_secctx
+#else
 int ksu_security_secctx_to_secid(const char *secdata, u32 seclen, u32 *secid)
 {
     static int (*real_func)(const char *, u32, u32 *) = NULL;
@@ -70,6 +74,7 @@ static void ksu_security_release_secctx(char *secdata, u32 seclen)
         real_func(secdata, seclen);
     }
 }
+#endif
 #endif
 
 /*


### PR DESCRIPTION
-Dynamic secctx wrappers (kallsyms) may trigger kCFI traps (indirect ptr calls)
  -Map kernel exports ('CONFIG_ANDROID'; bypasses kCFI; direct)
  -Retain modpost/linker fixes for out-of-tree