### PR TITLE
manager: differ export logs on rooted vs unrooted

### DIFF
--- a/manager/app/src/main/cpp/CMakeLists.txt
+++ b/manager/app/src/main/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(kernelsu
         SHARED
         jni.cc
         ksu.cc
+        ksuCheck.cc
         )
 
 target_include_directories(kernelsu PRIVATE .)

--- a/manager/app/src/main/cpp/ksuCheck.cc
+++ b/manager/app/src/main/cpp/ksuCheck.cc
@@ -1,0 +1,19 @@
+#include <jni.h>
+#include <errno.h>
+#include <sys/prctl.h>
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_rifsxd_ksunext_Natives_getLegacyInfo(JNIEnv *env, jclass /* clazz */) {
+    int32_t version = -1;
+    int32_t flags = 0;
+    int32_t result = 0;
+
+    errno = 0;
+    prctl(0xDEADBEEF, 2, &version, &flags, &result);
+
+    if (errno == EINVAL || version == -1) {
+        return -1L;
+    }
+
+    return (static_cast<jlong>(version) << 32) | (static_cast<jlong>(flags) & 0xFFFFFFFFL);
+}

--- a/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/Natives.kt
@@ -89,6 +89,11 @@ object Natives {
     external fun getAppProfile(key: String?, uid: Int): Profile
     external fun setAppProfile(profile: Profile?): Boolean
 
+    /*
+     *  prctl check for unrooted
+     */
+     external fun getLegacyInfo(): Long
+     
     /**
      * `su` compat mode can be disabled temporarily.
      *  0: disabled
@@ -130,6 +135,13 @@ object Natives {
      */
     external fun getUserName(uid: Int): String?
 
+        
+    sealed class KsuDriverStatus {
+        object NoDriver: KsuDriverStatus()
+        data class Present(val version: Int, val flags: Int): KsuDriverStatus() {
+            val isManager: Boolean get() = (flags and KSU_GET_INFO_FLAG_MANAGER) != 0
+        }
+    }
     /**
      * Avc spoof can be enabled/disabled.
      *  0: disabled
@@ -141,6 +153,7 @@ object Natives {
 
     external fun getSuperuserCount(): Int
 
+    private const val KSU_GET_INFO_FLAG_MANAGER = 1 shl 1
     private const val NON_ROOT_DEFAULT_PROFILE_KEY = "$"
     private const val NOBODY_UID = 9999
 
@@ -161,6 +174,14 @@ object Natives {
         }
     }
 
+    fun checkKsuDriver(): KsuDriverStatus {
+        val packed = Natives.getLegacyInfo()
+        if (packed == -1L) return KsuDriverStatus.NoDriver
+        val version = (packed shr 32).toInt()
+        val flags = (packed and 0xFFFFFFFFL).toInt()
+        return KsuDriverStatus.Present(version, flags)
+    }
+    
     val kernelUAPIVersion: Int
         external get
 

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
@@ -81,7 +81,8 @@ fun SettingScreen(navigator: DestinationsNavigator) {
 
     val scrollState = LocalScrollState.current
     val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
-    val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
+    val navBarPadding =
+        WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
     val bottomBarScrollState = LocalScrollState.current
     val bottomBarScrollConnection = if (bottomBarScrollState != null) {
@@ -352,14 +353,19 @@ private fun KernelFeaturesCard(
                         0 -> {}
                         -OsConstants.EAGAIN -> {
                             withContext(Dispatchers.Main) {
-                                Toast.makeText(context, R.string.settings_selinux_hide_reboot_required,
-                                    Toast.LENGTH_LONG).show()
+                                Toast.makeText(
+                                    context, R.string.settings_selinux_hide_reboot_required,
+                                    Toast.LENGTH_LONG
+                                ).show()
                             }
                         }
+
                         else -> {
                             withContext(Dispatchers.Main) {
-                                Toast.makeText(context, context.getString(R.string.settings_selinux_hide_failed, status),
-                                    Toast.LENGTH_LONG).show()
+                                Toast.makeText(
+                                    context, context.getString(R.string.settings_selinux_hide_failed, status),
+                                    Toast.LENGTH_LONG
+                                ).show()
                             }
                         }
                     }
@@ -531,12 +537,18 @@ private fun AppSettingsCard(
             )
 
             var showBottomsheet by remember { mutableStateOf(false) }
+            var isUnrooted by remember { mutableStateOf(false) }
 
             ListItem(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(8.dp))
-                    .clickable { showBottomsheet = true },
+                    .clickable {
+                        val noDriver = Natives.checkKsuDriver() is Natives.KsuDriverStatus.NoDriver
+
+                        isUnrooted = noDriver
+                        showBottomsheet = true
+                    },
                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                 leadingContent = { Icon(Icons.Filled.BugReport, null) },
                 headlineContent = {
@@ -561,7 +573,11 @@ private fun AppSettingsCard(
                         scope.launch {
                             val bugreport = loadingDialog.withLoading {
                                 withContext(Dispatchers.IO) {
-                                    getBugreportFile(context)
+                                    if (isUnrooted) {
+                                        getBugreportFileUnrooted(context)
+                                    } else {
+                                        getBugreportFile(context)
+                                    }
                                 }
                             }
                             val uri: Uri = FileProvider.getUriForFile(
@@ -693,9 +709,11 @@ fun UninstallItem(
                         UninstallType.PERMANENT -> navigator.navigate(
                             FlashScreenDestination(FlashIt.FlashUninstall)
                         )
+
                         UninstallType.RESTORE_STOCK_IMAGE -> navigator.navigate(
                             FlashScreenDestination(FlashIt.FlashRestore)
                         )
+
                         UninstallType.NONE -> Unit
                     }
                 }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/LogEvent.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/LogEvent.kt
@@ -43,7 +43,8 @@ fun getBugreportFile(context: Context): File {
     val shell = createRootShell(true)
 
     // busybox ps has very few features for embed devices
-    shell.newJob().add("toybox ps -T -A -w -o PID,TID,UID,COMM,CMDLINE,CMD,LABEL,STAT,WCHAN > ${processFile.absolutePath}").exec()
+    shell.newJob()
+        .add("toybox ps -T -A -w -o PID,TID,UID,COMM,CMDLINE,CMD,LABEL,STAT,WCHAN > ${processFile.absolutePath}").exec()
     shell.newJob().add("dmesg -r > ${dmesgFile.absolutePath}").exec()
     shell.newJob().add("logcat -b all -v uid -d > ${logcatFile.absolutePath}").exec()
     shell.newJob().add("tar -czf ${tombstonesFile.absolutePath} -C /data/tombstones .").exec()
@@ -114,3 +115,87 @@ fun getBugreportFile(context: Context): File {
     return targetFile
 }
 
+fun getBugreportFileUnrooted(context: Context): File {
+    val bugreportDir = File(context.cacheDir, "bugreport")
+    bugreportDir.mkdirs()
+
+    val processFile = File(bugreportDir, "process.txt")
+    val logcatFile = File(bugreportDir, "logcat.txt")
+    val fileSystemsFile = File(bugreportDir, "filesystems.txt")
+    val propFile = File(bugreportDir, "props.txt")
+    val driverStatus = File(bugreportDir, "kernel_status.txt")
+    
+    val status = Natives.checkKsuDriver()
+    val currentManagerAppId = Natives.getManagerAppid()
+
+    nonRootShell("toybox ps -T -A -w -o PID,TID,UID,COMM,CMDLINE,CMD,LABEL,STAT,WCHAN > ${processFile.absolutePath}")
+    nonRootShell("logcat -b all -v uid -d > ${logcatFile.absolutePath}")
+    nonRootShell("cat /proc/filesystems > ${fileSystemsFile.absolutePath}")
+    nonRootShell("getprop > ${propFile.absolutePath}")
+
+    val buildInfo = File(bugreportDir, "basic.txt")
+    PrintWriter(FileWriter(buildInfo)).use { pw ->
+        pw.println("Kernel: ${System.getProperty("os.version")}")
+        pw.println("BRAND: " + Build.BRAND)
+        pw.println("MODEL: " + Build.MODEL)
+        pw.println("PRODUCT: " + Build.PRODUCT)
+        pw.println("MANUFACTURER: " + Build.MANUFACTURER)
+        pw.println("ANDROID: " + Build.VERSION.RELEASE)
+        pw.println("SDK: " + Build.VERSION.SDK_INT)
+        pw.println("PREVIEW_SDK: " + Build.VERSION.PREVIEW_SDK_INT)
+        pw.println("FINGERPRINT: " + Build.FINGERPRINT)
+        pw.println("DEVICE: " + Build.DEVICE)
+        pw.println("Manager: " + getManagerVersion(context))
+
+        val uname = Os.uname()
+        pw.println("KernelRelease: ${uname.release}")
+        pw.println("KernelVersion: ${uname.version}")
+        pw.println("Machine: ${uname.machine}")
+        pw.println("Nodename: ${uname.nodename}")
+        pw.println("Sysname: ${uname.sysname}")
+
+        val ksuKernel = Natives.version
+        pw.println("KernelSU: $ksuKernel")
+        val safeMode = Natives.isSafeMode
+        pw.println("SafeMode: $safeMode")
+        val lkmMode = Natives.isLkmMode
+        pw.println("LKM: $lkmMode")
+    }
+
+    val hasMagisk = nonRootShell("which magisk")
+    if (hasMagisk) File(bugreportDir, "hasMagisk").createNewFile()
+
+    driverStatus.writeText(buildString {
+        when (val s = status) {
+            Natives.KsuDriverStatus.NoDriver ->
+                appendLine("no_driver: kernel has no KernelSU-Next hook")
+
+            is Natives.KsuDriverStatus.Present -> {
+                appendLine("driver_present: version=${s.version} flags=${s.flags} isManager=${s.isManager}")
+                if (!s.isManager) {
+                    val managerAppId = Natives.getManagerAppid()
+                    appendLine("manager_appid: $managerAppId")
+                }
+            }
+        }
+    })
+
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH_mm")
+    val current = LocalDateTime.now().format(formatter)
+
+    val targetFile = File(context.cacheDir, "KernelSU_Next_bugreport_${current}.tar.gz")
+
+    nonRootShell("tar czf ${targetFile.absolutePath} -C ${bugreportDir.absolutePath} .")
+    nonRootShell("rm -rf ${bugreportDir.absolutePath}")
+    nonRootShell("chmod 0644 ${targetFile.absolutePath}")
+
+    return targetFile
+}
+
+fun nonRootShell(command: String): Boolean {
+    val process = ProcessBuilder("sh", "-c", command)
+        .redirectErrorStream(true)
+        .start()
+    process.inputStream.bufferedReader().readText()
+    return process.waitFor() == 0
+}

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="show_system_apps">Show system apps</string>
     <string name="hide_system_apps">Hide system apps</string>
     <string name="export_log">Export logs</string>
+    <string name="export_log_unrooted">Export logs (non-root)</string>
     <string name="safe_mode">Safe mode</string>
     <string name="jailbreak_mode">Jailbreak mode</string>
     <string name="reboot_to_apply">Reboot to take effect</string>


### PR DESCRIPTION
rooted devices get full analystics, but unrooted ones (failing to root or genuinely unrooted) don't have any

this is basically the same as the rooted bug report except it strips unfunctional reports and has additional checks to which why couldn't it get root

examples: another crowned manager so current fails to, magisk installed and is interfering with KSU