### PR TITLE
risk: add 'anoroto' pattern to prevent obfuscated payload execution

### DIFF
--- a/risk/risk.json
+++ b/risk/risk.json
@@ -9,6 +9,13 @@
 			]
 		},
 		{
+			"reason": "Obfuscated root payload | Legacy loader script",
+			"severity": "medium",
+			"patterns": [
+				"anoroto"
+			]
+		},
+		{
 			"reason": "Possible spyware | Closed-source binaries",
 			"severity": "high",
 			"patterns": [


### PR DESCRIPTION
Identified a family of obfuscated legacy loader scripts and low-level binaries utilizing the anoroto string sequence to trigger unauthorized root calls and potential system partition instability.

​Adding this pattern with medium severity to ensure user confirmation before execution.