### PR TITLE
fix(kernel): Reject all signature block id except v2 (https://github.com/tiann/KernelSU/pull/3700)

### DIFF
--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -156,8 +156,6 @@ static __always_inline bool check_v2_signature(char *path,
 
 	bool v2_signing_valid = false;
 	int v2_signing_blocks = 0;
-	bool v3_signing_exist = false;
-	bool v3_1_signing_exist = false;
 
 	int i;
 	struct file *fp = filp_open(path, O_RDONLY, 0);
@@ -255,16 +253,12 @@ static __always_inline bool check_v2_signature(char *path,
 		if (id == 0x7109871au) {
 			v2_signing_blocks++;
 			v2_signing_valid = check_block(fp, &pos, pair_end, expected_size, expected_sha256);
-		} else if (id == 0xf05368c0u) {
-			// http://aospxref.com/android-14.0.0_r2/xref/frameworks/base/core/java/android/util/apk/ApkSignatureSchemeV3Verifier.java#73
-			v3_signing_exist = true;
-		} else if (id == 0x1b93ad61u) {
-			// http://aospxref.com/android-14.0.0_r2/xref/frameworks/base/core/java/android/util/apk/ApkSignatureSchemeV3Verifier.java#74
-			v3_1_signing_exist = true;
-		} else {
+		} else if (id != 0x42726577u) { // APK verity padding
+			// https://cs.android.com/android/platform/superproject/+/android-latest-release:tools/apksig/src/main/java/com/android/apksig/internal/apk/ApkSigningBlockUtils.java;l=102;drc=ebe4dfd4fd6550c949a6c7c2427484bf5e96500b
 #ifdef CONFIG_KSU_DEBUG
-			pr_info("Unknown id: 0x%08x\n", id);
+			pr_info("Unexpected signature block id: 0x%08x\n", id);
 #endif
+			goto invalid;
 		}
 		pos = pair_end;
 	}
@@ -282,11 +276,6 @@ invalid:
 	v2_signing_valid = false;
 clean:
 	filp_close(fp, 0);
-
-	if (v2_signing_valid && (v3_signing_exist || v3_1_signing_exist)) {
-		pr_err("Unexpected v3 signature scheme found!\n");
-		return false;
-	}
 
 	return v2_signing_valid;
 }


### PR DESCRIPTION
```
Author: Wang Han <416810799@qq.com>
Date:   Wed Sep 9 20:54:57 2026 +0800
```

Old code doesn't check for v3.2 signature block id and is unsafe. To ensure no additional block id is forgotten in the future, let's just allow ids we need.

---------

Co-authored-by: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>