### PR TITLE
feat: add Samsung KDP/RKP/DEFEX late-load compatibility

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -1,5 +1,9 @@
 kernelsu-objs := core/init.o
 
+kernelsu-objs += compat/samsung_kdp.o
+kernelsu-objs += compat/samsung_defex.o
+kernelsu-objs += compat/samsung_rkp.o
+
 kernelsu-objs += feature/kernel_umount.o
 kernelsu-objs += feature/sulog.o
 kernelsu-objs += feature/sucompat.o
@@ -65,6 +69,18 @@ endif
 ifeq ($(CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER),y)
 ccflags-y += -DCONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER=1
 endif
+ifeq ($(CONFIG_KSU_SAMSUNG_KDP),y)
+ccflags-y += -DCONFIG_KSU_SAMSUNG_KDP=1
+endif
+ifeq ($(CONFIG_KSU_SAMSUNG_RKP),y)
+ccflags-y += -DCONFIG_KSU_SAMSUNG_RKP=1
+endif
+ifeq ($(CONFIG_KSU_SAMSUNG_DEFEX),y)
+ccflags-y += -DCONFIG_KSU_SAMSUNG_DEFEX=1
+endif
+ifeq ($(CONFIG_KSU_SAMSUNG_NO_PATCH_TEXT),y)
+ccflags-y += -DCONFIG_KSU_SAMSUNG_NO_PATCH_TEXT=1
+endif
 endif
 
 ccflags-y += -I$(srctree)/security/selinux -I$(srctree)/security/selinux/include
@@ -84,7 +100,7 @@ KSU_KERNEL_DIR := $(src)
 endif
 endif
 
-ccflags-y += -I$(KSU_KERNEL_DIR) -I$(KSU_KERNEL_DIR)/include
+ccflags-y += -I$(KSU_KERNEL_DIR) -I$(KSU_KERNEL_DIR)/include -I$(KSU_KERNEL_DIR)/..
 
 obj-$(CONFIG_KSU) += kernelsu.o
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -43,4 +43,36 @@ config KSU_X86_PATCH_SYSCALL_DISPATCHER
 	  Dynamically patch x64's hardened syscall dispatcher to support syscall hooks. This is a
 	  replacement for a kernel source code patch, and is useful for x86_64 LKM mode.
 
+config KSU_SAMSUNG_KDP
+	bool "Samsung KDP credential compatibility"
+	depends on KSU && ARM64
+	default n
+	help
+	  Install and release credentials through Samsung KDP helpers.
+	  Enable only on Samsung kernels that use KDP-protected credentials.
+
+config KSU_SAMSUNG_RKP
+	bool "Samsung RKP hook compatibility"
+	depends on KSU && ARM64 && KPROBES && KRETPROBES
+	default n
+	help
+	  Use kprobe-based syscall fallbacks when Samsung RKP prevents live
+	  writes to the syscall table.
+
+config KSU_SAMSUNG_DEFEX
+	bool "Samsung DEFEX credential compatibility"
+	depends on KSU && ARM64 && KPROBES
+	default n
+	help
+	  Synchronize Samsung DEFEX task credentials after a KernelSU UID
+	  transition and bypass duplicate enforcement for KernelSU tasks.
+
+config KSU_SAMSUNG_NO_PATCH_TEXT
+	bool "Disable live kernel text/data patching on Samsung EL2"
+	depends on KSU && ARM64
+	default n
+	help
+	  Return -EOPNOTSUPP from KernelSU's live patch helper. Enable on
+	  Samsung kernels whose EL2 protection rejects fixmap writes.
+
 endmenu

--- a/kernel/compat/samsung_defex.c
+++ b/kernel/compat/samsung_defex.c
@@ -1,0 +1,109 @@
+#include <linux/cred.h>
+#include <linux/errno.h>
+#include <linux/kprobes.h>
+#include <linux/sched.h>
+
+#include "compat/samsung_defex.h"
+#include "infra/symbol_resolver.h"
+#include "klog.h"
+#include "selinux/selinux.h"
+
+#ifdef CONFIG_KSU_SAMSUNG_DEFEX
+typedef void (*defex_get_task_creds_t)(struct task_struct *task,
+				       unsigned int *uid, unsigned int *fsuid,
+				       unsigned int *egid,
+				       unsigned short *cred_flags);
+typedef int (*defex_set_task_creds_t)(struct task_struct *task,
+				      unsigned int uid, unsigned int fsuid,
+				      unsigned int egid,
+				      unsigned short cred_flags);
+
+static defex_get_task_creds_t defex_get_task_creds;
+static defex_set_task_creds_t defex_set_task_creds;
+static bool defex_enforce_hooked;
+
+static int ksu_samsung_defex_pre_handler(struct kprobe *probe,
+					 struct pt_regs *regs)
+{
+	struct task_struct *task = (struct task_struct *)regs->regs[0];
+
+	(void)probe;
+	if (task == current && current_uid().val == 0 && is_ksu_domain())
+		regs->regs[0] = 0;
+
+	return 0;
+}
+
+static struct kprobe defex_enforce_kprobe = {
+	.symbol_name = "task_defex_enforce",
+	.pre_handler = ksu_samsung_defex_pre_handler,
+};
+#endif
+
+int ksu_samsung_defex_init(void)
+{
+#ifdef CONFIG_KSU_SAMSUNG_DEFEX
+	int ret;
+
+	defex_get_task_creds =
+		(defex_get_task_creds_t)ksu_resolve_symbol_for_functable_hook(
+			"get_task_creds");
+	defex_set_task_creds =
+		(defex_set_task_creds_t)ksu_resolve_symbol_for_functable_hook(
+			"set_task_creds");
+	if (!defex_get_task_creds || !defex_set_task_creds) {
+		pr_err("Samsung DEFEX credential functions unavailable\n");
+		return -ENOENT;
+	}
+
+	ret = register_kprobe(&defex_enforce_kprobe);
+	if (ret) {
+		pr_err("Samsung DEFEX enforce hook unavailable: %d\n", ret);
+		return ret;
+	}
+	defex_enforce_hooked = true;
+	pr_info("Samsung DEFEX compatibility enabled\n");
+#endif
+	return 0;
+}
+
+void ksu_samsung_defex_exit(void)
+{
+#ifdef CONFIG_KSU_SAMSUNG_DEFEX
+	if (defex_enforce_hooked) {
+		unregister_kprobe(&defex_enforce_kprobe);
+		defex_enforce_hooked = false;
+	}
+#endif
+}
+
+void ksu_samsung_defex_sync_current(void)
+{
+#ifdef CONFIG_KSU_SAMSUNG_DEFEX
+	const struct cred *cred = current_cred();
+	unsigned int stored_uid;
+	unsigned int stored_fsuid;
+	unsigned int stored_egid;
+	unsigned short cred_flags;
+	int ret;
+
+	defex_get_task_creds(current, &stored_uid, &stored_fsuid, &stored_egid,
+			     &cred_flags);
+	if (__kuid_val(cred->euid) == 0 && __kuid_val(cred->fsuid) == 0 &&
+	    __kgid_val(cred->egid) == 0) {
+		stored_uid = 1;
+		stored_fsuid = 1;
+		stored_egid = 1;
+	} else {
+		stored_uid = __kuid_val(cred->euid);
+		stored_fsuid = __kuid_val(cred->fsuid);
+		stored_egid = __kgid_val(cred->egid);
+	}
+
+	ret = defex_set_task_creds(current, stored_uid, stored_fsuid,
+				   stored_egid, cred_flags);
+	if (ret)
+		pr_err("Samsung DEFEX credential synchronization failed: %d\n",
+		       ret);
+#endif
+}

--- a/kernel/compat/samsung_defex.h
+++ b/kernel/compat/samsung_defex.h
@@ -1,0 +1,8 @@
+#ifndef __KSU_SAMSUNG_DEFEX_H
+#define __KSU_SAMSUNG_DEFEX_H
+
+int ksu_samsung_defex_init(void);
+void ksu_samsung_defex_exit(void);
+void ksu_samsung_defex_sync_current(void);
+
+#endif

--- a/kernel/compat/samsung_kdp.c
+++ b/kernel/compat/samsung_kdp.c
@@ -1,0 +1,187 @@
+#include <linux/completion.h>
+#include <linux/cred.h>
+#include <linux/errno.h>
+#include <linux/rcupdate.h>
+#include <linux/sched.h>
+#include <linux/sched/task.h>
+#include <linux/sched/user.h>
+#include <linux/user_namespace.h>
+#include <linux/version.h>
+#include <linux/workqueue.h>
+
+#include "infra/symbol_resolver.h"
+#include "ksu_samsung_kdp.h"
+#include "klog.h"
+
+#ifdef CONFIG_KSU_SAMSUNG_KDP
+enum samsung_kdp_cred_command {
+	SAMSUNG_KDP_COPY_CREDS = 0,
+};
+
+typedef struct cred *(*prepare_ro_creds_t)(struct cred *cred, int command,
+					   u64 task);
+typedef void (*kdp_assign_pgd_t)(struct task_struct *task);
+typedef unsigned int (*kdp_usecount_dec_and_test_t)(struct cred *cred);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+typedef long (*inc_rlimit_ucounts_t)(struct ucounts *ucounts,
+				     enum rlimit_type type, long value);
+typedef bool (*dec_rlimit_ucounts_t)(struct ucounts *ucounts,
+				     enum rlimit_type type, long value);
+#endif
+
+struct samsung_kdp_commit_work {
+	struct work_struct work;
+	struct completion completion;
+	struct task_struct *target;
+	const struct cred *old_cred;
+	struct cred *rw_cred;
+	int result;
+};
+
+static prepare_ro_creds_t prepare_ro_creds_fn;
+static kdp_assign_pgd_t kdp_assign_pgd_fn;
+static kdp_usecount_dec_and_test_t kdp_usecount_dec_and_test_fn;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+static inc_rlimit_ucounts_t inc_rlimit_ucounts_fn;
+static dec_rlimit_ucounts_t dec_rlimit_ucounts_fn;
+#endif
+
+static void samsung_kdp_commit_worker(struct work_struct *work)
+{
+	struct samsung_kdp_commit_work *commit_work =
+		container_of(work, struct samsung_kdp_commit_work, work);
+	struct task_struct *target = commit_work->target;
+	const struct cred *old_cred = commit_work->old_cred;
+	const struct cred *target_cred;
+	const struct cred *target_real_cred;
+	struct cred *ro_cred;
+	bool user_changed;
+
+	if (!uid_eq(current_euid(), GLOBAL_ROOT_UID)) {
+		commit_work->result = -EPERM;
+		goto out;
+	}
+	target_cred = rcu_access_pointer(target->cred);
+	target_real_cred = rcu_access_pointer(target->real_cred);
+	if (target_cred != old_cred || target_real_cred != old_cred) {
+		commit_work->result = -EBUSY;
+		goto out;
+	}
+
+	ro_cred = prepare_ro_creds_fn(commit_work->rw_cred,
+				      SAMSUNG_KDP_COPY_CREDS, (u64)target);
+	if (!ro_cred) {
+		commit_work->result = -EIO;
+		goto out;
+	}
+
+	user_changed = ro_cred->user != old_cred->user;
+	if (user_changed) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+		inc_rlimit_ucounts_fn(ro_cred->ucounts, UCOUNT_RLIMIT_NPROC, 1);
+#else
+		atomic_inc(&ro_cred->user->processes);
+#endif
+	}
+	rcu_assign_pointer(target->real_cred, ro_cred);
+	rcu_assign_pointer(target->cred, ro_cred);
+	kdp_assign_pgd_fn(target);
+	if (user_changed) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+		dec_rlimit_ucounts_fn(old_cred->ucounts, UCOUNT_RLIMIT_NPROC,
+				      1);
+#else
+		atomic_dec(&old_cred->user->processes);
+#endif
+	}
+
+	abort_creds(commit_work->rw_cred);
+	commit_work->rw_cred = NULL;
+	ksu_put_cred(old_cred);
+	ksu_put_cred(old_cred);
+	commit_work->result = 0;
+	pr_info("Samsung KDP credential install pid=%d uid=%u euid=%u\n",
+		task_pid_nr(target), __kuid_val(ro_cred->uid),
+		__kuid_val(ro_cred->euid));
+out:
+	complete(&commit_work->completion);
+}
+#endif
+
+void ksu_samsung_kdp_put_cred(const struct cred *cred)
+{
+#ifdef CONFIG_KSU_SAMSUNG_KDP
+	struct cred *mutable_cred = (struct cred *)cred;
+
+	if (mutable_cred && kdp_usecount_dec_and_test_fn(mutable_cred))
+		__put_cred(mutable_cred);
+#else
+	put_cred(cred);
+#endif
+}
+
+int ksu_samsung_kdp_init(void)
+{
+#ifdef CONFIG_KSU_SAMSUNG_KDP
+	prepare_ro_creds_fn =
+		(prepare_ro_creds_t)ksu_resolve_symbol_for_functable_hook(
+			"prepare_ro_creds");
+	kdp_assign_pgd_fn =
+		(kdp_assign_pgd_t)ksu_resolve_symbol_for_functable_hook(
+			"kdp_assign_pgd");
+	kdp_usecount_dec_and_test_fn = (kdp_usecount_dec_and_test_t)
+		ksu_resolve_symbol_for_functable_hook(
+			"kdp_usecount_dec_and_test");
+	if (!prepare_ro_creds_fn || !kdp_assign_pgd_fn ||
+	    !kdp_usecount_dec_and_test_fn) {
+		pr_err("Samsung KDP credential functions unavailable\n");
+		return -ENOENT;
+	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+	inc_rlimit_ucounts_fn =
+		(inc_rlimit_ucounts_t)ksu_resolve_symbol_for_functable_hook(
+			"inc_rlimit_ucounts");
+	dec_rlimit_ucounts_fn =
+		(dec_rlimit_ucounts_t)ksu_resolve_symbol_for_functable_hook(
+			"dec_rlimit_ucounts");
+	if (!inc_rlimit_ucounts_fn || !dec_rlimit_ucounts_fn) {
+		pr_err("Samsung KDP ucounts functions unavailable\n");
+		return -ENOENT;
+	}
+#endif
+	pr_info("Samsung KDP credential compatibility enabled\n");
+#endif
+	return 0;
+}
+
+void ksu_samsung_kdp_exit(void)
+{
+}
+
+int ksu_samsung_kdp_commit_creds(struct cred *cred)
+{
+#ifdef CONFIG_KSU_SAMSUNG_KDP
+	struct samsung_kdp_commit_work commit_work;
+	bool queued;
+
+	if (!cred)
+		return -EINVAL;
+	INIT_WORK(&commit_work.work, samsung_kdp_commit_worker);
+	init_completion(&commit_work.completion);
+	commit_work.target = current;
+	commit_work.old_cred = current_real_cred();
+	commit_work.rw_cred = cred;
+	commit_work.result = -EIO;
+	get_task_struct(commit_work.target);
+	queued = schedule_work(&commit_work.work);
+	if (!queued) {
+		put_task_struct(commit_work.target);
+		return -EBUSY;
+	}
+	wait_for_completion(&commit_work.completion);
+	put_task_struct(commit_work.target);
+	return commit_work.result;
+#else
+	return commit_creds(cred);
+#endif
+}

--- a/kernel/compat/samsung_rkp.c
+++ b/kernel/compat/samsung_rkp.c
@@ -1,0 +1,250 @@
+#include <asm/syscall.h>
+#include <linux/kprobes.h>
+#include <linux/ptrace.h>
+#include <linux/slab.h>
+#include <linux/task_work.h>
+
+#include "arch.h"
+#include "compat/samsung_rkp.h"
+#include "feature/sucompat.h"
+#include "hook/setuid_hook.h"
+#include "hook/syscall_event_bridge.h"
+#include "hook/syscall_hook.h"
+#include "klog.h"
+#include "policy/allowlist.h"
+
+#if defined(CONFIG_KSU_SAMSUNG_RKP) && defined(CONFIG_KRETPROBES) &&           \
+	defined(__aarch64__)
+#define SAMSUNG_RKP_BYPASS_NR (-2)
+
+struct samsung_setresuid_work {
+	struct callback_head callback;
+	uid_t old_uid;
+	uid_t new_uid;
+};
+
+static bool hooks_registered;
+static bool setresuid_registered;
+
+static bool consume_bypass(int syscall_nr)
+{
+	struct pt_regs *regs = task_pt_regs(current);
+
+	if (unlikely(regs->syscallno == SAMSUNG_RKP_BYPASS_NR)) {
+		regs->syscallno = syscall_nr;
+		return true;
+	}
+	return false;
+}
+
+static long __nocfi samsung_execve(const struct pt_regs *regs)
+{
+	struct pt_regs *syscall_regs = (struct pt_regs *)regs;
+	long ret;
+
+	syscall_regs->syscallno = SAMSUNG_RKP_BYPASS_NR;
+	ret = ksu_hook_execve(__NR_execve, regs);
+	syscall_regs->syscallno = __NR_execve;
+	return ret;
+}
+
+static long __nocfi samsung_execveat(const struct pt_regs *regs)
+{
+	struct pt_regs *syscall_regs = (struct pt_regs *)regs;
+	long ret;
+
+	syscall_regs->syscallno = SAMSUNG_RKP_BYPASS_NR;
+	ret = ksu_hook_execveat(__NR_execveat, regs);
+	syscall_regs->syscallno = __NR_execveat;
+	return ret;
+}
+
+static long __nocfi samsung_newfstatat(const struct pt_regs *regs)
+{
+	struct pt_regs *syscall_regs = (struct pt_regs *)regs;
+	long ret;
+
+	syscall_regs->syscallno = SAMSUNG_RKP_BYPASS_NR;
+	ret = ksu_hook_newfstatat(__NR_newfstatat, regs);
+	syscall_regs->syscallno = __NR_newfstatat;
+	return ret;
+}
+
+static long __nocfi samsung_faccessat(const struct pt_regs *regs)
+{
+	struct pt_regs *syscall_regs = (struct pt_regs *)regs;
+	long ret;
+
+	syscall_regs->syscallno = SAMSUNG_RKP_BYPASS_NR;
+	ret = ksu_hook_faccessat(__NR_faccessat, regs);
+	syscall_regs->syscallno = __NR_faccessat;
+	return ret;
+}
+
+static int execve_pre(struct kprobe *probe, struct pt_regs *regs)
+{
+	(void)probe;
+	if (consume_bypass(__NR_execve))
+		return 0;
+	instruction_pointer_set(regs, (unsigned long)samsung_execve);
+	return 1;
+}
+
+static int execveat_pre(struct kprobe *probe, struct pt_regs *regs)
+{
+	(void)probe;
+	if (consume_bypass(__NR_execveat))
+		return 0;
+	instruction_pointer_set(regs, (unsigned long)samsung_execveat);
+	return 1;
+}
+
+static int newfstatat_pre(struct kprobe *probe, struct pt_regs *regs)
+{
+	(void)probe;
+	if (consume_bypass(__NR_newfstatat))
+		return 0;
+	if (!READ_ONCE(ksu_su_compat_enabled) ||
+	    !ksu_is_allow_uid_for_current(current_uid().val))
+		return 0;
+	instruction_pointer_set(regs, (unsigned long)samsung_newfstatat);
+	return 1;
+}
+
+static int faccessat_pre(struct kprobe *probe, struct pt_regs *regs)
+{
+	(void)probe;
+	if (consume_bypass(__NR_faccessat))
+		return 0;
+	if (!READ_ONCE(ksu_su_compat_enabled) ||
+	    !ksu_is_allow_uid_for_current(current_uid().val))
+		return 0;
+	instruction_pointer_set(regs, (unsigned long)samsung_faccessat);
+	return 1;
+}
+
+static struct kprobe execve_kprobe = { .pre_handler = execve_pre };
+static struct kprobe execveat_kprobe = { .pre_handler = execveat_pre };
+static struct kprobe newfstatat_kprobe = { .pre_handler = newfstatat_pre };
+static struct kprobe faccessat_kprobe = { .pre_handler = faccessat_pre };
+
+static void setresuid_work(struct callback_head *callback)
+{
+	struct samsung_setresuid_work *work =
+		container_of(callback, struct samsung_setresuid_work, callback);
+
+	ksu_handle_setresuid(work->old_uid, work->new_uid);
+	kfree(work);
+}
+
+static int setresuid_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+	(void)regs;
+	*(uid_t *)ri->data = current_uid().val;
+	return 0;
+}
+
+static int setresuid_return(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+	struct samsung_setresuid_work *work;
+	uid_t old_uid = *(uid_t *)ri->data;
+	uid_t new_uid;
+
+	if (regs_return_value(regs) < 0)
+		return 0;
+	new_uid = current_uid().val;
+	if (old_uid == new_uid)
+		return 0;
+
+	work = kzalloc(sizeof(*work), GFP_ATOMIC);
+	if (!work)
+		return 0;
+	work->old_uid = old_uid;
+	work->new_uid = new_uid;
+	work->callback.func = setresuid_work;
+	if (task_work_add(current, &work->callback, TWA_RESUME))
+		kfree(work);
+	return 0;
+}
+
+static struct kretprobe setresuid_kretprobe = {
+	.entry_handler = setresuid_entry,
+	.handler = setresuid_return,
+	.data_size = sizeof(uid_t),
+};
+
+static int register_syscall_kprobe(struct kprobe *probe, int nr)
+{
+	probe->addr = (kprobe_opcode_t *)READ_ONCE(ksu_syscall_table[nr]);
+	return register_kprobe(probe);
+}
+
+static void unregister_syscall_hooks(void)
+{
+	if (!hooks_registered)
+		return;
+	unregister_kprobe(&faccessat_kprobe);
+	unregister_kprobe(&newfstatat_kprobe);
+	unregister_kprobe(&execveat_kprobe);
+	unregister_kprobe(&execve_kprobe);
+	hooks_registered = false;
+}
+#endif
+
+int ksu_samsung_rkp_init(void)
+{
+#if defined(CONFIG_KSU_SAMSUNG_RKP) && defined(CONFIG_KRETPROBES) &&           \
+	defined(__aarch64__)
+	int ret;
+
+	if (!ksu_syscall_table)
+		return -ENOENT;
+	ret = register_syscall_kprobe(&execve_kprobe, __NR_execve);
+	if (ret)
+		return ret;
+	ret = register_syscall_kprobe(&execveat_kprobe, __NR_execveat);
+	if (ret)
+		goto unregister_execve;
+	ret = register_syscall_kprobe(&newfstatat_kprobe, __NR_newfstatat);
+	if (ret)
+		goto unregister_execveat;
+	ret = register_syscall_kprobe(&faccessat_kprobe, __NR_faccessat);
+	if (ret)
+		goto unregister_newfstatat;
+	hooks_registered = true;
+
+	setresuid_kretprobe.kp.addr =
+		(kprobe_opcode_t *)READ_ONCE(ksu_syscall_table[__NR_setresuid]);
+	ret = register_kretprobe(&setresuid_kretprobe);
+	if (ret)
+		goto unregister_all;
+	setresuid_registered = true;
+	pr_info("Samsung RKP syscall fallback enabled\n");
+	return 0;
+
+unregister_all:
+	unregister_syscall_hooks();
+	return ret;
+unregister_newfstatat:
+	unregister_kprobe(&newfstatat_kprobe);
+unregister_execveat:
+	unregister_kprobe(&execveat_kprobe);
+unregister_execve:
+	unregister_kprobe(&execve_kprobe);
+	return ret;
+#else
+	return -EOPNOTSUPP;
+#endif
+}
+
+void ksu_samsung_rkp_exit(void)
+{
+#if defined(CONFIG_KSU_SAMSUNG_RKP) && defined(CONFIG_KRETPROBES) &&           \
+	defined(__aarch64__)
+	if (setresuid_registered) {
+		unregister_kretprobe(&setresuid_kretprobe);
+		setresuid_registered = false;
+	}
+	unregister_syscall_hooks();
+#endif
+}

--- a/kernel/compat/samsung_rkp.h
+++ b/kernel/compat/samsung_rkp.h
@@ -1,0 +1,7 @@
+#ifndef __KSU_SAMSUNG_RKP_H
+#define __KSU_SAMSUNG_RKP_H
+
+int ksu_samsung_rkp_init(void);
+void ksu_samsung_rkp_exit(void);
+
+#endif

--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -25,6 +25,8 @@
 #include "feature/selinux_hide.h"
 #include "feature/sulog.h"
 #include "infra/symbol_resolver.h"
+#include "compat/samsung_defex.h"
+#include "ksu_samsung_kdp.h"
 
 #if defined(__x86_64__) && !defined(CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER)
 #include <asm/cpufeature.h>
@@ -86,6 +88,8 @@ module_param_named(norc, ksu_no_custom_rc, bool, 0);
 
 int __init kernelsu_init(void)
 {
+	int ret;
+
 #if defined(__x86_64__) && !defined(CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER)
     // If the kernel has the hardening patch, X86_FEATURE_INDIRECT_SAFE must be set
     if (!boot_cpu_has(X86_FEATURE_INDIRECT_SAFE)) {
@@ -121,13 +125,24 @@ int __init kernelsu_init(void)
 		pr_alert("shell is allowed at init!");
 	}
 
+	ksu_init_symbol_resolver();
+	ret = ksu_samsung_kdp_init();
+	if (ret)
+		return ret;
+
 	ksu_cred = prepare_creds();
 	if (!ksu_cred) {
 		pr_err("prepare cred failed!\n");
+		ksu_samsung_kdp_exit();
 		return -ENOSYS;
 	}
 
-	ksu_init_symbol_resolver();
+	ret = ksu_samsung_defex_init();
+	if (ret) {
+		ksu_put_cred(ksu_cred);
+		ksu_samsung_kdp_exit();
+		return ret;
+	}
 	ksu_syscall_hook_init();
 
 	ksu_feature_init();
@@ -218,7 +233,9 @@ void __exit kernelsu_exit(void)
 
 	ksu_feature_exit();
 
-	put_cred(ksu_cred);
+	ksu_samsung_defex_exit();
+	ksu_put_cred(ksu_cred);
+	ksu_samsung_kdp_exit();
 }
 
 #if NEED_OWN_STACKPROTECTOR

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -14,6 +14,11 @@
 #include <net/genetlink.h>
 #include <linux/moduleparam.h>
 #include <linux/mutex.h>
+#if defined(CONFIG_KSU_SAMSUNG_RKP) && defined(__aarch64__)
+#include <linux/hashtable.h>
+#include <linux/kprobes.h>
+#include <linux/spinlock.h>
+#endif
 // security/selinux/include/security.h
 #include <security.h>
 #include <ss/context.h>
@@ -318,6 +323,122 @@ static int my_sel_open_handle_status(struct inode *inode, struct file *filp)
     return ret;
 }
 
+#if defined(CONFIG_KSU_SAMSUNG_RKP) && defined(__aarch64__)
+/*
+ * Samsung RKP makes the SELinux operation tables read-only even to the
+ * kernel. Keep upstream's replacements, but reach them through function
+ * entry kprobes instead of modifying the protected table entries.
+ */
+#define KSU_SELINUX_BYPASS_BITS 4
+
+struct samsung_selinux_bypass {
+    struct hlist_node node;
+    struct task_struct *task;
+};
+
+static DEFINE_HASHTABLE(samsung_selinux_bypass_tasks, KSU_SELINUX_BYPASS_BITS);
+static DEFINE_SPINLOCK(samsung_selinux_bypass_lock);
+static bool samsung_context_registered;
+static bool samsung_access_registered;
+static bool samsung_status_registered;
+static bool samsung_setprocattr_registered;
+
+static bool samsung_selinux_is_bypassed(void)
+{
+    struct samsung_selinux_bypass *entry;
+    unsigned long flags;
+    bool found = false;
+
+    spin_lock_irqsave(&samsung_selinux_bypass_lock, flags);
+    hash_for_each_possible(samsung_selinux_bypass_tasks, entry, node, (unsigned long)current) {
+        if (entry->task == current) {
+            found = true;
+            break;
+        }
+    }
+    spin_unlock_irqrestore(&samsung_selinux_bypass_lock, flags);
+    return found;
+}
+
+static int samsung_setprocattr(const char *name, void *value, size_t size)
+{
+    struct samsung_selinux_bypass bypass = { .task = current };
+    unsigned long flags;
+    int ret;
+
+    spin_lock_irqsave(&samsung_selinux_bypass_lock, flags);
+    hash_add(samsung_selinux_bypass_tasks, &bypass.node, (unsigned long)current);
+    spin_unlock_irqrestore(&samsung_selinux_bypass_lock, flags);
+
+    ret = my_setprocattr(name, value, size);
+
+    spin_lock_irqsave(&samsung_selinux_bypass_lock, flags);
+    hash_del(&bypass.node);
+    spin_unlock_irqrestore(&samsung_selinux_bypass_lock, flags);
+    return ret;
+}
+
+static int samsung_context_pre(struct kprobe *probe, struct pt_regs *regs)
+{
+    (void)probe;
+    if (current_uid().val < 10000)
+        return 0;
+    instruction_pointer_set(regs, (unsigned long)my_write_context);
+    return 1;
+}
+
+static int samsung_access_pre(struct kprobe *probe, struct pt_regs *regs)
+{
+    (void)probe;
+    if (current_uid().val < 10000)
+        return 0;
+    instruction_pointer_set(regs, (unsigned long)my_write_access);
+    return 1;
+}
+
+static int samsung_status_pre(struct kprobe *probe, struct pt_regs *regs)
+{
+    (void)probe;
+    if (current_uid().val < 10000 || !READ_ONCE(ksu_selinux_hide_enabled) || !READ_ONCE(fake_status))
+        return 0;
+    instruction_pointer_set(regs, (unsigned long)my_sel_open_handle_status);
+    return 1;
+}
+
+static int samsung_setprocattr_pre(struct kprobe *probe, struct pt_regs *regs)
+{
+    (void)probe;
+    if (current_uid().val < 10000 || samsung_selinux_is_bypassed())
+        return 0;
+    instruction_pointer_set(regs, (unsigned long)samsung_setprocattr);
+    return 1;
+}
+
+static struct kprobe samsung_context_kprobe = { .pre_handler = samsung_context_pre };
+static struct kprobe samsung_access_kprobe = { .pre_handler = samsung_access_pre };
+static struct kprobe samsung_status_kprobe = { .pre_handler = samsung_status_pre };
+static struct kprobe samsung_setprocattr_kprobe = { .pre_handler = samsung_setprocattr_pre };
+
+static int samsung_register_kprobe(struct kprobe *probe, void *target, bool *registered)
+{
+    int ret;
+
+    probe->addr = (kprobe_opcode_t *)target;
+    ret = register_kprobe(probe);
+    if (!ret)
+        *registered = true;
+    return ret;
+}
+
+static void samsung_unregister_kprobe(struct kprobe *probe, bool *registered)
+{
+    if (!*registered)
+        return;
+    unregister_kprobe(probe);
+    *registered = false;
+}
+#endif
+
 static void hook_selinux_status_open();
 static void ksu_selinux_hide_unhook();
 static int ksu_selinux_hide_enable()
@@ -351,25 +472,43 @@ static int ksu_selinux_hide_enable()
 
     context_write = &selinux_write_op[SEL_CONTEXT];
     pr_info("selinux_hide: context_write: 0x%lx [%pSb]\n", (unsigned long)*context_write, *context_write);
-    write_op_fn my = my_write_context;
     orig_context_write = *context_write;
+#if defined(CONFIG_KSU_SAMSUNG_RKP) && defined(__aarch64__)
+    ret = samsung_register_kprobe(&samsung_context_kprobe, orig_context_write, &samsung_context_registered);
+#else
+    write_op_fn my = my_write_context;
     ret = ksu_patch_text(context_write, &my, sizeof(my), KSU_PATCH_TEXT_FLUSH_DCACHE);
+#endif
     if (ret) {
-        pr_err("selinux_hide: init: patch_text context_write err: %d\n", ret);
+        pr_err("selinux_hide: init: hook context_write err: %d\n", ret);
         goto unhook;
     }
 
     access_write = &selinux_write_op[SEL_ACCESS];
     pr_info("selinux_hide: access_write: 0x%lx [%pSb]\n", (unsigned long)*access_write, *access_write);
-    my = my_write_access;
     orig_access_write = *access_write;
+#if defined(CONFIG_KSU_SAMSUNG_RKP) && defined(__aarch64__)
+    ret = samsung_register_kprobe(&samsung_access_kprobe, orig_access_write, &samsung_access_registered);
+#else
+    my = my_write_access;
     ret = ksu_patch_text(access_write, &my, sizeof(my), KSU_PATCH_TEXT_FLUSH_DCACHE);
+#endif
     if (ret) {
-        pr_err("selinux_hide: init: patch_text access_write err: %d\n", ret);
+        pr_err("selinux_hide: init: hook access_write err: %d\n", ret);
         goto unhook;
     }
 
+#if defined(CONFIG_KSU_SAMSUNG_RKP) && defined(__aarch64__)
+    selinux_setprocattr_hook.original = find_kernel_symbol_exact("selinux_setprocattr");
+    if (!selinux_setprocattr_hook.original) {
+        ret = -ENOENT;
+    } else {
+        ret = samsung_register_kprobe(&samsung_setprocattr_kprobe, selinux_setprocattr_hook.original,
+                                      &samsung_setprocattr_registered);
+    }
+#else
     ret = ksu_lsm_hook(&selinux_setprocattr_hook);
+#endif
     if (ret) {
         pr_err("selinux_hide: init: selinux_setprocattr_hook err: %d\n", ret);
         goto unhook;
@@ -384,6 +523,16 @@ unhook:
 
 static void ksu_selinux_hide_unhook()
 {
+#if defined(CONFIG_KSU_SAMSUNG_RKP) && defined(__aarch64__)
+    samsung_unregister_kprobe(&samsung_setprocattr_kprobe, &samsung_setprocattr_registered);
+    samsung_unregister_kprobe(&samsung_access_kprobe, &samsung_access_registered);
+    samsung_unregister_kprobe(&samsung_context_kprobe, &samsung_context_registered);
+    samsung_unregister_kprobe(&samsung_status_kprobe, &samsung_status_registered);
+    selinux_setprocattr_hook.original = NULL;
+    orig_access_write = NULL;
+    orig_context_write = NULL;
+    orig_sel_open_handle_status = NULL;
+#else
     int ret;
     if (orig_context_write) {
         ret =
@@ -409,6 +558,7 @@ static void ksu_selinux_hide_unhook()
         }
     }
     ksu_lsm_unhook(&selinux_setprocattr_hook);
+#endif
 }
 
 static void ksu_selinux_hide_disable()
@@ -485,11 +635,15 @@ static void hook_selinux_status_open()
         }
         sel_open_handle_status_slot = &ops->open;
     }
-    sel_open_handle_status_fn new_fn = my_sel_open_handle_status;
     orig_sel_open_handle_status = *sel_open_handle_status_slot;
+#if defined(CONFIG_KSU_SAMSUNG_RKP) && defined(__aarch64__)
+    int ret = samsung_register_kprobe(&samsung_status_kprobe, orig_sel_open_handle_status, &samsung_status_registered);
+#else
+    sel_open_handle_status_fn new_fn = my_sel_open_handle_status;
     int ret = ksu_patch_text(sel_open_handle_status_slot, &new_fn, sizeof(new_fn), KSU_PATCH_TEXT_FLUSH_DCACHE);
+#endif
     if (ret) {
-        pr_err("selinux_hide: init: patch_text sel_open_handle_status err: %d\n", ret);
+        pr_err("selinux_hide: init: hook sel_open_handle_status err: %d\n", ret);
         sel_open_handle_status_slot = NULL;
         orig_sel_open_handle_status = NULL;
     }

--- a/kernel/hook/arm64/patch_memory.c
+++ b/kernel/hook/arm64/patch_memory.c
@@ -192,7 +192,12 @@ static int ksu_patch_text_cb(void *arg)
 
 int ksu_patch_text(void *dst, void *src, size_t len, int flags)
 {
-    struct patch_text_info info = {
+#ifdef CONFIG_KSU_SAMSUNG_NO_PATCH_TEXT
+	pr_warn("live patching disabled on Samsung EL2: dst=0x%lx len=%zu flags=0x%x\n",
+		(unsigned long)dst, len, flags);
+	return -EOPNOTSUPP;
+#else
+	struct patch_text_info info = {
         .dst = dst,
         .src = src,
         .len = len,
@@ -200,7 +205,8 @@ int ksu_patch_text(void *dst, void *src, size_t len, int flags)
         .flags = flags,
     };
 
-    return stop_machine(ksu_patch_text_cb, &info, cpu_online_mask);
+	return stop_machine(ksu_patch_text_cb, &info, cpu_online_mask);
+#endif
 }
 
 /*

--- a/kernel/hook/arm64/syscall_hook.c
+++ b/kernel/hook/arm64/syscall_hook.c
@@ -49,13 +49,15 @@ static int patch_syscall_table(int nr, syscall_fn_t fn)
 
 // Direct syscall table patching: overwrite syscall_table[nr] with fn,
 // save original to *old, and record for restoration at module exit.
-void ksu_syscall_table_hook(int nr, syscall_fn_t fn, syscall_fn_t *old)
+int ksu_syscall_table_hook(int nr, syscall_fn_t fn, syscall_fn_t *old)
 {
+	int ret;
+
     if (ksu_syscall_table == NULL)
-        return;
+        return -ENOENT;
     if (nr < 0 || nr >= __NR_syscalls) {
         pr_info("invalid nr: %d\n", nr);
-        return;
+        return -EINVAL;
     }
 
     mutex_lock(&hooked_entries_lock);
@@ -73,21 +75,27 @@ void ksu_syscall_table_hook(int nr, syscall_fn_t fn, syscall_fn_t *old)
             break;
         }
     }
+    if (!found && hooked_count >= ARRAY_SIZE(hooked_entries)) {
+        pr_warn("hooked_entries full, cannot track syscall %d for restoration\n",
+                nr);
+        mutex_unlock(&hooked_entries_lock);
+        return -ENOSPC;
+    }
+
+    ret = patch_syscall_table(nr, fn);
+    if (ret) {
+        mutex_unlock(&hooked_entries_lock);
+        return ret;
+    }
+
     if (!found) {
-        if (hooked_count < ARRAY_SIZE(hooked_entries)) {
             hooked_entries[hooked_count].nr = nr;
             hooked_entries[hooked_count].orig = orig;
             hooked_count++;
-        } else {
-            pr_warn(
-                "hooked_entries full, cannot track syscall %d for restoration\n",
-                nr);
-        }
     }
 
-    patch_syscall_table(nr, fn);
-
     mutex_unlock(&hooked_entries_lock);
+    return 0;
 }
 
 // Restore syscall_table[nr] to its original value and remove from tracking list.
@@ -218,9 +226,12 @@ void __init ksu_syscall_hook_init(void)
         return;
     }
 
+    if (ksu_syscall_table_hook(ni_slot, (syscall_fn_t)ksu_syscall_dispatcher,
+                               NULL)) {
+        pr_warn("dispatcher slot is protected; using architecture fallback hooks\n");
+        return;
+    }
     ksu_dispatcher_nr = ni_slot;
-    ksu_syscall_table_hook(ksu_dispatcher_nr,
-                           (syscall_fn_t)ksu_syscall_dispatcher, NULL);
     pr_info("dispatcher installed at slot %d\n", ksu_dispatcher_nr);
 }
 

--- a/kernel/hook/syscall_hook.h
+++ b/kernel/hook/syscall_hook.h
@@ -37,7 +37,7 @@ bool ksu_has_syscall_hook(int nr);
 // Saves the original handler to *@old (if non-NULL) and records the entry
 // for restoration at module exit. Use this for boot-time hooks that replace
 // a real syscall entry (e.g. ksud hooking __NR_execve/__NR_read/__NR_fstat).
-void ksu_syscall_table_hook(int nr, syscall_fn_t fn, syscall_fn_t *old);
+int ksu_syscall_table_hook(int nr, syscall_fn_t fn, syscall_fn_t *old);
 
 // Restore syscall_table[@nr] to its original value recorded by
 // ksu_syscall_table_hook(), and remove the entry from the tracking list.

--- a/kernel/hook/syscall_hook_manager.c
+++ b/kernel/hook/syscall_hook_manager.c
@@ -21,6 +21,10 @@
 #include "hook/setuid_hook.h"
 #include "hook/syscall_hook.h"
 #include "hook/syscall_event_bridge.h"
+#include "compat/samsung_rkp.h"
+
+static bool syscall_hook_manager_initialized;
+static bool samsung_rkp_initialized;
 
 #ifdef CONFIG_KRETPROBES
 
@@ -126,6 +130,22 @@ void __init ksu_syscall_hook_manager_init(void)
     int ret;
     pr_info("hook_manager: ksu_hook_manager_init called\n");
 
+    if (ksu_dispatcher_nr < 0) {
+        ret = ksu_samsung_rkp_init();
+        if (ret) {
+            pr_err("hook_manager: Samsung RKP fallback unavailable: %d\n",
+                   ret);
+            return;
+        }
+        samsung_rkp_initialized = true;
+        ksu_setuid_hook_init();
+        ksu_sucompat_init();
+        ksu_avc_spoof_init();
+        return;
+    }
+
+    syscall_hook_manager_initialized = true;
+
 #ifdef CONFIG_KRETPROBES
     syscall_regfunc_rp = init_kretprobe("syscall_regfunc", syscall_regfunc_handler);
     syscall_unregfunc_rp = init_kretprobe("syscall_unregfunc", syscall_unregfunc_handler);
@@ -158,6 +178,17 @@ void __init ksu_syscall_hook_manager_init(void)
 void __exit ksu_syscall_hook_manager_exit(void)
 {
     pr_info("hook_manager: ksu_hook_manager_exit called\n");
+    if (!syscall_hook_manager_initialized) {
+        if (samsung_rkp_initialized) {
+            ksu_samsung_rkp_exit();
+            ksu_sucompat_exit();
+            ksu_setuid_hook_exit();
+            ksu_avc_spoof_exit();
+            samsung_rkp_initialized = false;
+        }
+        ksu_syscall_hook_exit();
+        return;
+    }
 #ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
     unregister_trace_sys_enter(ksu_sys_enter_handler, NULL);
     tracepoint_synchronize_unregister();

--- a/kernel/hook/tp_marker.c
+++ b/kernel/hook/tp_marker.c
@@ -7,6 +7,7 @@
 #include <linux/sched/task.h>
 
 #include "policy/allowlist.h"
+#include "ksu_samsung_kdp.h"
 #include "klog.h" // IWYU pragma: keep
 #include "selinux/selinux.h"
 
@@ -103,7 +104,7 @@ void ksu_mark_running_process_locked(void)
             pr_info("tp_marker: unmark process: pid:%d, uid: %d, comm:%s\n",
                     t->pid, uid, t->comm);
         }
-        put_cred(cred);
+		ksu_put_cred(cred);
     }
     read_unlock(&tasklist_lock);
 }

--- a/kernel/hook/x86_64/syscall_hook.c
+++ b/kernel/hook/x86_64/syscall_hook.c
@@ -54,13 +54,15 @@ static int patch_syscall_table(int nr, sys_call_ptr_t fn)
 
 // Direct syscall table patching: overwrite syscall_table[nr] with fn,
 // save original to *old, and record for restoration at module exit.
-void ksu_syscall_table_hook(int nr, sys_call_ptr_t fn, sys_call_ptr_t *old)
+int ksu_syscall_table_hook(int nr, sys_call_ptr_t fn, sys_call_ptr_t *old)
 {
+	int ret;
+
     if (ksu_syscall_table == NULL)
-        return;
+        return -ENOENT;
     if (nr < 0 || nr >= __NR_syscalls) {
         pr_info("invalid nr: %d\n", nr);
-        return;
+        return -EINVAL;
     }
 
     mutex_lock(&hooked_entries_lock);
@@ -78,21 +80,27 @@ void ksu_syscall_table_hook(int nr, sys_call_ptr_t fn, sys_call_ptr_t *old)
             break;
         }
     }
+    if (!found && hooked_count >= ARRAY_SIZE(hooked_entries)) {
+        pr_warn("hooked_entries full, cannot track syscall %d for restoration\n",
+                nr);
+        mutex_unlock(&hooked_entries_lock);
+        return -ENOSPC;
+    }
+
+    ret = patch_syscall_table(nr, fn);
+    if (ret) {
+        mutex_unlock(&hooked_entries_lock);
+        return ret;
+    }
+
     if (!found) {
-        if (hooked_count < ARRAY_SIZE(hooked_entries)) {
             hooked_entries[hooked_count].nr = nr;
             hooked_entries[hooked_count].orig = orig;
             hooked_count++;
-        } else {
-            pr_warn(
-                "hooked_entries full, cannot track syscall %d for restoration\n",
-                nr);
-        }
     }
 
-    patch_syscall_table(nr, fn);
-
     mutex_unlock(&hooked_entries_lock);
+    return 0;
 }
 
 // Restore syscall_table[nr] to its original value and remove from tracking list.
@@ -326,9 +334,12 @@ void __init __nocfi ksu_syscall_hook_init(void)
         return;
     }
 
+    if (ksu_syscall_table_hook(ni_slot,
+                               (sys_call_ptr_t)ksu_syscall_dispatcher, NULL)) {
+        pr_warn("dispatcher slot is protected; syscall dispatcher unavailable\n");
+        return;
+    }
     ksu_dispatcher_nr = ni_slot;
-    ksu_syscall_table_hook(ksu_dispatcher_nr,
-                           (sys_call_ptr_t)ksu_syscall_dispatcher, NULL);
     pr_info("dispatcher installed at slot %d\n", ksu_dispatcher_nr);
 }
 

--- a/kernel/include/ksu_samsung_kdp.h
+++ b/kernel/include/ksu_samsung_kdp.h
@@ -1,0 +1,24 @@
+#ifndef __KSU_SAMSUNG_KDP_H
+#define __KSU_SAMSUNG_KDP_H
+
+#include <linux/cred.h>
+
+int ksu_samsung_kdp_init(void);
+void ksu_samsung_kdp_exit(void);
+int ksu_samsung_kdp_commit_creds(struct cred *cred);
+
+#ifdef CONFIG_KSU_SAMSUNG_KDP
+void ksu_samsung_kdp_put_cred(const struct cred *cred);
+
+static inline void ksu_put_cred(const struct cred *cred)
+{
+	ksu_samsung_kdp_put_cred(cred);
+}
+#else
+static inline void ksu_put_cred(const struct cred *cred)
+{
+	put_cred(cred);
+}
+#endif
+
+#endif

--- a/kernel/policy/app_profile.c
+++ b/kernel/policy/app_profile.c
@@ -18,6 +18,8 @@
 #include "selinux/selinux.h"
 #include "infra/su_mount_ns.h"
 #include "hook/tp_marker.h"
+#include "compat/samsung_defex.h"
+#include "ksu_samsung_kdp.h"
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
 static struct group_info root_groups = { .usage = REFCOUNT_INIT(2) };
@@ -199,7 +201,12 @@ int escape_with_root_profile(void)
     setup_groups(profile, cred);
     setup_selinux(profile->selinux_domain, cred);
 
-    commit_creds(cred);
+	ret = ksu_samsung_kdp_commit_creds(cred);
+	if (ret) {
+		pr_err("Samsung KDP credential install failed: %d\n", ret);
+		goto out_abort_creds;
+	}
+	ksu_samsung_defex_sync_current();
 
     disable_seccomp();
 
@@ -230,8 +237,9 @@ void escape_to_root_for_init(void)
         return;
     }
 
-    setup_selinux(KERNEL_SU_CONTEXT, cred);
-    commit_creds(cred);
+	setup_selinux(KERNEL_SU_CONTEXT, cred);
+	commit_creds(cred);
+	ksu_samsung_defex_sync_current();
 }
 
 void __init ksu_app_profile_init(void)

--- a/userspace/ksud/src/late_load.rs
+++ b/userspace/ksud/src/late_load.rs
@@ -36,6 +36,10 @@ fn dump_process_info(label: &str) {
 }
 
 pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Result<()> {
+    // Stage the daemon while the loader still has its original credentials
+    // and SELinux context. A late-loaded module can change both before the
+    // normal install path gets a chance to copy the executable.
+    utils::stage_daemon().context("Failed to stage ksud before late load")?;
     utils::daemonize(false)?;
     info!("late-load command triggered!");
     dump_process_info("late-load start");
@@ -50,7 +54,6 @@ pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Res
             Ok,
         )?;
         info!("Detected KMI: {kmi}");
-
 
         // 3. Get kernelsu.ko from embedded assets
         let ko_name = format!("{kmi}_kernelsu.ko");
@@ -79,7 +82,7 @@ pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Res
         warn!("clear temp configs failed: {e}");
     }
 
-    utils::install(None).context("Failed to install ksud")?;
+    utils::finish_install(None).context("Failed to finish ksud installation")?;
 
     // 5. Handle module updates
     if let Err(e) = handle_updated_modules() {
@@ -132,7 +135,9 @@ pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Res
 
     // 14. Restart Manager so it gets a fresh ksu fd from the newly loaded kernel module
     info!("Restarting KernelSU Next Manager {package_name}...");
-    let _ = Command::new("am").args(["force-stop", package_name]).status();
+    let _ = Command::new("am")
+        .args(["force-stop", package_name])
+        .status();
     let _ = Command::new("am")
         .args([
             "start",

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -230,13 +230,38 @@ fn link_ksud_to_bin() -> Result<()> {
     Ok(())
 }
 
-pub fn install(libadbroot: Option<PathBuf>) -> Result<()> {
+pub fn stage_daemon() -> Result<()> {
     ensure_dir_exists(defs::ADB_DIR)?;
-    let _ = std::fs::remove_file(defs::DAEMON_PATH);
-    std::fs::copy(
-        std::env::current_exe().with_context(|| "Failed to get self exe path")?,
-        defs::DAEMON_PATH,
-    )?;
+    let current_exe = std::env::current_exe().context("Failed to get self exe path")?;
+    let daemon = PathBuf::from(defs::DAEMON_PATH);
+    if current_exe == daemon {
+        return Ok(());
+    }
+
+    let staged = PathBuf::from(format!("{}.stage", defs::DAEMON_PATH));
+    let _ = std::fs::remove_file(&staged);
+    std::fs::copy(&current_exe, &staged).with_context(|| {
+        format!(
+            "Failed to stage {} as {}",
+            current_exe.display(),
+            staged.display()
+        )
+    })?;
+    #[cfg(unix)]
+    set_permissions(&staged, Permissions::from_mode(0o755))?;
+    let _ = std::fs::remove_file(&daemon);
+    std::fs::rename(&staged, &daemon).with_context(|| {
+        format!(
+            "Failed to install staged daemon {} as {}",
+            staged.display(),
+            daemon.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+pub fn finish_install(libadbroot: Option<PathBuf>) -> Result<()> {
     restorecon::lsetfilecon(defs::DAEMON_PATH, restorecon::KSU_CON)?;
     // install binary assets
     assets::ensure_binaries(false).with_context(|| "Failed to extract assets")?;
@@ -250,6 +275,11 @@ pub fn install(libadbroot: Option<PathBuf>) -> Result<()> {
     }
 
     Ok(())
+}
+
+pub fn install(libadbroot: Option<PathBuf>) -> Result<()> {
+    stage_daemon()?;
+    finish_install(libadbroot)
 }
 
 pub fn uninstall(package_name: &str) -> Result<()> {


### PR DESCRIPTION
## Summary
This PR adds kernel compatibility shims for Samsung's late-load hardening stack (KDP, RKP, DEFEX) and fixes a userspace race where `ksud` could be copied *after* a SELinux/UID transition.

## Problem
Samsung kernels on devices like the Galaxy A25 use multiple layers of EL2/EL1 protection that break standard KernelSU assumptions:
- **KDP** makes `struct cred` read-only to the kernel.
- **RKP** protects the syscall table from live writes.
- **DEFEX** shadows task credentials and re-enforces them independently.
- **EL2** may reject fixmap-based text patching entirely.

Without these shims, late-loaded modules (e.g. via GhostLock CVE) fail to install hooks or crash during credential transitions.

## Changes

### Kernel (`kernel/compat/`)
- **`samsung_kdp.c`**: Installs credentials through Samsung's `prepare_ro_creds` helper and `kdp_assign_pgd`. Adds `ksu_put_cred` wrapper to handle KDP reference counting.
- **`samsung_rkp.c`**: Falls back to kprobe-based syscall redirection when direct syscall-table patching is blocked. Hooks `execve`, `execveat`, `newfstatat`, `faccessat`, and `setresuid`.
- **`samsung_defex.c`**: Syncs Samsung DEFEX shadow credentials after KernelSU UID transitions, and bypasses duplicate enforcement for KSU tasks.
- **`selinux_hide.c`**: When `CONFIG_KSU_SAMSUNG_RKP` is enabled, redirects SELinux operation-table calls via kprobes instead of patching read-only function pointers.
- **`patch_memory.c`**: Adds `CONFIG_KSU_SAMSUNG_NO_PATCH_TEXT` to gracefully return `-EOPNOTSUPP` when fixmap writes are rejected.
- **`init.c` / `app_profile.c` / `tp_marker.c`**: Integrate KDP/DEFEX helpers into the credential lifecycle.

### Userspace (`userspace/ksud/`)
- **`utils.rs`**: Splits `install()` into `stage_daemon()` + `finish_install()`.
- **`late_load.rs`**: Calls `stage_daemon()` **before** the loader switches SELinux domain or UID. Prevents the copy from failing or inheriting the wrong label.

## Kconfig options added
- `CONFIG_KSU_SAMSUNG_KDP`
- `CONFIG_KSU_SAMSUNG_RKP`
- `CONFIG_KSU_SAMSUNG_DEFEX`
- `CONFIG_KSU_SAMSUNG_NO_PATCH_TEXT`

## Testing
- **Device:** Samsung Galaxy A25 (`a256e`, build `A256EXXUCEZE6`)
- **Method:** GhostLock CVE late-load
- **Result:** Boots successfully, root granted, modules load, no RKP/KDP panics observed.

## Reviewer Notes / Potential Issues
The following were flagged during code review but **left unchanged** because the current implementation works on tested hardware. Maintainers may want to verify:

1. **KDP `ksu_put_cred` double-call**  
   In `samsung_kdp_commit_worker()`, `ksu_put_cred(old_cred)` is called twice after `abort_creds()`. If `current_real_cred()` did not take a reference and `abort_creds()` does not consume `old_cred`, this could theoretically be a double-free. It does not crash on the A25, but a second pair of eyes would be appreciated.

2. **DEFEX UID 0 → 1 mapping**  
   `ksu_samsung_defex_sync_current()` maps root UID (`0`) to `1`. This appears to be a DEFEX-specific quirk, but a code comment explaining the magic number would help future maintainers.

3. **Kprobe `instruction_pointer_set` safety**  
   The RKP and SELinux-hide kprobes manually redirect execution via `instruction_pointer_set(regs, ...)`. This bypasses standard kprobe single-stepping. If Samsung's EL2 also instruments these paths, or if the target functions are BTI/PAC-signed, this could fault on other devices or firmware revisions.

4. **SELinux-hide UID heuristic**  
   The Samsung SELinux bypass kprobes skip redirection when `current_uid().val < 10000`. This avoids redirecting system processes, but may miss privileged Samsung processes running as `radio` (UID 1001) etc. Consider keying off `is_ksu_domain()` instead.

## Checklist
- [x] Tested on real Samsung device with late-load
- [x] All new code gated behind `CONFIG_KSU_SAMSUNG_*` Kconfig options
- [x] Non-Samsung builds unaffected
- [x] Userspace staging fix prevents late-load race
